### PR TITLE
Fixing docstring copy paste errors

### DIFF
--- a/wemake_python_styleguide/violations/best_practices.py
+++ b/wemake_python_styleguide/violations/best_practices.py
@@ -1128,7 +1128,7 @@ class StatementHasNoEffectViolation(ASTViolation):
 @final
 class MultipleAssignmentsViolation(ASTViolation):
     """
-    Forbids to have statements that do nothing.
+    Forbids to have multiple assignments on the same line.
 
     Reasoning:
         Multiple assignments on the same line might not do what you think

--- a/wemake_python_styleguide/violations/best_practices.py
+++ b/wemake_python_styleguide/violations/best_practices.py
@@ -1406,7 +1406,7 @@ class MethodWithoutArgumentsViolation(ASTViolation):
     Forbids to have methods without any arguments.
 
     Reasoning:
-        Methods withour arguments are allowed to be defined,
+        Methods without arguments are allowed to be defined,
         but almost impossible to use.
         Furthermore, they don't have an access to ``self``,
         so can not access the inner state of the object.
@@ -1437,7 +1437,7 @@ class MethodWithoutArgumentsViolation(ASTViolation):
 @final
 class IncorrectBaseClassViolation(ASTViolation):
     """
-    Forbids to have methods without any arguments.
+    Forbids to have anything else than a class as a base class.
 
     Reasoning:
         In Python you can specify anything in the base classes slot.

--- a/wemake_python_styleguide/violations/best_practices.py
+++ b/wemake_python_styleguide/violations/best_practices.py
@@ -1158,7 +1158,7 @@ class MultipleAssignmentsViolation(ASTViolation):
 @final
 class IncorrectUnpackingViolation(ASTViolation):
     """
-    Forbids to have statements that do nothing.
+    Forbids to have tuple unpacking with side-effects.
 
     Reasoning:
         Having unpacking with side-effects is very dirty.


### PR DESCRIPTION
Some classes have been copy pasted and then edited, but the headline remained the same. They have been updated to reflect the rule of each particular class.