### PR TITLE
Forbid usage of Literal[None] annotation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ We follow Semantic Versions since the `0.1.0` release.
 We used to have incremental versioning before `0.1.0`.
 
 
-## 0.13.1
+## 0.13.0 WIP
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ We follow Semantic Versions since the `0.1.0` release.
 We used to have incremental versioning before `0.1.0`.
 
 
+## 0.13.1
+
+### Features
+
+- Forbids using `Literal[None]` in function annotations
+
+
 ## 0.13.0
 
 ### Features

--- a/docs/pages/usage/violations/annotations.rst
+++ b/docs/pages/usage/violations/annotations.rst
@@ -1,0 +1,7 @@
+.. _annotations:
+
+Annotations
+===========
+
+.. automodule:: wemake_python_styleguide.violations.annotations
+   :no-members:

--- a/docs/pages/usage/violations/index.rst
+++ b/docs/pages/usage/violations/index.rst
@@ -17,6 +17,7 @@ Consistency    :ref:`WPS300 - WPS399 <consistency>`
 Best practices :ref:`WPS400 - WPS499 <best-practices>`
 Refactoring    :ref:`WPS500 - WPS599 <refactoring>`
 OOP            :ref:`WPS600 - WPS699 <oop>`
+Annotations    :ref:`WPS700 - WPS799 <annotations>`
 ============== ======
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ import pytest
 
 from wemake_python_styleguide.options.config import Configuration
 from wemake_python_styleguide.violations import (
+    annotations,
     best_practices,
     complexity,
     consistency,
@@ -47,6 +48,7 @@ def _load_all_violation_classes():
         best_practices,
         refactoring,
         oop,
+        annotations,
     ]
 
     classes = {}

--- a/tests/fixtures/noqa.py
+++ b/tests/fixtures/noqa.py
@@ -562,8 +562,8 @@ assert []  # noqa: WPS444
 unhashable = [] * 2  # noqa: WPS435
 
 
-def literal_none_func(arg: Literal[None]):  # noqa: WPS347
+def literal_none_func(arg: Literal[None]):  # noqa: WPS701
     '''Literal[None]'''
 
-def literal_none_return_func() -> Literal[None]:  # noqa: WPS347
+def literal_none_return_func() -> Literal[None]:  # noqa: WPS701
     '''Literal[None]'''

--- a/tests/fixtures/noqa.py
+++ b/tests/fixtures/noqa.py
@@ -560,3 +560,10 @@ print(literal)  # noqa: WPS441
 unhashable = {[]}  # noqa: WPS443
 assert []  # noqa: WPS444
 unhashable = [] * 2  # noqa: WPS435
+
+
+def literal_none_func(arg: Literal[None]):  # noqa: WPS347
+    '''Literal[None]'''
+
+def literal_none_return_func() -> Literal[None]:  # noqa: WPS347
+    '''Literal[None]'''

--- a/tests/test_checker/test_noqa.py
+++ b/tests/test_checker/test_noqa.py
@@ -120,7 +120,6 @@ SHOULD_BE_RAISED = types.MappingProxyType({
     'WPS344': 1,
     'WPS345': 1,
     'WPS346': 1,
-    'WPS347': 2,
 
     'WPS400': 0,
     'WPS401': 0,
@@ -206,6 +205,8 @@ SHOULD_BE_RAISED = types.MappingProxyType({
     'WPS610': 1,
     'WPS611': 1,
     'WPS612': 1,
+
+    'WPS701': 2,
 })
 
 

--- a/tests/test_checker/test_noqa.py
+++ b/tests/test_checker/test_noqa.py
@@ -120,6 +120,7 @@ SHOULD_BE_RAISED = types.MappingProxyType({
     'WPS344': 1,
     'WPS345': 1,
     'WPS346': 1,
+    'WPS347': 2,
 
     'WPS400': 0,
     'WPS401': 0,

--- a/tests/test_violations/test_codes.py
+++ b/tests/test_violations/test_codes.py
@@ -12,7 +12,7 @@ def test_all_unique_violation_codes(all_violations):
 
 def test_all_violations_correct_numbers(all_module_violations):
     """Ensures that all violations has correct violation code numbers."""
-    assert len(all_module_violations) == 6
+    assert len(all_module_violations) == 7
 
     for index, module in enumerate(all_module_violations.keys()):
         classes = all_module_violations[module]

--- a/tests/test_visitors/test_ast/test_annotations/test_argument_annotations.py
+++ b/tests/test_visitors/test_ast/test_annotations/test_argument_annotations.py
@@ -2,10 +2,8 @@
 
 import pytest
 
-from wemake_python_styleguide.violations.consistency import (
-    LiteralNoneViolation,
-)
 from wemake_python_styleguide.visitors.ast.annotations import (
+    LiteralNoneViolation,
     MultilineFunctionAnnotationViolation,
     WrongAnnotationVisitor,
 )

--- a/tests/test_visitors/test_ast/test_annotations/test_argument_annotations.py
+++ b/tests/test_visitors/test_ast/test_annotations/test_argument_annotations.py
@@ -2,6 +2,9 @@
 
 import pytest
 
+from wemake_python_styleguide.violations.consistency import (
+    LiteralNoneViolation,
+)
 from wemake_python_styleguide.visitors.ast.annotations import (
     MultilineFunctionAnnotationViolation,
     WrongAnnotationVisitor,
@@ -32,6 +35,14 @@ def function(
 ): ...
 """
 
+correct_literal_annotation = """
+def function(arg: Literal[True]) -> Literal["foo"]: ...
+"""
+
+correct_arg_none_annotation = """
+def function(empty_arg: None): ...
+"""
+
 # Wrong:
 
 wrong_multiline_arguments = """
@@ -50,6 +61,34 @@ def function(
     ],
 ): ...
 """
+
+wrong_arg_none_annotation = """
+def function(empty_arg: Literal[None]): ...
+"""
+
+wrong_embedded_arg_none_annotation = """
+def function(empty_arg: Union[Literal[None], Optional[int]]): ...
+"""
+
+
+@pytest.mark.parametrize('code', [
+    wrong_arg_none_annotation,
+    wrong_embedded_arg_none_annotation,
+])
+def test_forbidden_literal_none_annotation(
+    assert_errors,
+    parse_ast_tree,
+    code,
+    default_options,
+    mode,
+):
+    """Ensures that using incorrect argument annotations is forbiden."""
+    tree = parse_ast_tree(mode(code))
+
+    visitor = WrongAnnotationVisitor(default_options, tree=tree)
+    visitor.run()
+
+    assert_errors(visitor, [LiteralNoneViolation])
 
 
 @pytest.mark.parametrize('code', [
@@ -78,6 +117,8 @@ def test_wrong_argument_annotation(
     correct_simple_argument,
     correct_compound_argument,
     correct_multiline_arguments,
+    correct_arg_none_annotation,
+    correct_literal_annotation,
 ])
 def test_correct_argument_annotation(
     assert_errors,

--- a/tests/test_visitors/test_ast/test_annotations/test_return_annotations.py
+++ b/tests/test_visitors/test_ast/test_annotations/test_return_annotations.py
@@ -2,6 +2,9 @@
 
 import pytest
 
+from wemake_python_styleguide.violations.consistency import (
+    LiteralNoneViolation,
+)
 from wemake_python_styleguide.visitors.ast.annotations import (
     MultilineFunctionAnnotationViolation,
     WrongAnnotationVisitor,
@@ -27,7 +30,23 @@ def function(
 ) -> Optional[Union[int, str]]: ...
 """
 
+correct_return_none_annotation = """
+def function(arg) -> None: ...
+"""
+
+correct_embedded_return_none_annotation = """
+def function(arg) -> Union[None, Optional[int]]: ...
+"""
+
 # Wrong:
+
+wrong_embedded_return_none_annotation = """
+def function(arg) -> Union[Literal[None], Optional[int]]: ...
+"""
+
+wrong_return_none_annotation = """
+def function(arg) -> Literal[None]: ...
+"""
 
 wrong_multiline_return1 = """
 def function(
@@ -81,10 +100,32 @@ def test_wrong_return_annotation(
 
 
 @pytest.mark.parametrize('code', [
+    wrong_embedded_return_none_annotation,
+    wrong_return_none_annotation,
+])
+def test_wrong_literal_none_return_annotation(
+    assert_errors,
+    parse_ast_tree,
+    code,
+    default_options,
+    mode,
+):
+    """Ensures that using incorrect return annotations is forbiden."""
+    tree = parse_ast_tree(mode(code))
+
+    visitor = WrongAnnotationVisitor(default_options, tree=tree)
+    visitor.run()
+
+    assert_errors(visitor, [LiteralNoneViolation])
+
+
+@pytest.mark.parametrize('code', [
     correct_function_without_annotations,
     correct_simple_return,
     correct_compound_return,
     correct_multiline_return,
+    correct_embedded_return_none_annotation,
+    correct_return_none_annotation,
 ])
 def test_correct_return_annotation(
     assert_errors,

--- a/tests/test_visitors/test_ast/test_annotations/test_return_annotations.py
+++ b/tests/test_visitors/test_ast/test_annotations/test_return_annotations.py
@@ -2,10 +2,8 @@
 
 import pytest
 
-from wemake_python_styleguide.violations.consistency import (
-    LiteralNoneViolation,
-)
 from wemake_python_styleguide.visitors.ast.annotations import (
+    LiteralNoneViolation,
     MultilineFunctionAnnotationViolation,
     WrongAnnotationVisitor,
 )

--- a/wemake_python_styleguide/violations/annotations.py
+++ b/wemake_python_styleguide/violations/annotations.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+
+"""
+These checks help to prevent incorrect usage of Python 3 typing annotations.
+
+While they maybe of a great help in writing clear
+and concise code, they still can be abused.
+
+Once again, these rules are highly subjective. But, we love them.
+
+.. currentmodule:: wemake_python_styleguide.violations.annotations
+
+Summary
+-------
+
+.. autosummary::
+   :nosignatures:
+
+   LiteralNoneViolation
+
+Annotation checks
+------------------
+
+.. autoclass:: LiteralNoneViolation
+
+"""
+
+from typing_extensions import final
+
+from wemake_python_styleguide.violations.base import ASTViolation
+
+
+@final
+class LiteralNoneViolation(ASTViolation):
+    """
+    Forbids to use ``Literal[None]`` typing annotation.
+
+    Reasoning:
+        Literal[None] is just the same as None.
+        There's no need to use the first version.
+        It is not type related, it is a consistency rule.
+
+    Solution:
+        Replace ``Literal[None]`` with ``None``.
+
+    Example::
+
+        # Correct:
+        def func(empty: None):
+            '''Empty function.'''
+
+        # Wrong:
+        def func(empty: Literal[None]):
+            '''Empty function.'''
+
+    .. versionadded:: 0.13.0
+
+    """
+
+    code = 701
+    error_template = 'Found useless `Literal[None]` typing annotation'

--- a/wemake_python_styleguide/violations/consistency.py
+++ b/wemake_python_styleguide/violations/consistency.py
@@ -72,7 +72,6 @@ Summary
    ZeroDivisionViolation
    MeaninglessNumberOperationViolation
    OperationSignNegationViolation
-   LiteralNoneViolation
 
 Consistency checks
 ------------------
@@ -124,7 +123,6 @@ Consistency checks
 .. autoclass:: ZeroDivisionViolation
 .. autoclass:: MeaninglessNumberOperationViolation
 .. autoclass:: OperationSignNegationViolation
-.. autoclass:: LiteralNoneViolation
 
 """
 
@@ -1750,34 +1748,3 @@ class OperationSignNegationViolation(ASTViolation):
 
     error_template = 'Found wrong operation sign'
     code = 346
-
-
-@final
-class LiteralNoneViolation(ASTViolation):
-    """
-    Forbids to use ``Literal[None]`` typing annotation.
-
-    Reasoning:
-        Literal[None] is just the same as None.
-        There's no need to use the first version.
-        It is not type related, it is a consistency rule.
-
-    Solution:
-        Replace ``Literal[None]`` with ``None``.
-
-    Example::
-
-        # Correct:
-        def func(empty: None):
-            '''Empty function.'''
-
-        # Wrong:
-        def func(empty: Literal[None]):
-            '''Empty function.'''
-
-    .. versionadded:: 0.13.0
-
-    """
-
-    code = 347
-    error_template = 'Found useless `Literal[None]` typing annotation'

--- a/wemake_python_styleguide/violations/consistency.py
+++ b/wemake_python_styleguide/violations/consistency.py
@@ -72,6 +72,7 @@ Summary
    ZeroDivisionViolation
    MeaninglessNumberOperationViolation
    OperationSignNegationViolation
+   LiteralNoneViolation
 
 Consistency checks
 ------------------
@@ -123,6 +124,7 @@ Consistency checks
 .. autoclass:: ZeroDivisionViolation
 .. autoclass:: MeaninglessNumberOperationViolation
 .. autoclass:: OperationSignNegationViolation
+.. autoclass:: LiteralNoneViolation
 
 """
 
@@ -1748,3 +1750,34 @@ class OperationSignNegationViolation(ASTViolation):
 
     error_template = 'Found wrong operation sign'
     code = 346
+
+
+@final
+class LiteralNoneViolation(ASTViolation):
+    """
+    Forbids to use ``Literal[None]`` typing annotation.
+
+    Reasoning:
+        Literal[None] is just the same as None.
+        There's no need to use the first version.
+        It is not type related, it is a consistency rule.
+
+    Solution:
+        Replace ``Literal[None]`` with ``None``.
+
+    Example::
+
+        # Correct:
+        def func(empty: None):
+            '''Empty function.'''
+
+        # Wrong:
+        def func(empty: Literal[None]):
+            '''Empty function.'''
+
+    .. versionadded:: 0.13.0
+
+    """
+
+    code = 347
+    error_template = 'Found useless `Literal[None]` typing annotation'

--- a/wemake_python_styleguide/visitors/ast/annotations.py
+++ b/wemake_python_styleguide/visitors/ast/annotations.py
@@ -6,8 +6,10 @@ from typing import cast
 from typing_extensions import final
 
 from wemake_python_styleguide.types import AnyFunctionDef
-from wemake_python_styleguide.violations.consistency import (
+from wemake_python_styleguide.violations.annotations import (
     LiteralNoneViolation,
+)
+from wemake_python_styleguide.violations.consistency import (
     MultilineFunctionAnnotationViolation,
 )
 from wemake_python_styleguide.visitors.base import BaseNodeVisitor

--- a/wemake_python_styleguide/visitors/ast/annotations.py
+++ b/wemake_python_styleguide/visitors/ast/annotations.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
 
 import ast
+from typing import cast
 
 from typing_extensions import final
 
 from wemake_python_styleguide.types import AnyFunctionDef
 from wemake_python_styleguide.violations.consistency import (
+    LiteralNoneViolation,
     MultilineFunctionAnnotationViolation,
 )
 from wemake_python_styleguide.visitors.base import BaseNodeVisitor
@@ -42,12 +44,28 @@ class WrongAnnotationVisitor(BaseNodeVisitor):
         self._check_arg_annotation(node)
         self.generic_visit(node)
 
+    def _check_for_literal_none(self, node: ast.Subscript) -> None:
+        annotation_name = cast(ast.Name, node.value)
+        slice_index = cast(ast.Index, node.slice)
+
+        if annotation_name.id != 'Literal':
+            return
+
+        if not isinstance(slice_index.value, ast.NameConstant):
+            return
+
+        if slice_index.value.value is None:
+            self.add_violation(LiteralNoneViolation(node))
+
     def _check_arg_annotation(self, node: ast.arg) -> None:
         for sub_node in ast.walk(node):
             lineno = getattr(sub_node, 'lineno', None)
             if lineno and lineno != node.lineno:
                 self.add_violation(MultilineFunctionAnnotationViolation(node))
                 return
+
+            if isinstance(sub_node, ast.Subscript):
+                self._check_for_literal_none(sub_node)
 
     def _check_return_annotation(self, node: AnyFunctionDef) -> None:
         if not node.returns:
@@ -58,3 +76,6 @@ class WrongAnnotationVisitor(BaseNodeVisitor):
             if lineno and lineno != node.returns.lineno:
                 self.add_violation(MultilineFunctionAnnotationViolation(node))
                 return
+
+            if isinstance(sub_node, ast.Subscript):
+                self._check_for_literal_none(sub_node)


### PR DESCRIPTION
Closes #829 

I've decided to fold the check into an existing one for the wrong annotations, although
it took some doing to appease `mypy`.

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Checklist

<!-- Please check everything that applies: -->

- [X] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [X] I have created at least one test case for the changes I have made
- [X] I have updated the documentation for the changes I have made
- [X] I have added my changes to the `CHANGELOG.md`

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

On the side note, you may need to extend your contributor's guidelines to include recommendations on how to properly write integration tests in your project. Debugging those cryptic failures was somewhat fun, but rather non-trivial.