### PR TITLE
Add LGTM code quality shield

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # wemake-python-styleguide
 
 [![wemake.services](https://img.shields.io/badge/%20-wemake.services-green.svg?label=%20&logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAMAAAAoLQ9TAAAABGdBTUEAALGPC%2FxhBQAAAAFzUkdCAK7OHOkAAAAbUExURQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP%2F%2F%2F5TvxDIAAAAIdFJOUwAjRA8xXANAL%2Bv0SAAAADNJREFUGNNjYCAIOJjRBdBFWMkVQeGzcHAwksJnAPPZGOGAASzPzAEHEGVsLExQwE7YswCb7AFZSF3bbAAAAABJRU5ErkJggg%3D%3D)](https://wemake.services)
+[![Python Version](https://img.shields.io/pypi/pyversions/wemake-python-styleguide.svg)](https://pypi.org/project/wemake-python-styleguide/)
+[![wemake-python-styleguide](https://img.shields.io/badge/style-wemake-000000.svg)](https://github.com/wemake-services/wemake-python-styleguide)
+
 [![Build Status](https://travis-ci.org/wemake-services/wemake-python-styleguide.svg?branch=master)](https://travis-ci.org/wemake-services/wemake-python-styleguide) 
 [![Coverage](https://coveralls.io/repos/github/wemake-services/wemake-python-styleguide/badge.svg?branch=master)](https://coveralls.io/github/wemake-services/wemake-python-styleguide?branch=master)
-[![Python Version](https://img.shields.io/pypi/pyversions/wemake-python-styleguide.svg)](https://pypi.org/project/wemake-python-styleguide/)
 [![Documentation Status](https://readthedocs.org/projects/wemake-python-styleguide/badge/?version=latest)](https://wemake-python-styleguide.readthedocs.io/en/latest/?badge=latest)
 [![Dependencies Status](https://img.shields.io/badge/dependencies-up%20to%20date-brightgreen.svg)](https://github.com/wemake-services/wemake-python-styleguide/pulls?utf8=%E2%9C%93&q=is%3Apr%20author%3Aapp%2Fdependabot)
-[![wemake-python-styleguide](https://img.shields.io/badge/style-wemake-000000.svg)](https://github.com/wemake-services/wemake-python-styleguide)
 [![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/wemake-services/wemake-python-styleguide.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/wemake-services/wemake-python-styleguide/context:python)
 ---
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Documentation Status](https://readthedocs.org/projects/wemake-python-styleguide/badge/?version=latest)](https://wemake-python-styleguide.readthedocs.io/en/latest/?badge=latest)
 [![Dependencies Status](https://img.shields.io/badge/dependencies-up%20to%20date-brightgreen.svg)](https://github.com/wemake-services/wemake-python-styleguide/pulls?utf8=%E2%9C%93&q=is%3Apr%20author%3Aapp%2Fdependabot)
 [![wemake-python-styleguide](https://img.shields.io/badge/style-wemake-000000.svg)](https://github.com/wemake-services/wemake-python-styleguide)
-
+[![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/wemake-services/wemake-python-styleguide.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/wemake-services/wemake-python-styleguide/context:python)
 ---
 
 Welcome to the strictest and most opinionated python linter ever.


### PR DESCRIPTION
I am adding a shield to demonstrate the exemplary quality of Python code compared to other Python projects.

I have also added this style guide project to LGTM.com so each commit will be analyzed to see if any alert is introduced. Project overview page is accessible [here](https://lgtm.com/projects/g/wemake-services/wemake-python-styleguide/overview/).

Nearly all queries from the [Python queries suite](https://help.semmle.com/wiki/display/PYTHON/Python+queries) will be run on each commit. It is also possible to add existing custom queries, for instance, this one: [Accepting unknown SSH host keys when using Paramiko](https://github.com/Semmle/ql/blob/2ba122373acd660ea0c2fb148d6ee2e1e8732dca/python/ql/src/Security/CWE-295/MissingHostKeyValidation.ql) or even write custom queries using QL, for instance, [Find all Python identifiers with a non-ASCII character](https://lgtm.com/query/3123831890641430639/). If you have an idea of what you would like to test in Python code, please do let me know as I could add it to your project to be run on each commit.

You can also use LGTM as a continuous integration tool to automatically review code in pull requests before it reaches your main branch. Read more [here](https://lgtm.com/projects/g/wemake-services/wemake-python-styleguide/ci/). The alerts won't impede you from merging a PR; you can choose what is important for you. If you feel you are not ready for this, no worries, I'll check periodically the LGTM project overview page to see for any new alerts being introduced and will post an issue / submit a PR.
