### PR TITLE
fixing typos and minor grammar issues

### DIFF
--- a/docs/_pages/glossary.rst
+++ b/docs/_pages/glossary.rst
@@ -14,7 +14,7 @@ Glossary
       Set of rules of how we write ``python`` code in `wemake.services <https://wemake.services>`_.
 
    checker
-      ``flake8`` plugin compatible class that is used as an entrypoint.
+      ``flake8`` plugin compatible class that is used as an entry point.
       Entry point and violation codes are defined in ``pyproject.toml``.
       This class runs all visitors that exist in our style guide.
 

--- a/wemake_python_styleguide/logics/filenames.py
+++ b/wemake_python_styleguide/logics/filenames.py
@@ -14,7 +14,7 @@ def _get_stem(file_path: str) -> str:
 
 def is_stem_in_list(file_path: str, to_check: Iterable[str]) -> bool:
     """
-    Checks either module's name is included in a search list.
+    Checks whether module's name is included in a search list.
 
     >>> is_stem_in_list('/some/module.py', ['other'])
     False
@@ -34,7 +34,7 @@ def is_stem_in_list(file_path: str, to_check: Iterable[str]) -> bool:
 
 def is_magic(file_path: str) -> bool:
     """
-    Checks either the given `file_path` contains the magic module name.
+    Checks whether the given `file_path` contains the magic module name.
 
     >>> is_magic('__init__.py')
     True
@@ -61,7 +61,7 @@ def is_too_short_stem(
     min_length: int = defaults.MIN_MODULE_NAME_LENGTH,
 ) -> bool:
     """
-    Checks either the file's stem fits into the minimum length.
+    Checks whether the file's stem fits into the minimum length.
 
     >>> is_too_short_stem('a.py')
     True
@@ -85,7 +85,7 @@ def is_matching_pattern(
     pattern: Pattern = constants.MODULE_NAME_PATTERN,
 ) -> bool:
     r"""
-    Checks either the file's stem matches the given pattern or not.
+    Checks whether the file's stem matches the given pattern.
 
     >>> is_matching_pattern('some.py')
     True

--- a/wemake_python_styleguide/logics/functions.py
+++ b/wemake_python_styleguide/logics/functions.py
@@ -30,7 +30,7 @@ def given_function_called(node: Call, to_check: Iterable[str]) -> str:
 
 def is_method(function_type: Optional[str]) -> bool:
     """
-    Returns either or not given function type belongs to a class.
+    Returns whether a given function type belongs to a class.
 
     >>> is_method('function')
     False

--- a/wemake_python_styleguide/logics/nodes.py
+++ b/wemake_python_styleguide/logics/nodes.py
@@ -9,7 +9,7 @@ def is_subtype_of_any(
     to_check: Iterable[Type[ast.AST]],
 ) -> bool:
     """
-    Checks either the given node is subtype of any of the provided types.
+    Checks whether the given node is subtype of any of the provided types.
 
     >>> import ast
     >>> node = ast.parse('')  # ast.Module

--- a/wemake_python_styleguide/options/config.py
+++ b/wemake_python_styleguide/options/config.py
@@ -31,8 +31,8 @@ class Configuration(object):
     We try to make all defaults as reasonable as possible.
 
     However, you can currently adjust some complexity options. Why?
-    Because we are not quite sure about the ideal values yet. We are still 
-    researching them, and providing a way for developers to help us out is 
+    Because we are not quite sure about the ideal values yet. We are still
+    researching them, and providing a way for developers to help us out is
     a good thing at the moment.
 
     Options for general checks:

--- a/wemake_python_styleguide/options/config.py
+++ b/wemake_python_styleguide/options/config.py
@@ -31,17 +31,17 @@ class Configuration(object):
     We try to make all defaults as reasonable as possible.
 
     However, you can currently adjust some complexity options. Why?
-    Because we are quite sure about the ideal values. We are still researching
-    them, and providing a way for developers to help us out is a good thing
-    at the moment.
+    Because we are not quite sure about the ideal values yet. We are still 
+    researching them, and providing a way for developers to help us out is 
+    a good thing at the moment.
 
     Options for general checks:
 
     - ``min-variable-length`` - minimum number of chars to define a valid
       variable name, defaults to
       :str:`wemake_python_styleguide.options.defaults.MIN_VARIABLE_LENGTH`
-    - ``i-control-code`` - either or not your control ones who use your code,
-      more rule are enforced when you do control it, defaults to
+    - ``i-control-code`` - whether you control ones who use your code,
+      more rules are enforced when you do control it, defaults to
       :str:`wemake_python_styleguide.options.defaults.I_CONTROL_CODE`
 
     Options for module names related checks:
@@ -190,7 +190,7 @@ class Configuration(object):
         _Option(
             '--i-control-code',
             defaults.I_CONTROL_CODE,
-            'Either or not you control ones who use your code.',
+            'Whether you control ones who use your code.',
             action='store_true',
             type=None,
         ),

--- a/wemake_python_styleguide/options/defaults.py
+++ b/wemake_python_styleguide/options/defaults.py
@@ -19,7 +19,7 @@ if you find them too strict or too permissive.
 #: Minimum variable's name length:
 MIN_VARIABLE_LENGTH = 2
 
-#: Either or not you control ones who use your code:
+#: Whether you control ones who use your code:
 I_CONTROL_CODE = True
 
 

--- a/wemake_python_styleguide/violations/best_practices.py
+++ b/wemake_python_styleguide/violations/best_practices.py
@@ -3,8 +3,6 @@
 """
 These checks ensures that you follow the best practices.
 
-It also
-
 Note:
 
     Explicit is better than implicit.
@@ -127,7 +125,7 @@ class WrongDocCommentViolation(TokenizeViolation):
 
     Reasoning:
         Doc comments are used to provide a documentation.
-        But supling empty doc comments breaks this use-case.
+        But supplying empty doc comments breaks this use-case.
         It is unclear why they can be used with no contents.
 
     Solution:
@@ -255,8 +253,8 @@ class WrongKeywordViolation(ASTViolation):
     Forbids to use some keywords from ``python``.
 
     Reasoning:
-        We believe, tha some keywords are anti-patterns.
-        They promote bad-practices like ``global``  and ``pass``,
+        We believe that some keywords are anti-patterns.
+        They promote bad-practices like ``global`` and ``pass``,
         or just not user-friendly like ``del``.
 
     Solution:
@@ -289,7 +287,7 @@ class WrongFunctionCallViolation(ASTViolation):
 
     Reasoning:
         Some functions are only suitable
-        for very specific usecases,
+        for very specific use cases,
         we forbid to use them in a free manner.
 
     See
@@ -471,7 +469,7 @@ class MagicNumberViolation(ASTViolation):
 
     Solution:
         Give these numbers a name! Move them to a separate variable,
-        givin more context to the reader. And by moving things into new
+        giving more context to the reader. And by moving things into new
         variables you will trigger other complexity checks.
 
     Example::
@@ -483,7 +481,7 @@ class MagicNumberViolation(ASTViolation):
         # Wrong:
         total = get_items_from_cart() * 3.33
 
-    What are number that we exclude from this check?
+    What are numbers that we exclude from this check?
     Any numbers that are assigned to a variable, array, dictionary,
     or keyword arguments inside a function.
     ``int`` numbers that are in range ``[-10, 10]`` and
@@ -506,7 +504,7 @@ class StaticMethodViolation(ASTViolation):
 
     Reasoning:
         Static methods are not required to be inside the class.
-        Because it even does not an access to the current instance.
+        Because they even do not have access to the current instance.
 
     Solution:
         Use instance methods, ``@classmethod``, or functions instead.
@@ -528,7 +526,7 @@ class BadMagicMethodViolation(ASTViolation):
 
     Reasoning:
         We forbid to use magic methods related to the forbidden language parts.
-        Like, we forbid to use ``del`` keyword, so we forbid to use all
+        Likewise, we forbid to use ``del`` keyword, so we forbid to use all
         magic methods related to it.
 
     Solution:
@@ -559,8 +557,8 @@ class NestedImportViolation(ASTViolation):
 
     Solution:
         You don't need nested imports, you need to refactor your code.
-        Introduce a new module, a find another way to do what you want to do.
-        Rething how your layered architecture should look like.
+        Introduce a new module or find another way to do what you want to do.
+        Rethink how your layered architecture should look like.
 
     Example::
 

--- a/wemake_python_styleguide/violations/complexity.py
+++ b/wemake_python_styleguide/violations/complexity.py
@@ -155,7 +155,7 @@ class TooManyModuleMembersViolation(SimpleViolation):
 
     We do not make any differences between classes and functions in this check.
     They are treated as the same unit of logic.
-    We also do no care about functions and classes been public or not.
+    We also do not care about functions and classes being public or not.
     However, methods are counted separately on a per-class basis.
 
     This rule is configurable with ``--max-module-members``.
@@ -227,7 +227,7 @@ class TooManyArgumentsViolation(ASTViolation):
     Reasoning:
         This is an indicator of a bad design. When function requires many
         arguments it shows that it is required to refactor this piece of code.
-        It also indicates that function does to many things at once.
+        It also indicates that function does too many things at once.
 
     Solution:
         Split function into several functions.
@@ -271,11 +271,11 @@ class TooManyReturnsViolation(ASTViolation):
 
 class TooManyExpressionsViolation(ASTViolation):
     """
-    Forbids putting to many expression is a unit of code.
+    Forbids putting too many expressions in a unit of code.
 
     Reasoning:
-        When there are too many expression it means that this specific
-        function does too many things at once. It has too many logic.
+        When there are too many expressions it means that this specific
+        function does too many things at once. It has too much logic.
 
     Solution:
         Split function into several functions, refactor your API.
@@ -299,7 +299,7 @@ class TooManyMethodsViolation(SimpleViolation):
     Reasoning:
         Having too many methods might lead to the "God object".
         This kind of objects can handle everything.
-        So, in the end your code becomes to hard to maintain and test.
+        So, in the end your code becomes too hard to maintain and test.
 
     Solution:
         What to do if you have too many methods in a single class?
@@ -309,9 +309,9 @@ class TooManyMethodsViolation(SimpleViolation):
         See: https://en.wikipedia.org/wiki/God_object
 
     We do not make any difference between instance and class methods.
-    We also do no care about functions and classes been public or not.
+    We also do not care about functions and classes being public or not.
     We also do not count inherited methods from parents.
-    This rule do not count attributes of a class.
+    This rule does not count attributes of a class.
 
     This rule is configurable with ``--max-methods``.
 
@@ -332,7 +332,7 @@ class TooDeepNestingViolation(ASTViolation):
     Forbids nesting blocks too deep.
 
     Reasoning:
-        If nesting is too deep that indicates of a complex logic
+        If nesting is too deep that indicates usage of a complex logic
         and language constructions. This means that our design is not
         suited to handle such construction.
 
@@ -357,7 +357,7 @@ class LineComplexityViolation(ASTViolation):
     Forbids to have complex lines.
 
     We are using Jones Complexity algorithm to count complexity.
-    What is Jones Complexity? It is a simple yet power method to count
+    What is Jones Complexity? It is a simple yet powerful method to count
     the number of ``ast`` nodes per line.
     If the complexity of a single line is higher than a threshold,
     then an error is raised.
@@ -370,7 +370,7 @@ class LineComplexityViolation(ASTViolation):
 
     Reasoning:
         Having a complex line indicates that you somehow managed to put too
-        many logic inside a single line.
+        much logic inside a single line.
         At some point in time you will no longer be able to understand
         what this line means and what it does.
 
@@ -427,7 +427,7 @@ class TooManyConditionsViolation(ASTViolation):
     """
 
     #: Error message shown to the user.
-    error_template = 'Found a condition with too many logic: {0}'
+    error_template = 'Found a condition with too much logic: {0}'
     code = 222
 
 

--- a/wemake_python_styleguide/violations/consistency.py
+++ b/wemake_python_styleguide/violations/consistency.py
@@ -224,7 +224,7 @@ class FormattedStringViolation(ASTViolation):
         ``f`` strings looses context too often and they are hard to lint.
         Imagine that you have a string that breaks
         when you move it two lines above.
-        That's not how should a string behave.
+        That's not how a string should behave.
         Also, they promote a bad practice:
         putting your logic inside the template.
 

--- a/wemake_python_styleguide/violations/naming.py
+++ b/wemake_python_styleguide/violations/naming.py
@@ -226,7 +226,7 @@ class WrongVariableNameViolation(ASTViolation):
 
     Reasoning:
         We have found some names that are not expressive enough.
-        However, they appear in the code more than offten.
+        However, they appear in the code more than often.
         All names that we forbid to use could be improved.
 
     Solution:


### PR DESCRIPTION
fixing typos and minor grammar issues in the docs and a few source code files' comments and docstrings