### PR TITLE
Closes #177: count async function as a module member

### DIFF
--- a/tests/test_visitors/test_ast/test_complexity/test_counts/test_module_counts.py
+++ b/tests/test_visitors/test_ast/test_complexity/test_counts/test_module_counts.py
@@ -13,6 +13,12 @@ def first(): ...
 class Second(object): ...
 """
 
+module_with_async_function_and_class = """
+async def first(): ...
+
+class Second(object): ...
+"""
+
 module_with_methods = """
 class First(object):
     def method(self): ...
@@ -24,6 +30,7 @@ class Second(object):
 
 @pytest.mark.parametrize('code', [
     module_with_function_and_class,
+    module_with_async_function_and_class,
     module_with_methods,
 ])
 def test_module_counts_normal(
@@ -40,6 +47,7 @@ def test_module_counts_normal(
 
 @pytest.mark.parametrize('code', [
     module_with_function_and_class,
+    module_with_async_function_and_class,
     module_with_methods,
 ])
 def test_module_counts_violation(

--- a/wemake_python_styleguide/types.py
+++ b/wemake_python_styleguide/types.py
@@ -36,7 +36,7 @@ AnyImport = Union[ast.Import, ast.ImportFrom]
 CheckResult = Tuple[int, int, str, type]
 
 #: Code members that we count in a module:
-ModuleMembers = Union[ast.FunctionDef, ast.ClassDef]
+ModuleMembers = Union[ast.FunctionDef, ast.ClassDef, ast.AsyncFunctionDef]
 
 
 class ConfigurationOptions(Protocol):

--- a/wemake_python_styleguide/visitors/ast/complexity/counts.py
+++ b/wemake_python_styleguide/visitors/ast/complexity/counts.py
@@ -48,7 +48,8 @@ class ModuleMembersVisitor(BaseNodeVisitor):
         self._check_members_count(node)
         self.generic_visit(node)
 
-    visit_AsyncFunctionDef = visit_FunctionDef = visit_ClassDef = visit_module_members
+    visit_ClassDef = visit_module_members
+    visit_AsyncFunctionDef = visit_FunctionDef = visit_module_members
 
 
 class ImportMembersVisitor(BaseNodeVisitor):

--- a/wemake_python_styleguide/visitors/ast/complexity/counts.py
+++ b/wemake_python_styleguide/visitors/ast/complexity/counts.py
@@ -37,9 +37,9 @@ class ModuleMembersVisitor(BaseNodeVisitor):
         if self._public_items_count > self.options.max_module_members:
             self.add_violation(TooManyModuleMembersViolation())
 
-    def visit_ClassDef(self, node: ModuleMembers) -> None:
+    def visit_module_members(self, node: ModuleMembers) -> None:
         """
-        Counts the number of `class`es in a single module.
+        Counts the number of ModuleMembers in a single module.
 
         Raises:
             TooManyModuleMembersViolation
@@ -48,7 +48,7 @@ class ModuleMembersVisitor(BaseNodeVisitor):
         self._check_members_count(node)
         self.generic_visit(node)
 
-    visit_AsyncFunctionDef = visit_FunctionDef = visit_ClassDef
+    visit_AsyncFunctionDef = visit_FunctionDef = visit_ClassDef = visit_module_members
 
 
 class ImportMembersVisitor(BaseNodeVisitor):

--- a/wemake_python_styleguide/visitors/ast/complexity/counts.py
+++ b/wemake_python_styleguide/visitors/ast/complexity/counts.py
@@ -37,7 +37,7 @@ class ModuleMembersVisitor(BaseNodeVisitor):
         if self._public_items_count > self.options.max_module_members:
             self.add_violation(TooManyModuleMembersViolation())
 
-    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+    def visit_ClassDef(self, node: ModuleMembers) -> None:
         """
         Counts the number of `class`es in a single module.
 
@@ -49,6 +49,7 @@ class ModuleMembersVisitor(BaseNodeVisitor):
         self.generic_visit(node)
 
     visit_AsyncFunctionDef = visit_FunctionDef = visit_ClassDef
+
 
 class ImportMembersVisitor(BaseNodeVisitor):
     """Counts imports in a module."""

--- a/wemake_python_styleguide/visitors/ast/complexity/counts.py
+++ b/wemake_python_styleguide/visitors/ast/complexity/counts.py
@@ -48,17 +48,7 @@ class ModuleMembersVisitor(BaseNodeVisitor):
         self._check_members_count(node)
         self.generic_visit(node)
 
-    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
-        """
-        Counts the number of functions in a single module.
-
-        Raises:
-            TooManyModuleMembersViolation
-
-        """
-        self._check_members_count(node)
-        self.generic_visit(node)
-
+    visit_AsyncFunctionDef = visit_FunctionDef = visit_ClassDef
 
 class ImportMembersVisitor(BaseNodeVisitor):
     """Counts imports in a module."""


### PR DESCRIPTION
1. Count `AsyncFunctionDef` in Modules.
2. Improved `ModuleMembers` type, added `AsyncFunctionDef`.
3. Make base function for all types: `visit_AsyncFunctionDef = visit_FunctionDef = visit_ClassDef = visit_module_members`
4. Added to unit tests async functions.
