### PR TITLE
Added inspection for class-level attributes containing upper-class letters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ to the project during `#hactoberfest`. List of awesome people:
 - Forbids the comparison of two literals
 - Forbids the incorrect order comparison
 - Forbids underscores before numbers in names
+- Forbids class level attributes whose name is not in snake_case
 - Forbids comparison of the same variable
 - Enforce consistent octal, binary, and hex numbers
 - We not check the argument count in Lambda functions

--- a/tests/test_visitors/test_ast/test_naming/test_class_attributes.py
+++ b/tests/test_visitors/test_ast/test_naming/test_class_attributes.py
@@ -44,7 +44,7 @@ def test_wrong_attributes_names(
     assert_errors(visitor, [WrongVariableNameViolation])
 
 
-@pytest.mark.parametrize('short_name', string.ascii_letters)
+@pytest.mark.parametrize('short_name', string.ascii_lowercase)
 @pytest.mark.parametrize('code', [
     static_attribute,
     instance_attribute,
@@ -53,7 +53,7 @@ def test_too_short_attribute_names(
     assert_errors, parse_ast_tree, short_name, code, default_options,
 ):
     """Testing that attribute can not have too short names."""
-    tree = parse_ast_tree(code.format(short_name.lower()))
+    tree = parse_ast_tree(code.format(short_name))
 
     visitor = WrongNameVisitor(default_options, tree=tree)
     visitor.run()

--- a/tests/test_visitors/test_ast/test_naming/test_class_attributes.py
+++ b/tests/test_visitors/test_ast/test_naming/test_class_attributes.py
@@ -7,6 +7,7 @@ import pytest
 from wemake_python_styleguide.violations.naming import (
     PrivateNameViolation,
     TooShortVariableNameViolation,
+    UpperCaseAttributeViolation,
     WrongVariableNameViolation,
 )
 from wemake_python_styleguide.visitors.ast.naming import (
@@ -52,7 +53,7 @@ def test_too_short_attribute_names(
     assert_errors, parse_ast_tree, short_name, code, default_options,
 ):
     """Testing that attribute can not have too short names."""
-    tree = parse_ast_tree(code.format(short_name))
+    tree = parse_ast_tree(code.format(short_name.lower()))
 
     visitor = WrongNameVisitor(default_options, tree=tree)
     visitor.run()
@@ -92,6 +93,46 @@ def test_correct_attribute_name(
 ):
     """Testing that attribute can have normal names."""
     tree = parse_ast_tree(code.format(correct_name))
+
+    visitor = WrongNameVisitor(default_options, tree=tree)
+    visitor.run()
+
+    assert_errors(visitor, [])
+
+
+@pytest.mark.parametrize('non_snake_case_name', [
+    'Abc',
+    'A_CONSTANT',
+    'AAA',
+    'CONST1_bc',
+    'camelCase',
+    '_A_c',
+])
+def test_upper_case_class_attributes(
+    assert_errors, parse_ast_tree, non_snake_case_name, default_options,
+):
+    """Testing that attribute can not have too short names."""
+    tree = parse_ast_tree(static_attribute.format(non_snake_case_name))
+
+    visitor = WrongNameVisitor(default_options, tree=tree)
+    visitor.run()
+
+    assert_errors(visitor, [UpperCaseAttributeViolation])
+
+
+@pytest.mark.parametrize('snake_case_name', [
+    'abc',
+    'a_variable',
+    'aaa',
+    'two_minutes_to_midnight',
+    'variable_42',
+    '_a_c',
+])
+def test_snake_case_class_attributes(
+    assert_errors, parse_ast_tree, snake_case_name, default_options,
+):
+    """Testing that attribute can not have too short names."""
+    tree = parse_ast_tree(static_attribute.format(snake_case_name))
 
     visitor = WrongNameVisitor(default_options, tree=tree)
     visitor.run()

--- a/wemake_python_styleguide/logics/variables.py
+++ b/wemake_python_styleguide/logics/variables.py
@@ -47,16 +47,22 @@ def is_upper_case_name(name: str):
 
     >>> is_upper_case_name('camelCase')
     True
+
     >>> is_upper_case_name('UPPER_CASE')
     True
+
     >>> is_upper_case_name('camel_Case')
     True
+
     >>> is_upper_case_name('snake_case')
     False
+
     >>> is_upper_case_name('snake')
     False
+
     >>> is_upper_case_name('snake111')
     False
+
     >>> is_upper_case_name('__variable_v2')
     False
     """

--- a/wemake_python_styleguide/logics/variables.py
+++ b/wemake_python_styleguide/logics/variables.py
@@ -41,6 +41,28 @@ def is_wrong_variable_name(name: str, to_check: Iterable[str]) -> bool:
     return False
 
 
+def is_upper_case_name(name: str):
+    """
+    Checks that attribute name has no upper-case letters.
+
+    >>> is_upper_case_name('camelCase')
+    True
+    >>> is_upper_case_name('UPPER_CASE')
+    True
+    >>> is_upper_case_name('camel_Case')
+    True
+    >>> is_upper_case_name('snake_case')
+    False
+    >>> is_upper_case_name('snake')
+    False
+    >>> is_upper_case_name('snake111')
+    False
+    >>> is_upper_case_name('__variable_v2')
+    False
+    """
+    return any(character.isupper() for character in name)
+
+
 def is_too_short_variable_name(
     name: Optional[str],
     min_length: int = MIN_VARIABLE_LENGTH,

--- a/wemake_python_styleguide/violations/naming.py
+++ b/wemake_python_styleguide/violations/naming.py
@@ -453,7 +453,7 @@ class UnderScoredNumberNameViolation(SimpleViolation):
         This is done for consistency in naming.
 
     Solution:
-        Do not put an underscore between text and numbers, that confusing.
+        Do not put an underscore between text and numbers, that is confusing.
         Rename your variable or modules to not include underscored numbers.
 
     This rule checks: variables, and modules.
@@ -486,6 +486,10 @@ class UpperCaseAttributeViolation(ASTViolation):
 
     Reasoning:
         Constants with upper-case names belong on a module level.
+
+    Solution:
+        Move your constants to the module level.
+        Rename your variables so that they conform to "snake_case" convention.
 
     Example::
 

--- a/wemake_python_styleguide/violations/naming.py
+++ b/wemake_python_styleguide/violations/naming.py
@@ -125,6 +125,7 @@ Summary
    PrivateNameViolation
    SameAliasImportViolation
    UnderScoredNumberNameViolation
+   UpperCaseAttributeViolation
 
 Module names
 ------------
@@ -143,6 +144,7 @@ Variable names
 .. autoclass:: PrivateNameViolation
 .. autoclass:: SameAliasImportViolation
 .. autoclass:: UnderScoredNumberNameViolation
+.. autoclass:: UpperCaseAttributeViolations
 
 """
 
@@ -476,3 +478,30 @@ class UnderScoredNumberNameViolation(SimpleViolation):
     #: Error message shown to the user.
     error_template = 'Found underscored name pattern "{0}"'
     code = 114
+
+
+class UpperCaseAttributeViolation(ASTViolation):
+    """
+    Forbids to use anything but snake_case for naming attributes on a class.
+
+    Reasoning:
+        Constants with upper-case names belong on a module level.
+
+    Example::
+
+        # Correct:
+        class A(object):
+            my_constant = 42
+
+        # Wrong:
+        class A(object):
+            MY_CONSTANT = 42
+
+    Note:
+        Returns Z115 as error code
+
+    """
+
+    #: Error message shown to the user.
+    error_template = 'Found upper-case constant in a class "{0}"'
+    code = 115


### PR DESCRIPTION
"noqa: Z214" is needed on WrongNameVisitor since I could not find a way to implement this without adding ClassDef-specific handler to the class, which in turn raised method count over the limit.

I could have maintaned a "last visited node" context inside the visitor and trigger check in standard place, but it would not be explicit enough in my opinion.

Previous pull request was closed because I forgot to run mypy, which in turn required me to add some additional `isinstances` to facilitate type inference.

P.S. There is also a problem with variables inside code comprehensions being counted as locals, which in turn triggers *Z210*. Will fix it in separate PR if I have the time or just create an issue.

# I have made things!

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made
- [x] I have added my changes to the `CHANGELOG.md`

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
