### PR TITLE
Added inspection for class-level attributes containing upper-class le…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ to the project during `#hactoberfest`. List of awesome people:
 - Forbids the comparison of two literals
 - Forbids the incorrect order comparison
 - Forbids underscores before numbers in names
+- Forbids class level attributes whose name is not in snake_case
 - Enforce consistent octal, binary, and hex numbers
 - Forbid `for` loops with unused `else`
 

--- a/tests/test_visitors/test_ast/test_naming/test_class_attributes.py
+++ b/tests/test_visitors/test_ast/test_naming/test_class_attributes.py
@@ -7,6 +7,7 @@ import pytest
 from wemake_python_styleguide.violations.naming import (
     PrivateNameViolation,
     TooShortVariableNameViolation,
+    UpperCaseAttributeViolation,
     WrongVariableNameViolation,
 )
 from wemake_python_styleguide.visitors.ast.naming import (
@@ -52,7 +53,7 @@ def test_too_short_attribute_names(
     assert_errors, parse_ast_tree, short_name, code, default_options,
 ):
     """Testing that attribute can not have too short names."""
-    tree = parse_ast_tree(code.format(short_name))
+    tree = parse_ast_tree(code.format(short_name.lower()))
 
     visitor = WrongNameVisitor(default_options, tree=tree)
     visitor.run()
@@ -92,6 +93,46 @@ def test_correct_attribute_name(
 ):
     """Testing that attribute can have normal names."""
     tree = parse_ast_tree(code.format(correct_name))
+
+    visitor = WrongNameVisitor(default_options, tree=tree)
+    visitor.run()
+
+    assert_errors(visitor, [])
+
+
+@pytest.mark.parametrize('non_snake_case_name', [
+    'Abc',
+    'A_CONSTANT',
+    'AAA',
+    'CONST1_bc',
+    'camelCase',
+    '_A_c',
+])
+def test_upper_case_class_attributes(
+    assert_errors, parse_ast_tree, non_snake_case_name, default_options,
+):
+    """Testing that attribute can not have too short names."""
+    tree = parse_ast_tree(static_attribute.format(non_snake_case_name))
+
+    visitor = WrongNameVisitor(default_options, tree=tree)
+    visitor.run()
+
+    assert_errors(visitor, [UpperCaseAttributeViolation])
+
+
+@pytest.mark.parametrize('snake_case_name', [
+    'abc',
+    'a_variable',
+    'aaa',
+    'two_minutes_to_midnight',
+    'variable_42',
+    '_a_c',
+])
+def test_snake_case_class_attributes(
+    assert_errors, parse_ast_tree, snake_case_name, default_options,
+):
+    """Testing that attribute can not have too short names."""
+    tree = parse_ast_tree(static_attribute.format(snake_case_name))
 
     visitor = WrongNameVisitor(default_options, tree=tree)
     visitor.run()

--- a/wemake_python_styleguide/logics/variables.py
+++ b/wemake_python_styleguide/logics/variables.py
@@ -40,6 +40,28 @@ def is_wrong_variable_name(name: str, to_check: Iterable[str]) -> bool:
     return False
 
 
+def is_upper_case_name(name: str):
+    """
+    Checks that attribute name has no upper-case letters.
+
+    >>> is_upper_case_name('camelCase')
+    True
+    >>> is_upper_case_name('UPPER_CASE')
+    True
+    >>> is_upper_case_name('camel_Case')
+    True
+    >>> is_upper_case_name('snake_case')
+    False
+    >>> is_upper_case_name('snake')
+    False
+    >>> is_upper_case_name('snake111')
+    False
+    >>> is_upper_case_name('__variable_v2')
+    False
+    """
+    return any(character.isupper() for character in name)
+
+
 def is_too_short_variable_name(
     name: Optional[str],
     min_length: int = MIN_VARIABLE_LENGTH,

--- a/wemake_python_styleguide/violations/naming.py
+++ b/wemake_python_styleguide/violations/naming.py
@@ -125,6 +125,7 @@ Summary
    PrivateNameViolation
    SameAliasImportViolation
    UnderScoredNumberNameViolation
+   UpperCaseAttributeViolation
 
 Module names
 ------------
@@ -143,6 +144,7 @@ Variable names
 .. autoclass:: PrivateNameViolation
 .. autoclass:: SameAliasImportViolation
 .. autoclass:: UnderScoredNumberNameViolation
+.. autoclass:: UpperCaseAttributeViolations
 
 """
 
@@ -476,3 +478,30 @@ class UnderScoredNumberNameViolation(SimpleViolation):
     #: Error message shown to the user.
     error_template = 'Found underscored name pattern "{0}"'
     code = 114
+
+
+class UpperCaseAttributeViolation(ASTViolation):
+    """
+    Forbids to use anything but snake_case for naming attributes on a class.
+
+    Reasoning:
+        Constants with upper-case names belong on a module level.
+
+    Example::
+
+        # Correct:
+        class A(object):
+            my_constant = 42
+
+        # Wrong:
+        class A(object):
+            MY_CONSTANT = 42
+
+    Note:
+        Returns Z115 as error code
+
+    """
+
+    #: Error message shown to the user.
+    error_template = 'Found upper-case constant in a class "{0}"'
+    code = 115

--- a/wemake_python_styleguide/visitors/ast/naming.py
+++ b/wemake_python_styleguide/visitors/ast/naming.py
@@ -9,6 +9,7 @@ from wemake_python_styleguide.constants import (
 from wemake_python_styleguide.logics.variables import (
     is_private_variable,
     is_too_short_variable_name,
+    is_upper_case_name,
     is_variable_name_with_underscored_number,
     is_wrong_variable_name,
 )
@@ -20,13 +21,14 @@ from wemake_python_styleguide.violations.naming import (
     PrivateNameViolation,
     TooShortVariableNameViolation,
     UnderScoredNumberNameViolation,
+    UpperCaseAttributeViolation,
     WrongVariableNameViolation,
 )
 from wemake_python_styleguide.visitors.base import BaseNodeVisitor
 from wemake_python_styleguide.visitors.decorators import alias
 
 
-@alias('visit_any_import', (
+@alias('visit_any_import', (  # noqa: Z214
     'visit_ImportFrom',
     'visit_Import',
 ))
@@ -123,6 +125,35 @@ class WrongNameVisitor(BaseNodeVisitor):
         """
         if isinstance(node.ctx, ast.Store):
             self._check_name(node, node.id)
+
+        self.generic_visit(node)
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        """
+        Used to find upper attribute declarations.
+
+        Raises:
+            WrongVariableNameViolation
+            TooShortVariableNameViolation
+            PrivateNameViolation
+
+        """
+        top_level_assigns = filter(
+            lambda child: isinstance(child, ast.Assign),
+            node.body,
+        )
+
+        upper_case_violations = [
+            target
+            for assignment in top_level_assigns
+            for target in assignment.targets
+            if is_upper_case_name(target.id)
+        ]
+
+        for violation in upper_case_violations:
+            self.add_violation(
+                UpperCaseAttributeViolation(violation, text=violation.id),
+            )
 
         self.generic_visit(node)
 


### PR DESCRIPTION
…tters.

"noqa: Z214" is needed on WrongNameVisitor since I could not find a way to implement this without adding ClassDef-specific handler to the class, which in turn raised method count over the limit.

I could have maintaned a "last visited node" context inside the visitor and trigger check in standard place, but it would not have been explicit enough in my opinion.

# I have made things!

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made
- [x] I have added my changes to the `CHANGELOG.md`

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
