### PR TITLE
Add rule about vague import names.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ We used to have incremental versioning before `0.1.0`.
 ### Features
 
 - Forbids using `Literal[None]` in function annotations
+- Forbids use of vague import names (e.g. `from json import loads`)
 
 ### Bugfixes
 

--- a/tests/fixtures/noqa.py
+++ b/tests/fixtures/noqa.py
@@ -565,5 +565,11 @@ unhashable = [] * 2  # noqa: WPS435
 def literal_none_func(arg: Literal[None]):  # noqa: WPS701
     '''Literal[None]'''
 
+
 def literal_none_return_func() -> Literal[None]:  # noqa: WPS701
     '''Literal[None]'''
+
+
+from json import loads  # noqa: WPS347
+from some_module import a  # noqa: WPS347
+from text import from_file  # noqa: WPS347

--- a/tests/test_checker/test_noqa.py
+++ b/tests/test_checker/test_noqa.py
@@ -120,6 +120,7 @@ SHOULD_BE_RAISED = types.MappingProxyType({
     'WPS344': 1,
     'WPS345': 1,
     'WPS346': 1,
+    'WPS347': 3,
 
     'WPS400': 0,
     'WPS401': 0,

--- a/tests/test_visitors/test_ast/test_imports/test_vague_imports.py
+++ b/tests/test_visitors/test_ast/test_imports/test_vague_imports.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+
+from wemake_python_styleguide.violations.consistency import (
+    VagueImportViolation,
+)
+from wemake_python_styleguide.visitors.ast.imports import WrongImportVisitor
+
+import_template = 'from mod import {0}'
+
+blacklisted_method_names = [
+    'dump',
+    'dumps',
+    'load',
+    'loads',
+    'parse',
+    'safe_dump',
+    'safe_dump_all',
+    'load_all',
+    'dump_all',
+    'safe_load_all',
+    'safe_dump_all',
+]
+
+
+@pytest.mark.parametrize(
+    'method_name',
+    blacklisted_method_names + ['a', 'from_something', 'to_something'],
+)
+def test_special_cases_vague_import(
+    assert_errors,
+    parse_ast_tree,
+    method_name,
+    default_options,
+):
+    """Testing that imports with the same aliases are restricted."""
+    tree = parse_ast_tree(import_template.format(method_name))
+
+    visitor = WrongImportVisitor(default_options, tree=tree)
+    visitor.run()
+
+    assert_errors(visitor, [VagueImportViolation])

--- a/tests/test_visitors/test_ast/test_imports/test_vague_imports.py
+++ b/tests/test_visitors/test_ast/test_imports/test_vague_imports.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from wemake_python_styleguide import constants
 from wemake_python_styleguide.violations.consistency import (
     VagueImportViolation,
 )
@@ -9,26 +10,14 @@ from wemake_python_styleguide.visitors.ast.imports import WrongImportVisitor
 
 import_template = 'from mod import {0}'
 
-blacklisted_method_names = [
-    'dump',
-    'dumps',
-    'load',
-    'loads',
-    'parse',
-    'safe_dump',
-    'safe_dump_all',
-    'load_all',
-    'dump_all',
-    'safe_load_all',
-    'safe_dump_all',
-]
+alias_import_template = 'from mod import something as {0}'
 
 
 @pytest.mark.parametrize(
     'method_name',
-    blacklisted_method_names + ['a', 'from_something', 'to_something'],
+    list(constants.VAGUE_IMPORTS_BLACKLIST) + ['a', 'from_thing', 'to_thing'],
 )
-def test_special_cases_vague_import(
+def test_vague_method_name_import(
     assert_errors,
     parse_ast_tree,
     method_name,
@@ -36,6 +25,25 @@ def test_special_cases_vague_import(
 ):
     """Testing that imports with the same aliases are restricted."""
     tree = parse_ast_tree(import_template.format(method_name))
+
+    visitor = WrongImportVisitor(default_options, tree=tree)
+    visitor.run()
+
+    assert_errors(visitor, [VagueImportViolation])
+
+
+@pytest.mark.parametrize(
+    'alias',
+    list(constants.VAGUE_IMPORTS_BLACKLIST) + ['a', 'from_a', 'to_a'],
+)
+def test_vague_alias_import(
+    assert_errors,
+    parse_ast_tree,
+    alias,
+    default_options,
+):
+    """Testing that imports with the same aliases are restricted."""
+    tree = parse_ast_tree(alias_import_template.format(alias))
 
     visitor = WrongImportVisitor(default_options, tree=tree)
     visitor.run()

--- a/wemake_python_styleguide/constants.py
+++ b/wemake_python_styleguide/constants.py
@@ -331,6 +331,8 @@ UNDERSCORED_NUMBER_PATTERN: Final = re.compile(r'.+\D\_\d+(\D|$)')
 
 # List of vague method names that may cause confusion if imported as is:
 VAGUE_IMPORTS_BLACKLIST = frozenset([
+    'read',
+    'write',
     'load',
     'loads',
     'dump',

--- a/wemake_python_styleguide/constants.py
+++ b/wemake_python_styleguide/constants.py
@@ -328,3 +328,18 @@ NON_MAGIC_MODULO: Final = 10
 # Used to specify a pattern which checks variables and modules for underscored
 # numbers in their names:
 UNDERSCORED_NUMBER_PATTERN: Final = re.compile(r'.+\D\_\d+(\D|$)')
+
+# List of vague method names that may cause confusion if imported as is:
+VAGUE_IMPORTS_BLACKLIST = frozenset([
+    'load',
+    'loads',
+    'dump',
+    'dumps',
+    'parse',
+    'safe_load',
+    'safe_dump',
+    'load_all',
+    'dump_all',
+    'safe_load_all',
+    'safe_dump_all',
+])

--- a/wemake_python_styleguide/violations/consistency.py
+++ b/wemake_python_styleguide/violations/consistency.py
@@ -72,6 +72,7 @@ Summary
    ZeroDivisionViolation
    MeaninglessNumberOperationViolation
    OperationSignNegationViolation
+   VagueImportViolation
 
 Consistency checks
 ------------------
@@ -123,6 +124,7 @@ Consistency checks
 .. autoclass:: ZeroDivisionViolation
 .. autoclass:: MeaninglessNumberOperationViolation
 .. autoclass:: OperationSignNegationViolation
+.. autoclass:: VagueImportViolation
 
 """
 
@@ -1748,3 +1750,37 @@ class OperationSignNegationViolation(ASTViolation):
 
     error_template = 'Found wrong operation sign'
     code = 346
+
+
+@final
+class VagueImportViolation(ASTViolation):
+    """
+    Forbids imports that outside of the module may cause confusion.
+
+    Reasoning:
+        When you see datetime.* in the code, you know that it's from datetime.
+        When you see BaseView in a Django project, you know where it is from.
+        When you see loads, it can be anything: yaml, toml, json ...
+
+    Example::
+
+        # Correct:
+        import json
+
+        ...
+
+        json.loads(content)
+
+        # Wrong:
+        from json import loads
+
+        ...
+
+        loads(content)
+
+    .. versionadded:: 0.1.0
+
+    """
+
+    error_template = 'Found vague import that may cause confusion: {0}'
+    code = 347

--- a/wemake_python_styleguide/violations/consistency.py
+++ b/wemake_python_styleguide/violations/consistency.py
@@ -1758,9 +1758,9 @@ class VagueImportViolation(ASTViolation):
     Forbids imports that outside of the module may cause confusion.
 
     Reasoning:
-        When you see datetime.* in the code, you know that it's from datetime.
-        When you see BaseView in a Django project, you know where it is from.
-        When you see loads, it can be anything: yaml, toml, json ...
+        See ``datetime.*`` in code? You know that it's from datetime.
+        See ``BaseView`` in a Django project? You know where it is from.
+        See ``loads``? It can be anything: ``yaml``, ``toml``, ``json`` ...
 
     Example::
 
@@ -1778,7 +1778,7 @@ class VagueImportViolation(ASTViolation):
 
         loads(content)
 
-    .. versionadded:: 0.1.0
+    .. versionadded:: 0.13.0
 
     """
 

--- a/wemake_python_styleguide/visitors/ast/imports.py
+++ b/wemake_python_styleguide/visitors/ast/imports.py
@@ -66,15 +66,18 @@ class _ImportsValidator(object):
                     SameAliasImportViolation(node, text=alias.name),
                 )
 
-            blacklisted = alias.name in constants.VAGUE_IMPORTS_BLACKLIST
-            too_short = len(alias.name) == 1
-            starts_with_from = alias.name.startswith('from_')
-            starts_with_to = alias.name.startswith('to_')
+            for name in (alias.name, alias.asname):
+                if name is None:
+                    continue
 
-            if blacklisted or too_short or starts_with_from or starts_with_to:
-                self._error_callback(
-                    VagueImportViolation(node, text=alias.name),
-                )
+                blacklisted = name in constants.VAGUE_IMPORTS_BLACKLIST
+                with_from = name.startswith('from_')
+                with_to = name.startswith('to_')
+
+                if blacklisted or with_from or with_to or len(name) == 1:
+                    self._error_callback(
+                        VagueImportViolation(node, text=alias.name),
+                    )
 
     def check_protected_import(self, node: AnyImport) -> None:
         import_names = [alias.name for alias in node.names]

--- a/wemake_python_styleguide/visitors/ast/imports.py
+++ b/wemake_python_styleguide/visitors/ast/imports.py
@@ -6,6 +6,7 @@ from typing import Callable
 
 from typing_extensions import final
 
+from wemake_python_styleguide import constants
 from wemake_python_styleguide.constants import FUTURE_IMPORTS_WHITELIST
 from wemake_python_styleguide.logic import imports, nodes
 from wemake_python_styleguide.logic.naming import access
@@ -30,20 +31,6 @@ ErrorCallback = Callable[[BaseViolation], None]  # TODO: alias and move
 @final
 class _ImportsValidator(object):
     """Utility class to separate logic from the visitor."""
-
-    _vague_imports_blacklist = {
-        'load',
-        'loads',
-        'dump',
-        'dumps',
-        'parse',
-        'safe_load',
-        'safe_dump',
-        'load_all',
-        'dump_all',
-        'safe_load_all',
-        'safe_dump_all',
-    }
 
     def __init__(self, error_callback: ErrorCallback) -> None:
         self._error_callback = error_callback
@@ -79,7 +66,7 @@ class _ImportsValidator(object):
                     SameAliasImportViolation(node, text=alias.name),
                 )
 
-            blacklisted = alias.name in self._vague_imports_blacklist
+            blacklisted = alias.name in constants.VAGUE_IMPORTS_BLACKLIST
             too_short = len(alias.name) == 1
             starts_with_from = alias.name.startswith('from_')
             starts_with_to = alias.name.startswith('to_')


### PR DESCRIPTION
Implemented this using the original proposal from #814, opting for the broader scope of the check - all the imported method names are checked against blacklist, not only those relating to `json` or `yaml`.

I feel that this may be a lapse of judgment on my part, so feel free to suggest restricting blacklist on per-module basis.

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Checklist

<!-- Please check everything that applies: -->

- [X] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [X] I have created at least one test case for the changes I have made
- [X] I have updated the documentation for the changes I have made
- [X] I have added my changes to the `CHANGELOG.md`

## Related issues

Closes #814 

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
