### PR TITLE
Fixes for latest flake8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ We used to have incremental versioning before `0.1.0`.
 
 - Fixes ``ImplicitElifViolation`` false positives on a specific edge cases
 - Fixes ``I_CONTROL_CODE setting`` for ``BadMagicModuleFunctionViolation``
+- Fixes compatibility with flake8 3.8.x
 
 
 ## 0.12.5

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -16,3 +16,11 @@ def test_option_help():
         assert len(option.help) > 10
         assert '%default' in option.help
         assert option.help.split(' Defaults to:')[0].endswith('.')
+
+
+def test_option_asdict_no_none():
+    """Ensure that `None` is not returned from `asdict_no_none()`."""
+    opt = config._Option(  # noqa: WPS437
+        '--foo', default=False, action='store_true', type=None, help='',
+    )
+    assert 'type' not in opt.asdict_no_none()

--- a/wemake_python_styleguide/options/config.py
+++ b/wemake_python_styleguide/options/config.py
@@ -115,7 +115,15 @@ You can also show all options that ``flake8`` supports by running:
 
 """
 
-from typing import ClassVar, FrozenSet, Mapping, Optional, Sequence, Union
+from typing import (
+    ClassVar,
+    Dict,
+    FrozenSet,
+    Mapping,
+    Optional,
+    Sequence,
+    Union,
+)
 
 import attr
 from flake8.options.manager import OptionManager
@@ -148,6 +156,10 @@ class _Option(object):
         object.__setattr__(  # noqa: WPS609
             self, 'help', ' '.join((self.help, 'Defaults to: %default')),
         )
+
+    def asdict_no_none(self) -> Dict[str, ConfigValuesTypes]:
+        dct = attr.asdict(self)
+        return {key: opt for key, opt in dct.items() if opt is not None}
 
 
 @final
@@ -317,4 +329,4 @@ class Configuration(object):
     def register_options(self, parser: OptionManager) -> None:
         """Registers options for our plugin."""
         for option in self._options:
-            parser.add_option(**attr.asdict(option))
+            parser.add_option(**option.asdict_no_none())


### PR DESCRIPTION
`action='store_true'` + `type=None` is not valid for argparse

See also https://github.com/sobolevn/flake8-eradicate/pull/79

# I have made things!

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made
- [x] I have added my changes to the `CHANGELOG.md`


<!--
:thinkbread:

writing the dictionary comprehension was wayyyyy too difficult, what the heck am I supposed to call the value if not `v`, `val`, or `value`?
-->
