### PR TITLE
Fix #821

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ We used to have incremental versioning before `0.1.0`.
 - Fixes compatibility with flake8 `3.8.x`
 - Fixes that `not not True` was not detected as `WPS330`
 - Fixes addition of ``MisrefactoredAssignmentViolation`` check
+- Fixes ``WrongMagicCommentViolation`` not catching certain wrong comments
 
 ### Misc
 

--- a/tests/test_visitors/test_tokenize/test_comments/test_noqa_comment.py
+++ b/tests/test_visitors/test_tokenize/test_comments/test_noqa_comment.py
@@ -38,6 +38,7 @@ def test_correct_comments(
 
 
 @pytest.mark.parametrize('code', [
+    'x = 10_00 # noqa WPS002',
     'x = 10_00  # noqa',
     'x = 10_00  #   noqa   ',
     'x = 10_00 #noqa',

--- a/wemake_python_styleguide/visitors/tokenize/comments.py
+++ b/wemake_python_styleguide/visitors/tokenize/comments.py
@@ -44,7 +44,7 @@ class WrongCommentVisitor(BaseTokenVisitor):
     """Checks comment tokens."""
 
     _no_cover: ClassVar[Pattern] = re.compile(r'^pragma:\s+no\s+cover')
-    _noqa_check: ClassVar[Pattern] = re.compile(r'^noqa:?($|[A-Z\d\,\s]+)')
+    _noqa_check: ClassVar[Pattern] = re.compile(r'^(noqa:?)($|[A-Z\d\,\s]+)')
     _type_check: ClassVar[Pattern] = re.compile(
         r'^type:\s?([\w\d\[\]\'\"\.]+)$',
     )
@@ -77,8 +77,10 @@ class WrongCommentVisitor(BaseTokenVisitor):
             return
 
         self._noqa_count += 1
-        excludes = match.groups()[0].strip()
-        if not excludes:
+        excludes = match.groups()[1].strip()
+        prefix = match.groups()[0].strip()
+
+        if not excludes or prefix[-1] != ':':
             # We cannot pass the actual line here,
             # since it will be ignored due to `# noqa` comment:
             self.add_violation(WrongMagicCommentViolation(text=comment_text))


### PR DESCRIPTION
# I have made things!

I have created a fix for `WrongMagicCommentViolation` not catching ill-formed syntax `noqa WPSXXX`. (Note the lack of `:`).

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [ ] I have updated the documentation for the changes I have made (was not deemed necessary)
- [x] I have added my changes to the `CHANGELOG.md`

## Related issues

- Closes #821 
