### PR TITLE
Issue #189, Feature: ignore async function definitions from jones complexity check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ We used to have incremental versioning before `0.1.0`.
 - We now count `async` methods as method for classes complexity check
 - We now count `async` functions as functions for module complexity check
 - We now count `async` functions complexity
-- We now ignore `async` functions definitions from jones complexity check
+- We now ignore `async` functions in jones complexity check
 
 ### Misc
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ We used to have incremental versioning before `0.1.0`.
 - We now count `async` methods as method for classes complexity check
 - We now count `async` functions as functions for module complexity check
 - We now count `async` functions complexity
+- We now ignore `async` functions definitions from jones complexity check
 
 ### Misc
 

--- a/wemake_python_styleguide/visitors/ast/complexity/jones.py
+++ b/wemake_python_styleguide/visitors/ast/complexity/jones.py
@@ -38,6 +38,7 @@ class JonesComplexityVisitor(BaseNodeVisitor):  # TODO: consider `logical_line`
     _ignored_nodes = (
         ast.FunctionDef,
         ast.ClassDef,
+        ast.AsyncFunctionDef,
     )
 
     def __init__(self, *args, **kwargs) -> None:


### PR DESCRIPTION
# I have made things!

- Add to ignore list `AsyncFunctionDef`
- Add special test case for check ignoring nodes `test_that_some_nodes_are_ignored`

## Checklist

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made
- [x] I have added my changes to the `CHANGELOG.md`

## Related issues

- Closes #189 
