### PR TITLE
resrtricting multiple in comparisons to fix #228

### DIFF
--- a/tests/test_visitors/test_ast/test_comparisons/test_multiple_in.py
+++ b/tests/test_visitors/test_ast/test_comparisons/test_multiple_in.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+
+from wemake_python_styleguide.violations.consistency import (
+    MultipleInComparisonViolation,
+)
+from wemake_python_styleguide.visitors.ast.comparisons import MultipleInVisitor
+
+if_with_multiple_in_comaprisons = 'if {0} in {1} in {2}: ...'
+if_without_multiple_in_comparisons = 'if {0} in {1} : ...'
+
+ternary = 'ternary = 0 if {0} in {1} else 1'
+ternary_with_multiple_in = 'ternary = 0 if {0} in {1} in {2} else 1'
+while_construct = 'while {0} in {1}: ...'
+while_with_multiple_in = 'while {0} in {1} in {2}: ...'
+
+
+@pytest.mark.parametrize('code', [
+    if_without_multiple_in_comparisons,
+    ternary,
+    while_construct,
+])
+@pytest.mark.parametrize('comparators', [
+    ('6', '6'),
+    ('6', [True]),
+    ('a', ['a', 'b']),
+])
+def test_comparison_with_in(
+    assert_errors,
+    parse_ast_tree,
+    code,
+    comparators,
+    default_options,
+):
+    """Comparisons work well for single `in`."""
+    tree = parse_ast_tree(code.format(*comparators))
+
+    visitor = MultipleInVisitor(default_options, tree=tree)
+    visitor.run()
+
+    assert_errors(visitor, [])
+
+
+@pytest.mark.parametrize('code', [
+    if_with_multiple_in_comaprisons,
+    ternary_with_multiple_in,
+    while_with_multiple_in,
+])
+@pytest.mark.parametrize('comparators', [
+    ('6', '6', '6'),
+    ('6', '6', [True]),
+    ('6', '5', '65'),
+])
+def test_comparison_with_multiple_in(
+    assert_errors,
+    parse_ast_tree,
+    code,
+    comparators,
+    default_options,
+):
+    """Comparisons raise for multiple `in`s."""
+    tree = parse_ast_tree(code.format(*comparators))
+
+    visitor = MultipleInVisitor(default_options, tree=tree)
+    visitor.run()
+
+    assert_errors(visitor, [MultipleInComparisonViolation])

--- a/tests/test_visitors/test_ast/test_comparisons/test_multiple_in.py
+++ b/tests/test_visitors/test_ast/test_comparisons/test_multiple_in.py
@@ -24,7 +24,7 @@ if_with_refactored_in = 'if x_coord in line and line in square: ...'
     if_with_refactored_in,
 ])
 @pytest.mark.parametrize('comparators', [
-    ('x', '6'),
+    ('x_coord', '6'),
     ('status', [True]),
     ('letter', ['a', 'b']),
 ])

--- a/tests/test_visitors/test_ast/test_comparisons/test_multiple_in.py
+++ b/tests/test_visitors/test_ast/test_comparisons/test_multiple_in.py
@@ -14,17 +14,19 @@ ternary = 'ternary = 0 if {0} in {1} else 1'
 ternary_with_multiple_in = 'ternary = 0 if {0} in {1} in {2} else 1'
 while_construct = 'while {0} in {1}: ...'
 while_with_multiple_in = 'while {0} in {1} in {2}: ...'
+if_with_refactored_in = 'if x_coord in line and line in square: ...'
 
 
 @pytest.mark.parametrize('code', [
     if_without_multiple_in_comparisons,
     ternary,
     while_construct,
+    if_with_refactored_in,
 ])
 @pytest.mark.parametrize('comparators', [
-    ('6', '6'),
-    ('6', [True]),
-    ('a', ['a', 'b']),
+    ('x', '6'),
+    ('status', [True]),
+    ('letter', ['a', 'b']),
 ])
 def test_comparison_with_in(
     assert_errors,
@@ -48,9 +50,9 @@ def test_comparison_with_in(
     while_with_multiple_in,
 ])
 @pytest.mark.parametrize('comparators', [
-    ('6', '6', '6'),
-    ('6', '6', [True]),
-    ('6', '5', '65'),
+    ('line', 'sqaure', 'shape'),
+    ('output', 'status', [True]),
+    ('letter', 'line', 'book'),
 ])
 def test_comparison_with_multiple_in(
     assert_errors,

--- a/wemake_python_styleguide/violations/consistency.py
+++ b/wemake_python_styleguide/violations/consistency.py
@@ -438,17 +438,18 @@ class MultipleInComparisonViolation(ASTViolation):
         Bring a consistency to the comparison!
 
     Solution:
-        Refactor your comparison expression.
-        Use different Comparisons.
+        Refactor your comparison expression to use several `and` conditions
+        or separate `if` statements in case it is appropriate.
 
     Example::
 
         # Correct:
-        if item in list:
-        if 1 in [3,4]:
+        if item in list and list in master_list:
+        if x_coord in line and line in square:
 
         # Wrong:
-        if 3 in [3,4] in [True]:
+        if item in list in master_list:
+        if x_cord in line in square:
 
     Note:
         Returns Z311 as error code

--- a/wemake_python_styleguide/violations/consistency.py
+++ b/wemake_python_styleguide/violations/consistency.py
@@ -438,17 +438,17 @@ class MultipleInComparisonViolation(ASTViolation):
         Bring a consistency to the comparison!
 
     Solution:
-        Refactor your comparison expression to use several `and` conditions
-        or separate `if` statements in case it is appropriate.
+        Refactor your comparison expression to use several ``and`` conditions
+        or separate ``if`` statements in case it is appropriate.
 
     Example::
 
         # Correct:
-        if item in list and list in master_list:
+        if item in bucket and bucket in master_list_of_buckets:
         if x_coord in line and line in square:
 
         # Wrong:
-        if item in list in master_list:
+        if item in bucket in master_list_of_buckets:
         if x_cord in line in square:
 
     Note:

--- a/wemake_python_styleguide/violations/consistency.py
+++ b/wemake_python_styleguide/violations/consistency.py
@@ -42,6 +42,7 @@ Summary
    ConstantComparisonViolation
    BadNumberSuffixViolation
    ComparisonOrderViolation
+   MultipleInComparisonViolation
 
 Consistency checks
 ------------------
@@ -57,6 +58,7 @@ Consistency checks
 .. autoclass:: ConstantComparisonViolation
 .. autoclass:: BadNumberSuffixViolation
 .. autoclass:: ComparisonOrderViolation
+.. autoclass:: MultipleInComparisonViolation
 
 """
 
@@ -425,3 +427,35 @@ class BadNumberSuffixViolation(TokenizeViolation):
     #: Error message shown to the user.
     error_template = 'Found underscored number: {0}'
     code = 310
+
+
+class MultipleInComparisonViolation(ASTViolation):
+    """
+    Forbids comparision where multiple 'in's are userd in a statement.
+
+    Reasoning:
+        This is unreadable. Use different comparisons for it.
+        Bring a consistency to the comparison!
+
+    Solution:
+        Refactor your comparison expression.
+        Use different Comparisons.
+
+    Example::
+
+        # Correct:
+        if item in list:
+        if 1 in [3,4]:
+
+        # Wrong:
+        if 3 in [3,4] in [True]:
+
+    Note:
+        Returns Z311 as error code
+
+    """
+
+    should_use_text = False
+    #: Error message shown to the user.
+    error_template = 'Found multiple in comparisons'
+    code = 311

--- a/wemake_python_styleguide/visitors/ast/comparisons.py
+++ b/wemake_python_styleguide/visitors/ast/comparisons.py
@@ -7,6 +7,7 @@ from wemake_python_styleguide.types import AnyNodes
 from wemake_python_styleguide.violations.consistency import (
     ComparisonOrderViolation,
     ConstantComparisonViolation,
+    MultipleInComparisonViolation,
 )
 from wemake_python_styleguide.visitors.base import BaseNodeVisitor
 
@@ -122,4 +123,30 @@ class WrongOrderVisitor(BaseNodeVisitor):
 
         """
         self._check_ordering(node)
+        self.generic_visit(node)
+
+
+class MultipleInVisitor(BaseNodeVisitor):
+    """Restricts comparision where multiple `in`s are used."""
+
+    def _has_multiple_in_comparisons(self, node: ast.Compare) -> bool:
+        count = 0
+        for op in node.ops:
+            if isinstance(op, ast.In):
+                count += 1
+        return count > 1
+
+    def _count_in_comparisons(self, node: ast.Compare) -> None:
+        if self._has_multiple_in_comparisons(node):
+            self.add_violation(MultipleInComparisonViolation(node))
+
+    def visit_Compare(self, node: ast.Compare) -> None:
+        """
+        Forbids comparisons including multiple 'in's in a statement.
+
+        Raise:
+            MultipleInComparisonViolation
+
+        """
+        self._count_in_comparisons(node)
         self.generic_visit(node)

--- a/wemake_python_styleguide/visitors/ast/comparisons.py
+++ b/wemake_python_styleguide/visitors/ast/comparisons.py
@@ -126,6 +126,7 @@ class WrongOrderVisitor(BaseNodeVisitor):
         self.generic_visit(node)
 
 
+# TODO(@sobolevn): refactor to be a single visitor
 class MultipleInVisitor(BaseNodeVisitor):
     """Restricts comparision where multiple `in`s are used."""
 

--- a/wemake_python_styleguide/visitors/presets/general.py
+++ b/wemake_python_styleguide/visitors/presets/general.py
@@ -38,6 +38,7 @@ GENERAL_PRESET = (
 
     comparisons.ConstantComparisonVisitor,
     comparisons.WrongOrderVisitor,
+    comparisons.MultipleInVisitor,
 
     # Classes:
     WrongClassVisitor,


### PR DESCRIPTION
# I have made things!
Restricted the use of multiple `in` comparisons in a single statement.
<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made
- [ ] I have added my changes to the `CHANGELOG.md`

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->
Closes #228 
<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
