### PR TITLE
Issue 933 reference isort settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ We used to have incremental versioning before `0.1.0`.
 - Replace `scripts/tokens.py` with an external tool
 - Improves violation code testing
 - Improves testing of `.. versionchanged` and `previous_codes` properties
+- Reference `isort` settings requirement for compliance with WSP318 in docstring
 
 
 ## 0.12.5

--- a/docs/pages/usage/configuration.rst
+++ b/docs/pages/usage/configuration.rst
@@ -40,7 +40,7 @@ file is available with the core settings for ``flake8``.
 We also use ``flake8-isort`` to style our imports.
 You will need to update your configuration with the following lines:
 Otherwise, your ``isort`` will complain about your imports.
-Our `isort.toml <https://github.com/wemake-services/wemake-python-styleguide/blob/master/styles/flake8.toml>`_
+Our `isort.toml <https://github.com/wemake-services/wemake-python-styleguide/blob/master/styles/isort.toml>`_
 file is available with the core settings for ``isort``.
 
 All recommended settings can be found in our `styleguide.toml <https://github.com/wemake-services/wemake-python-styleguide/blob/master/styles/styleguide.toml>`_.

--- a/wemake_python_styleguide/violations/consistency.py
+++ b/wemake_python_styleguide/violations/consistency.py
@@ -750,6 +750,14 @@ class ParametersIndentationViolation(ASTViolation):
     This rule checks: lists, sets, tuples, dicts, calls,
     functions, methods, and classes.
 
+    This rule is consistent with the "Vertical Hanging Indent" option for
+    ``multi_line_output`` setting of ``isort``. To avoid conflicting rules,
+    you should set ``multi_line_output = 3`` in the ``isort`` settings.
+
+    See also:
+        https://github.com/timothycrosley/isort#multi-line-output-modes
+        https://github.com/wemake-services/wemake-python-styleguide/blob/master/styles/isort.toml
+
     .. versionadded:: 0.6.0
 
     """

--- a/wemake_python_styleguide/violations/consistency.py
+++ b/wemake_python_styleguide/violations/consistency.py
@@ -750,14 +750,6 @@ class ParametersIndentationViolation(ASTViolation):
     This rule checks: lists, sets, tuples, dicts, calls,
     functions, methods, and classes.
 
-    This rule is consistent with the "Vertical Hanging Indent" option for
-    ``multi_line_output`` setting of ``isort``. To avoid conflicting rules,
-    you should set ``multi_line_output = 3`` in the ``isort`` settings.
-
-    See also:
-        https://github.com/timothycrosley/isort#multi-line-output-modes
-        https://github.com/wemake-services/wemake-python-styleguide/blob/master/styles/isort.toml
-
     .. versionadded:: 0.6.0
 
     """
@@ -790,6 +782,14 @@ class ExtraIndentationViolation(TokenizeViolation):
         # Wrong:
         def test():
                     print('test')
+
+    This rule is consistent with the "Vertical Hanging Indent" option for
+    ``multi_line_output`` setting of ``isort``. To avoid conflicting rules,
+    you should set ``multi_line_output = 3`` in the ``isort`` settings.
+
+    See also:
+        https://github.com/timothycrosley/isort#multi-line-output-modes
+        https://github.com/wemake-services/wemake-python-styleguide/blob/master/styles/isort.toml
 
     .. versionadded:: 0.6.0
 


### PR DESCRIPTION
# I have made things!


Added reference to needed `isort` setting for `multi_line_output` to prevent conflicting rules with WSP318. 
Also, fixed a link on the "Configuration" page that was meant to go to `isort.toml` but went to `flake8.toml`.

## Checklist

- [ ] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [ ] ~I have created at least one test case for the changes I have made~ Documentation change only.
- [x] I have updated the documentation for the changes I have made
- [x]  I have added my changes to the `CHANGELOG.md`

## Related issues

Closes #933 

## Feedback 

`flake8` took quite some time to run and ended with a Traceback message but finished with not errors:
```
...
flake8.bugbear            ForkPoolWorker-3 872034 INFO     Optional warning B950 not present in selected warnings: ['E', 'F', 'W', 'C90']. Not firing it at all.
flake8.processor          ForkPoolWorker-3 872040 WARNING  Plugin requested optional parameter "search_current" but this is not an available parameter.
flake8.processor          ForkPoolWorker-2 872156 WARNING  Plugin requested optional parameter "builtins" but this is not an available parameter.
flake8.processor          ForkPoolWorker-3 872194 WARNING  Plugin requested optional parameter "builtins" but this is not an available parameter.
flake8.checker            ForkPoolWorker-2 872521 CRITICAL Plugin F raised an unexpected exception
Traceback (most recent call last):
  File "/Users/tibor/dev/wemake-python-styleguide/venv/lib/python3.6/site-packages/flake8/checker.py", line 435, in run_check
    return plugin["plugin"](**arguments)
  File "/Users/tibor/dev/wemake-python-styleguide/venv/lib/python3.6/site-packages/flake8/plugins/pyflakes.py", line 94, in __init__
    file_tokens=file_tokens,
  File "/Users/tibor/dev/wemake-python-styleguide/venv/lib/python3.6/site-packages/pyflakes/checker.py", line 673, in __init__
    self.runDeferred(self._deferredFunctions)
  File "/Users/tibor/dev/wemake-python-styleguide/venv/lib/python3.6/site-packages/pyflakes/checker.py", line 710, in runDeferred
    handler()
  File "/Users/tibor/dev/wemake-python-styleguide/venv/lib/python3.6/site-packages/pyflakes/checker.py", line 1529, in <lambda>
    self.deferFunction(lambda: self.handleDoctests(node))
  File "/Users/tibor/dev/wemake-python-styleguide/venv/lib/python3.6/site-packages/pyflakes/checker.py", line 1156, in handleDoctests
    self.addBinding(None, Builtin('_'))
  File "/Users/tibor/dev/wemake-python-styleguide/venv/lib/python3.6/site-packages/pyflakes/checker.py", line 878, in addBinding
    parent_stmt = self.getParent(value.source)
  File "/Users/tibor/dev/wemake-python-styleguide/venv/lib/python3.6/site-packages/pyflakes/checker.py", line 816, in getParent
    node = node.parent
AttributeError: 'NoneType' object has no attribute 'parent'
"pyflakes" failed during execution due to "'NoneType' object has no attribute 'parent'"
Run flake8 with greater verbosity to see more details
flake8.main.application   MainProcess 872665 INFO     Finished running
flake8.main.application   MainProcess 872670 INFO     Reporting errors
flake8.main.application   MainProcess 873385 INFO     Found a total of 0 violations and reported 0
```

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
