### PR TITLE
Fix `TooManyMethodsViolation` not displaying line number.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ to the project during `#hactoberfest`. List of awesome people:
 
 - Fixes that `MultipleIfsInComprehensionViolation` was not enabled
 - Fixes flaky behaviour of test_module_names
+- Fixed `TooManyMethodsViolation` not displaying line number
 
 ### Misc
 

--- a/wemake_python_styleguide/violations/complexity.py
+++ b/wemake_python_styleguide/violations/complexity.py
@@ -292,7 +292,7 @@ class TooManyExpressionsViolation(ASTViolation):
     code = 213
 
 
-class TooManyMethodsViolation(SimpleViolation):
+class TooManyMethodsViolation(ASTViolation):
     """
     Forbids to have many methods in a single class.
 

--- a/wemake_python_styleguide/visitors/ast/complexity/counts.py
+++ b/wemake_python_styleguide/visitors/ast/complexity/counts.py
@@ -106,7 +106,9 @@ class MethodMembersVisitor(BaseNodeVisitor):
     def _post_visit(self) -> None:
         for node, count in self._methods.items():
             if count > self.options.max_methods:
-                self.add_violation(TooManyMethodsViolation(text=node.name))
+                self.add_violation(
+                    TooManyMethodsViolation(node, text=node.name),
+                )
 
     def visit_any_function(self, node: AnyFunctionDef) -> None:
         """


### PR DESCRIPTION
When `TooManyMethodsViolation` was triggered, flake8 showed it happening at line number 0. This was due to this violation being SimpleViolation, instead of a more appropriate ASTViolation. It may have occured because other violations in the same packageare module-level ones and therefore it is sufficient for them to be `simple`, without pointing to particular node.

I am not sure how to proceed with tests here, seeing that it may involve breaking current philosophy of using provided `assert_errors` helper, since it checks only class of the violation without looking at the node contents.

# I have made things!

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [ ] I have created at least one test case for the changes I have made
- [ ] I have updated the documentation for the changes I have made
- [x] I have added my changes to the `CHANGELOG.md`

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
