### PR TITLE
Solved Issue-254: Forbid `yield` keyword in `__init__` method

### DIFF
--- a/tests/test_visitors/test_ast/test_classes/test_yield_init.py
+++ b/tests/test_visitors/test_ast/test_classes/test_yield_init.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+
+from wemake_python_styleguide.violations.best_practices import (
+    YieldInsideInitViolation,
+)
+from wemake_python_styleguide.visitors.ast.classes import (
+    WrongClassVisitor,
+)
+
+init_without_yield = """
+class ModuleMembersVisitor(object):
+    def __init__(self, *args, **kwargs):
+        self._public_items_count = 0
+"""
+
+init_with_yield = """
+class ModuleMembersVisitor(object):
+    def __init__(self, *args, **kwargs):
+        yield 10
+"""
+
+async_init_without_yield = """
+class ModuleMembersVisitor(object):
+    async def __init__(self, *args, **kwargs):
+        self._public_items_count = 0
+"""
+
+async_init_with_yield = """
+class ModuleMembersVisitor(object):
+    async def __init__(self, *args, **kwargs):
+        yield 10
+"""
+
+
+@pytest.mark.parametrize('code', [
+    init_with_yield,
+    async_init_with_yield,
+])
+def test_init(
+    assert_errors, parse_ast_tree, code, default_options,
+):
+    tree = parse_ast_tree(code)
+
+    visitor = WrongClassVisitor(default_options, tree=tree)
+    visitor.run()
+
+    assert_errors(visitor, [YieldInsideInitViolation])
+
+
+@pytest.mark.parametrize('code', [
+    init_without_yield,
+    async_init_without_yield,
+])
+def test_init(
+    assert_errors, parse_ast_tree, code, default_options,
+):
+    tree = parse_ast_tree(code)
+
+    visitor = WrongClassVisitor(default_options, tree=tree)
+    visitor.run()
+
+    assert_errors(visitor, [YieldInsideInitViolation])

--- a/tests/test_visitors/test_ast/test_classes/test_yield_init.py
+++ b/tests/test_visitors/test_ast/test_classes/test_yield_init.py
@@ -2,11 +2,11 @@
 
 import pytest
 
-from wemake_python_styleguide.violations.best_practices import (
-    YieldInsideInitViolation,
-)
 from wemake_python_styleguide.visitors.ast.classes import (
     WrongClassVisitor,
+)
+from wemake_python_styleguide.violations.best_practices import (
+    YieldInsideInitViolation,
 )
 
 init_without_yield = """
@@ -41,6 +41,7 @@ class ModuleMembersVisitor(object):
 def test_init(
     assert_errors, parse_ast_tree, code, default_options,
 ):
+    """Testing that `__init__` without `yield` is prohibited"""
     tree = parse_ast_tree(code)
 
     visitor = WrongClassVisitor(default_options, tree=tree)
@@ -56,9 +57,10 @@ def test_init(
 def test_init(
     assert_errors, parse_ast_tree, code, default_options,
 ):
+    """Testing that `__init__` without `yield` is allowed."""
     tree = parse_ast_tree(code)
 
     visitor = WrongClassVisitor(default_options, tree=tree)
     visitor.run()
 
-    assert_errors(visitor, [YieldInsideInitViolation])
+    assert_errors(visitor, [])

--- a/wemake_python_styleguide/violations/best_practices.py
+++ b/wemake_python_styleguide/violations/best_practices.py
@@ -40,6 +40,7 @@ Summary
    RedundantForElseViolation
    RedundantFinallyViolation
    ReassigningVariableToItselfViolation
+   YieldInsideInitViolation
 
 Comments
 --------

--- a/wemake_python_styleguide/violations/best_practices.py
+++ b/wemake_python_styleguide/violations/best_practices.py
@@ -733,8 +733,40 @@ class ReassigningVariableToItselfViolation(ASTViolation):
 
     Note:
         Returns Z438 as error code
+
     """
 
     #: Error message shown to the user.
     error_template = 'Found reassigning variable "{0}" to itself'
     code = 438
+
+
+@final
+class YieldInsideInitViolation(ASTViolation):
+    """
+    Forbids to use ``yield`` inside of ``__init__``
+
+    Reasoning:
+        ``__init__`` should be used to initialize new objects.
+        It shouldn't create any new objects by yielding them
+
+    Example::
+         # Correct:
+        class ModuleMembersVisitor(object):
+            def __init__(self, *args, **kwargs):
+                self._public_items_count = 0
+
+        # Wrong:
+        class ModuleMembersVisitor(object):
+            def __init__(self, *args, **kwargs):
+                self._public_items_count = 0
+                yield 10
+
+    Note:
+        Returns Z439 as error code
+
+    """
+
+    #: Error message shown to the user.
+    error_template = 'Found `yield` inside `__init__`'
+    code = 439

--- a/wemake_python_styleguide/visitors/ast/classes.py
+++ b/wemake_python_styleguide/visitors/ast/classes.py
@@ -75,7 +75,7 @@ class WrongClassVisitor(BaseNodeVisitor):
             )
 
     def _check_yield_inside_init(self, node: AnyFunctionDef) -> None:
-        """Check yield is not in the __init__"""
+        """Check yield is not in the __init__."""
         if node.name == '__init__':
             for inner_node in ast.iter_child_nodes(node):
                 if isinstance(inner_node, self._not_appropriate_for_init):


### PR DESCRIPTION
# `yield` is no longer allowed in the `__init__`

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Checklist

<!-- Please check everything that applies: -->

- [ ] I have added the code to make sure the `yield` generator can't be used in the `__init__` initializer 
- [ ] The following test cases have been covered: `def __init__` with yield, `def __init__` without yield, `async def __init__` with yield,  `async def __init__` without yield.


## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
