### PR TITLE
Fix flaking test in test_module_names.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ to the project during `#hactoberfest`. List of awesome people:
 ### Bugfixes
 
 - Fixes that `MultipleIfsInComprehensionViolation` was not enabled
+- Fixes flaky behaviour of test_module_names
 
 ### Misc
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,11 +2,13 @@
 
 import inspect
 import os
+from collections import namedtuple
 from operator import itemgetter
 
 import pytest
 
 from wemake_python_styleguide import violations
+from wemake_python_styleguide.options.config import Configuration
 from wemake_python_styleguide.violations.base import (
     ASTViolation,
     BaseViolation,
@@ -70,3 +72,27 @@ def absolute_path():
         return os.path.join(dirname, *files)
 
     return factory
+
+
+@pytest.fixture(scope='session')
+def options():
+    """Returns the options builder."""
+    default_values = {
+        option.long_option_name[2:].replace('-', '_'): option.default
+        for option in Configuration.options
+    }
+
+    Options = namedtuple('options', default_values.keys())
+
+    def factory(**kwargs):
+        final_options = default_values.copy()
+        final_options.update(kwargs)
+        return Options(**final_options)
+
+    return factory
+
+
+@pytest.fixture(scope='session')
+def default_options(options):
+    """Returns the default options."""
+    return options()

--- a/tests/test_checkers/test_module_names.py
+++ b/tests/test_checkers/test_module_names.py
@@ -16,9 +16,10 @@ from wemake_python_styleguide.violations import naming
     ('123py.py', naming.WrongModuleNamePatternViolation),
     ('version_1.py', naming.UnderScoredNumberNameViolation),
 ])
-def test_module_names(filename, error):
+def test_module_names(filename, error, default_options):
     """Ensures that checker works with module names."""
     module = ast.parse('')
+    Checker.parse_options(default_options)
     checker = Checker(tree=module, file_tokens=[], filename=filename)
     _, _, error_text, _ = next(checker.run())
     error_code = int(error_text[1:4])

--- a/tests/test_visitors/conftest.py
+++ b/tests/test_visitors/conftest.py
@@ -1,16 +1,10 @@
 # -*- coding: utf-8 -*-
 
-from collections import namedtuple
 from typing import Sequence
 
 import pytest
 
-from wemake_python_styleguide.options.config import Configuration
 from wemake_python_styleguide.visitors.base import BaseVisitor
-
-
-def _to_dest_option(long_option_name: str) -> str:
-    return long_option_name[2:].replace('-', '_')
 
 
 @pytest.fixture(scope='session')
@@ -23,27 +17,3 @@ def assert_errors():
             assert error.code == errors[index].code
 
     return factory
-
-
-@pytest.fixture(scope='session')
-def options():
-    """Returns the options builder."""
-    default_values = {
-        _to_dest_option(option.long_option_name): option.default
-        for option in Configuration.options
-    }
-
-    Options = namedtuple('options', default_values.keys())
-
-    def factory(**kwargs):
-        final_options = default_values.copy()
-        final_options.update(kwargs)
-        return Options(**final_options)
-
-    return factory
-
-
-@pytest.fixture(scope='session')
-def default_options(options):
-    """Returns the default options."""
-    return options()


### PR DESCRIPTION
Our code always expects Checker class to have options attribute set by flake8. Since we call flake8 by using an external helper, it usually behaves as expected and all is well. But in the case of test_module_names, we are instantiating Checker instance by ourselves without calling parse_options() first, which leads to AttributeError.

It is possible not to see this bug due to pytest skipping some tests, but it is easy to trigger by introducing new unrelated changes into the testing code and change cached coverage, leading to pytest deciding to run this test again.

# I have made things!

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [ ] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made
- [x] I have added my changes to the `CHANGELOG.md`

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
