### PR TITLE
Fix #902

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ We used to have incremental versioning before `0.1.0`.
 - Forbid incorrectly swapped variables
 - Forbids to use `+=` with list arguments
 - Forbids to use redundant subscripts (e.g., `[0:7]` or `[3:None]`)
+- Allow `super()` as a valid overused expression
 
 ### Bugfixes
 

--- a/tests/test_visitors/test_ast/test_complexity/test_overuses/test_overused_expressions.py
+++ b/tests/test_visitors/test_ast/test_complexity/test_overuses/test_overused_expressions.py
@@ -184,9 +184,10 @@ def test_class_expression_use(
     method_context1,
     method_context2,
     method_context3,
+    module_context,
 ])
 @pytest.mark.parametrize('expression', ignored_expressions)
-def test_func_ignored_expressions(
+def test_ignored_expressions(
     assert_errors,
     parse_ast_tree,
     options,
@@ -198,27 +199,6 @@ def test_func_ignored_expressions(
     tree = parse_ast_tree(mode(code.format(expression, expression)))
 
     option_values = options(max_function_expressions=1)
-    visitor = ExpressionOveruseVisitor(option_values, tree=tree)
-    visitor.run()
-
-    assert_errors(visitor, [])
-
-
-@pytest.mark.parametrize('code', [
-    module_context,
-])
-@pytest.mark.parametrize('expression', ignored_expressions)
-def test_module_ignored_expressions(
-    assert_errors,
-    parse_ast_tree,
-    options,
-    expression,
-    code,
-):
-    """Ensures that ignored expressions does not raise violations."""
-    tree = parse_ast_tree(code.format(expression, expression))
-
-    option_values = options(max_module_expressions=1)
     visitor = ExpressionOveruseVisitor(option_values, tree=tree)
     visitor.run()
 

--- a/tests/test_visitors/test_ast/test_complexity/test_overuses/test_overused_expressions.py
+++ b/tests/test_visitors/test_ast/test_complexity/test_overuses/test_overused_expressions.py
@@ -74,7 +74,7 @@ class Context(object):
 
 # Expressions:
 
-expressions = (
+violating_expressions = (
     # Nodes:
     'assert 1',
     'a and b',
@@ -98,6 +98,10 @@ expressions = (
     'x: types.List[Set[int]] = call()',  # call is raising
 )
 
+ignored_expressions = (
+    'super()',
+)
+
 
 @pytest.mark.parametrize('code', [
     function_context1,
@@ -108,7 +112,7 @@ expressions = (
     method_context2,
     method_context3,
 ])
-@pytest.mark.parametrize('expression', expressions)
+@pytest.mark.parametrize('expression', violating_expressions)
 def test_func_expression_overuse(
     assert_errors,
     parse_ast_tree,
@@ -130,7 +134,7 @@ def test_func_expression_overuse(
 @pytest.mark.parametrize('code', [
     module_context,
 ])
-@pytest.mark.parametrize('expression', expressions)
+@pytest.mark.parametrize('expression', violating_expressions)
 def test_module_expression_overuse(
     assert_errors,
     parse_ast_tree,
@@ -151,7 +155,7 @@ def test_module_expression_overuse(
 @pytest.mark.parametrize('code', [
     class_context,
 ])
-@pytest.mark.parametrize('expression', expressions)
+@pytest.mark.parametrize('expression', violating_expressions)
 def test_class_expression_use(
     assert_errors,
     parse_ast_tree,
@@ -166,6 +170,55 @@ def test_class_expression_use(
         max_module_expressions=1,
         max_function_expressions=1,
     )
+    visitor = ExpressionOveruseVisitor(option_values, tree=tree)
+    visitor.run()
+
+    assert_errors(visitor, [])
+
+
+@pytest.mark.parametrize('code', [
+    function_context1,
+    function_context2,
+    function_context3,
+    function_context4,
+    method_context1,
+    method_context2,
+    method_context3,
+])
+@pytest.mark.parametrize('expression', ignored_expressions)
+def test_func_ignored_expressions(
+    assert_errors,
+    parse_ast_tree,
+    options,
+    expression,
+    code,
+    mode,
+):
+    """Ensures that ignored expressions does not raise violations."""
+    tree = parse_ast_tree(mode(code.format(expression, expression)))
+
+    option_values = options(max_function_expressions=1)
+    visitor = ExpressionOveruseVisitor(option_values, tree=tree)
+    visitor.run()
+
+    assert_errors(visitor, [])
+
+
+@pytest.mark.parametrize('code', [
+    module_context,
+])
+@pytest.mark.parametrize('expression', ignored_expressions)
+def test_module_ignored_expressions(
+    assert_errors,
+    parse_ast_tree,
+    options,
+    expression,
+    code,
+):
+    """Ensures that ignored expressions does not raise violations."""
+    tree = parse_ast_tree(code.format(expression, expression))
+
+    option_values = options(max_module_expressions=1)
     visitor = ExpressionOveruseVisitor(option_values, tree=tree)
     visitor.run()
 

--- a/wemake_python_styleguide/visitors/ast/complexity/overuses.py
+++ b/wemake_python_styleguide/visitors/ast/complexity/overuses.py
@@ -191,6 +191,5 @@ def _is_class_context(node: ast.AST) -> bool:
 
 def _is_super_call(node: ast.AST) -> bool:
     if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
-        if node.func.id == 'super':
-            return True
+        return node.func.id == 'super'
     return False

--- a/wemake_python_styleguide/visitors/ast/complexity/overuses.py
+++ b/wemake_python_styleguide/visitors/ast/complexity/overuses.py
@@ -117,6 +117,7 @@ class ExpressionOveruseVisitor(base.BaseNodeVisitor):
             # DSL to be created: like django-orm, attrs, and dataclasses.
             # And these DSLs are built using attributes and calls.
             _is_class_context,
+            _is_super_call,
         ]
         if any(ignore(node) for ignore in ignore_predicates):
             return
@@ -186,3 +187,10 @@ class ExpressionOveruseVisitor(base.BaseNodeVisitor):
 
 def _is_class_context(node: ast.AST) -> bool:
     return isinstance(nodes.get_context(node), ast.ClassDef)
+
+
+def _is_super_call(node: ast.AST) -> bool:
+    if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+        if node.func.id == 'super':
+            return True
+    return False


### PR DESCRIPTION
# I have made things!
Added a special case in the rule forbidding overused expressions (`WPS204`) to ignore `super()` calls.

## Checklist
- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made
- [x] I have added my changes to the `CHANGELOG.md`

## Related issues
- Closes #902 
