### PR TITLE
Adds "no __author__" validator

### DIFF
--- a/tests/fixtures/wrong_variable.py
+++ b/tests/fixtures/wrong_variable.py
@@ -49,4 +49,4 @@ val = Fixture()  # error here
 print(val.var)  # no error here
 
 if val:
-    __author__ = 'John'  # no error here since it's a rare use of module metsta
+    __author__ = 'John'  # no error here since it's a rare use of module meta

--- a/tests/fixtures/wrong_variable.py
+++ b/tests/fixtures/wrong_variable.py
@@ -4,7 +4,13 @@
 This file contains all broken variable names.
 """
 
+__author__ = 'John Doe'  # error here
+
 x = 1  # error here
+
+
+def fixture():
+    __author__ = 'John Doe'  # no error, because not module metadata
 
 
 def check_function_args(data, t, *a, **vals):  # 4 errors here
@@ -41,3 +47,6 @@ class Fixture(object):
 
 val = Fixture()  # error here
 print(val.var)  # no error here
+
+if val:
+    __author__ = 'John'  # no error here since it's a rare use of module metsta

--- a/tests/test_checkers/test_wrong_variable.py
+++ b/tests/test_checkers/test_wrong_variable.py
@@ -18,3 +18,4 @@ def test_wrong_variables_in_fixture(absolute_path):
     assert stdout.count(b'WPS122') == 3
     assert stdout.count(b'WPS123') == 2
     assert stdout.count(b'WPS124') == 1
+    assert stdout.count(b'WPS126') == 1

--- a/wemake_python_styleguide/checker.py
+++ b/wemake_python_styleguide/checker.py
@@ -15,8 +15,8 @@ from wemake_python_styleguide.visitors.wrong_keyword import (
 )
 from wemake_python_styleguide.visitors.wrong_nested import WrongNestedVisitor
 from wemake_python_styleguide.visitors.wrong_variable import (
-    WrongVariableVisitor,
     WrongModuleMetadata,
+    WrongVariableVisitor,
 )
 
 

--- a/wemake_python_styleguide/checker.py
+++ b/wemake_python_styleguide/checker.py
@@ -16,6 +16,7 @@ from wemake_python_styleguide.visitors.wrong_keyword import (
 from wemake_python_styleguide.visitors.wrong_nested import WrongNestedVisitor
 from wemake_python_styleguide.visitors.wrong_variable import (
     WrongVariableVisitor,
+    WrongModuleMetadata,
 )
 
 
@@ -42,6 +43,7 @@ class Checker(object):
             WrongNestedVisitor,
             ComplexityVisitor,
             WrongVariableVisitor,
+            WrongModuleMetadata,
         )
 
     def run(self) -> Generator[tuple, None, None]:

--- a/wemake_python_styleguide/constants.py
+++ b/wemake_python_styleguide/constants.py
@@ -25,6 +25,10 @@ BAD_IMPORT_FUNCTIONS = frozenset((
     '__import__',
 ))
 
+BAD_MODULE_METADATA_VARIABLES = frozenset((
+    '__author__',
+))
+
 BAD_VARIABLE_NAMES = frozenset((
     'data',
     'result',

--- a/wemake_python_styleguide/errors.py
+++ b/wemake_python_styleguide/errors.py
@@ -87,6 +87,11 @@ class TooShortAttributeNameViolation(BaseStyleViolation):
     _code = 'WPS125'
 
 
+class WrongModuleMetadataViolation(BaseStyleViolation):
+    _error_tmpl = '{} Found wrong metadata variable {}'
+    _code = 'WPS126'
+
+
 class LocalFolderImportViolation(BaseStyleViolation):
     _error_tmpl = '{} Found local folder import "{}"'
     _code = 'WPS130'

--- a/wemake_python_styleguide/visitors/wrong_variable.py
+++ b/wemake_python_styleguide/visitors/wrong_variable.py
@@ -104,7 +104,7 @@ class WrongModuleMetadata(BaseNodeVisitor):
     """This class finds wrong metadata information of a module."""
 
     def visit_Assign(self, node: ast.Assign):
-        """Used to find the bad metadata variable names"""
+        """Used to find the bad metadata variable names."""
         node_parent = getattr(node, 'parent')
         if not isinstance(node_parent, ast.Module):
             return
@@ -112,5 +112,5 @@ class WrongModuleMetadata(BaseNodeVisitor):
         for target_node in node.targets:
             if getattr(target_node, 'id') in BAD_MODULE_METADATA_VARIABLES:
                 self.add_error(
-                    WrongModuleMetadataViolation(node, text=target_node.id)
+                    WrongModuleMetadataViolation(node, text=target_node.id),
                 )

--- a/wemake_python_styleguide/visitors/wrong_variable.py
+++ b/wemake_python_styleguide/visitors/wrong_variable.py
@@ -110,7 +110,8 @@ class WrongModuleMetadata(BaseNodeVisitor):
             return
 
         for target_node in node.targets:
-            if getattr(target_node, 'id') in BAD_MODULE_METADATA_VARIABLES:
+            target_node_id = getattr(target_node, 'id')
+            if target_node_id in BAD_MODULE_METADATA_VARIABLES:
                 self.add_error(
-                    WrongModuleMetadataViolation(node, text=target_node.id),
+                    WrongModuleMetadataViolation(node, text=target_node_id),
                 )

--- a/wemake_python_styleguide/visitors/wrong_variable.py
+++ b/wemake_python_styleguide/visitors/wrong_variable.py
@@ -2,13 +2,17 @@
 
 import ast
 
-from wemake_python_styleguide.constants import BAD_VARIABLE_NAMES
+from wemake_python_styleguide.constants import (
+    BAD_MODULE_METADATA_VARIABLES,
+    BAD_VARIABLE_NAMES,
+)
 from wemake_python_styleguide.errors import (
     TooShortArgumentNameViolation,
     TooShortAttributeNameViolation,
     TooShortVariableNameViolation,
     WrongArgumentNameViolation,
     WrongAttributeNameViolation,
+    WrongModuleMetadataViolation,
     WrongVariableNameViolation,
 )
 from wemake_python_styleguide.helpers.variables import (
@@ -94,3 +98,19 @@ class WrongVariableVisitor(BaseNodeVisitor):
                 )
 
         self.generic_visit(node)
+
+
+class WrongModuleMetadata(BaseNodeVisitor):
+    """This class finds wrong metadata information of a module."""
+
+    def visit_Assign(self, node: ast.Assign):
+        """Used to find the bad metadata variable names"""
+        node_parent = getattr(node, 'parent')
+        if not isinstance(node_parent, ast.Module):
+            return
+
+        for target_node in node.targets:
+            if getattr(target_node, 'id') in BAD_MODULE_METADATA_VARIABLES:
+                self.add_error(
+                    WrongModuleMetadataViolation(node, text=target_node.id)
+                )


### PR DESCRIPTION
Implements the rule `no __author__`.

Note that it does not protect against the case
```
if True:
    __author__ = 'John'
```
because this is simply a strange thing to write (and it would complicate the logic for no good reason).

I've created a set `BAD_MODULE_METADATA_VARIABLES`, just in case other variables need to be added (such as `__version__` or `__copyright__`).