### PR TITLE
Fix ImplicitElifViolation false positives on try/except and for/else.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ We used to have incremental versioning before `0.1.0`.
 ### Features
 
 - Forbids using `Literal[None]` in function annotations
+- Fixes 
 
 
 ## 0.13.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@ We used to have incremental versioning before `0.1.0`.
 ### Features
 
 - Forbids using `Literal[None]` in function annotations
-- Fixes 
+
+### Bugfixes
+
+- Fixes **ImplicitElifViolation** false positives on a specific edge cases.
 
 
 ## 0.13.0

--- a/tests/test_visitors/test_tokenize/test_conditions/test_implicit_elif.py
+++ b/tests/test_visitors/test_tokenize/test_conditions/test_implicit_elif.py
@@ -46,6 +46,30 @@ else:
         ...
 """
 
+# False positives
+
+for_else = """
+for a in b:
+   ...
+else:
+   if some:
+       ...
+"""
+
+try_except_else = """
+try:
+   ...
+except:
+   ...
+else:
+   if some:
+       ...
+"""
+
+embedded_else = """
+... if ... else ...
+"""
+
 
 @pytest.mark.parametrize('code', [
     elif_cases,
@@ -83,3 +107,23 @@ def test_implicit_elif_statements(
     visitor.run()
 
     assert_errors(visitor, [ImplicitElifViolation])
+
+
+@pytest.mark.parametrize('code', [
+    for_else,
+    try_except_else,
+    embedded_else,
+])
+def test_false_positives_are_ignored(
+    code,
+    assert_errors,
+    parse_tokens,
+    default_options,
+):
+    """Testing regular conditions."""
+    file_tokens = parse_tokens(code)
+
+    visitor = IfElseVisitor(default_options, file_tokens=file_tokens)
+    visitor.run()
+
+    assert_errors(visitor, [])

--- a/tests/test_visitors/test_tokenize/test_conditions/test_implicit_elif.py
+++ b/tests/test_visitors/test_tokenize/test_conditions/test_implicit_elif.py
@@ -46,7 +46,8 @@ else:
         ...
 """
 
-# False positives
+# False positives, triggered by other constructs with `else` clause
+# (see https://github.com/wemake-services/wemake-python-styleguide/issues/835)
 
 for_else = """
 for a in b:
@@ -68,6 +69,12 @@ else:
 
 embedded_else = """
 ... if ... else ...
+"""
+
+technically_correct_token_stream = """
+    42
+        a
+    else
 """
 
 
@@ -113,6 +120,7 @@ def test_implicit_elif_statements(
     for_else,
     try_except_else,
     embedded_else,
+    technically_correct_token_stream,
 ])
 def test_false_positives_are_ignored(
     code,

--- a/wemake_python_styleguide/visitors/tokenize/conditions.py
+++ b/wemake_python_styleguide/visitors/tokenize/conditions.py
@@ -57,7 +57,7 @@ class IfElseVisitor(BaseTokenVisitor):
         """
         self._check_implicit_elif(token)
 
-    def _check_else_belongs_to_if(self, start_index: int) -> bool:
+    def _does_else_belong_to_if(self, start_index: int) -> bool:
         previous_token = self.file_tokens[start_index - 1]
 
         if previous_token.type != tokenize.DEDENT:
@@ -74,7 +74,7 @@ class IfElseVisitor(BaseTokenVisitor):
             if token.start[1] == previous_token.start[1]:
                 return token.string in {'if', 'elif'}
 
-        return False  # pragma: no cover
+        return False
 
     def _check_implicit_elif(self, token: tokenize.TokenInfo) -> None:
         if token.string != 'else':
@@ -84,7 +84,7 @@ class IfElseVisitor(BaseTokenVisitor):
 
         # `else` token can belong also to `for` and `try/except` statement,
         # which can trigger false positive for that violation.
-        if not self._check_else_belongs_to_if(index):
+        if not self._does_else_belong_to_if(index):
             return
 
         # There's a bug in coverage, I am not sure how to make it work.

--- a/wemake_python_styleguide/visitors/tokenize/conditions.py
+++ b/wemake_python_styleguide/visitors/tokenize/conditions.py
@@ -57,11 +57,36 @@ class IfElseVisitor(BaseTokenVisitor):
         """
         self._check_implicit_elif(token)
 
+    def _check_else_belongs_to_if(self, start_index: int) -> bool:
+        previous_token = self.file_tokens[start_index - 1]
+
+        if previous_token.type != tokenize.DEDENT:
+            # This is not the first token on the line, which means that it can
+            # also be "embedded" else: x if A else B
+            return False
+
+        for token in reversed(self.file_tokens[:start_index - 1]):
+            if token.type != tokenize.NAME:
+                continue
+
+            # Here we rely upon an intuition that in Python else have to be
+            # on the same level (same indentation) as parent statement.
+            if token.start[1] == previous_token.start[1]:
+                return token.string in {'if', 'elif'}
+
+        return False  # pragma: no cover
+
     def _check_implicit_elif(self, token: tokenize.TokenInfo) -> None:
         if token.string != 'else':
             return
 
         index = self.file_tokens.index(token)
+
+        # `else` token can belong also to `for` and `try/except` statement,
+        # which can trigger false positive for that violation.
+        if not self._check_else_belongs_to_if(index):
+            return
+
         # There's a bug in coverage, I am not sure how to make it work.
         for next_token in self.file_tokens[index + 1:]:  # pragma: no cover
             if next_token.exact_type in self._allowed_token_types:


### PR DESCRIPTION
So this implements additional heuristics to prevent `ImplicitElifViolation` triggering on the following cases:

```python
try:
    ...
except ValueError:
    ...
else:
    ...
```

and

```python
for a in b:
    ...
else:
    ...
```

There is one line covered by `pragma: no cover`, as it can only trigger only when running this tool on obviously broken code and crafting a specific test case for this unlikely eventuality proved burdensome.

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Checklist

<!-- Please check everything that applies: -->

- [X] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [X] I have created at least one test case for the changes I have made
- [X] I have updated the documentation for the changes I have made
- [X] I have added my changes to the `CHANGELOG.md`

## Related issues

Closes #835 

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
