### PR TITLE
Issue 255: Forbid using multiple `for` in comprehensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ to the project during `#hactoberfest`. List of awesome people:
 - Forbid `for` loops with unused `else`
 - Forbid `try` with `finally` without `except`
 - Forbid opening parenthesis from following keyword without space in between them
+- Forbid the use of more than 2 `for` loops within a comprehension
 
 ### Bugfixes
 

--- a/wemake_python_styleguide/violations/complexity.py
+++ b/wemake_python_styleguide/violations/complexity.py
@@ -489,7 +489,7 @@ class TooManyForsInComprehensionViolation(ASTViolation):
         amount of ``for`` statements
 
     Example::
-
+        # Wrong
         test = [
             target
             for assignment in top_level_assigns

--- a/wemake_python_styleguide/violations/complexity.py
+++ b/wemake_python_styleguide/violations/complexity.py
@@ -39,6 +39,7 @@ Summary
    LineComplexityViolation
    TooManyConditionsViolation
    TooManyElifsViolation
+   TooManyForsInComprehensionViolation
 
 Module complexity
 -----------------
@@ -63,6 +64,7 @@ Structures complexity
 .. autoclass:: LineComplexityViolation
 .. autoclass:: TooManyConditionsViolation
 .. autoclass:: TooManyElifsViolation
+.. autoclass:: TooManyForsInComprehensionViolation
 
 """
 
@@ -471,3 +473,36 @@ class TooManyElifsViolation(ASTViolation):
     #: Error message shown to the user.
     error_template = 'Found too many `elif` branches'
     code = 223
+
+
+@final
+class TooManyForsInComprehensionViolation(ASTViolation):
+    """
+    Forbids to have too many ``for`` statement within a comprehension.
+
+    Reasoning:
+        When reading through the complex comprehension you will fail
+        to understand it.
+
+    Solution:
+        We can reduce the complexity of a comprehension by reducing the
+        amount of ``for`` statements
+
+    Example::
+
+        test = [
+            target
+            for assignment in top_level_assigns
+            for target in assignment.targets
+            for _ in range(10)
+            if isinstance(target, ast.Name) and is_upper_case_name(target.id)
+        ]
+
+    Note:
+        Returns Z224 as error code
+
+    """
+
+    #: Error message shown to the user.
+    error_template = 'Found a comprehension with too many for statements: {0}'
+    code = 224


### PR DESCRIPTION
# I have made things!

- Forbid using multiple `for` in comprehensions (Closes issue #255)
- Added new  `TooManyForsInComprehensionViolation` violation

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [ ] I have updated the documentation for the changes I have made
- [x] I have added my changes to the `CHANGELOG.md`

## Related issues

- Closes issue #255 
