### PR TITLE
Add separate tests for violations controlled by 'i_control_code' option (#957)

### DIFF
--- a/docs/pages/api/tutorial.rst
+++ b/docs/pages/api/tutorial.rst
@@ -176,3 +176,33 @@ You may also end up using the same logic over and over again.
 In this case we can decouple it and move to ``logics/`` package.
 
 Then it would be easy to reuse something.
+
+
+Writing tests
+-------------
+
+Writing end-to-end tests
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+In end-to-end tests we check that our visitor, violation and business logic
+work correctly together all the way from flake8 config file to its output.
+
+To check all supported violations, we have two modules containing code which
+raises them: ``noqa.py`` and ``noqa_controlled.py``. The first is for all
+possible violations while the second is only for those which may be tweaked
+using ``i_control_code`` option. If violation may be ignored (or istead,
+raised) with ``i_control_code``, the appropriate piece of code should be
+added to both modules.
+
+The next thing is test itself which should reside in
+``tests/test_checker/test_noqa.py`` module. The main test functions are
+written already, so probably the only thing to do is to put the violation
+code into either ``SHOULD_BE_RAISED``, or ``SHOULD_BE_RAISED_NO_CONTROL``
+container, or into both. For example, if the violation is raised with
+``i_control_code=True``, it must be placed into ``SHOULD_BE_RAISED``
+with value ``1`` and into ``SHOULD_BE_RAISED_NO_CONTROL`` with value ``0``.
+By doing this we check that the violation is raised in one situation and
+is not raised in opposite one. If the violation is ignored when
+``i_control_code=True``, swap ``0`` and ``1`` it containers. If the
+violation cannot be tweaked with ``i_control_code`` it should only be
+put into ``SHOULD_BE_RAISED`` container with appropriate value.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,84 +1,13 @@
 # -*- coding: utf-8 -*-
 
-import inspect
 import os
 from collections import namedtuple
-from operator import attrgetter, itemgetter
 
 import pytest
 
 from wemake_python_styleguide.options.config import Configuration
-from wemake_python_styleguide.violations import (
-    annotations,
-    best_practices,
-    complexity,
-    consistency,
-    naming,
-    oop,
-    refactoring,
-    system,
-)
-from wemake_python_styleguide.violations.base import (
-    ASTViolation,
-    BaseViolation,
-    MaybeASTViolation,
-    SimpleViolation,
-    TokenizeViolation,
-)
 
-
-def _is_violation_class(cls) -> bool:
-    base_classes = {
-        ASTViolation,
-        BaseViolation,
-        SimpleViolation,
-        TokenizeViolation,
-        MaybeASTViolation,
-    }
-    if not inspect.isclass(cls):
-        return False
-
-    return issubclass(cls, BaseViolation) and cls not in base_classes
-
-
-def _load_all_violation_classes():
-    modules = [
-        system,
-        naming,
-        complexity,
-        consistency,
-        best_practices,
-        refactoring,
-        oop,
-        annotations,
-    ]
-
-    classes = {}
-    for module in modules:
-        classes_names_list = inspect.getmembers(module, _is_violation_class)
-        only_classes = map(itemgetter(1), classes_names_list)
-        classes.update({
-            module: list(
-                sorted(only_classes, key=attrgetter('code')),
-            ),
-        })
-    return classes
-
-
-@pytest.fixture(scope='session')
-def all_violations():
-    """Loads all violations from the package and creates a flat list."""
-    classes = _load_all_violation_classes()
-    all_errors_container = []
-    for module_classes in classes.values():
-        all_errors_container.extend(module_classes)
-    return all_errors_container
-
-
-@pytest.fixture(scope='session')
-def all_module_violations():
-    """Loads all violations from the package."""
-    return _load_all_violation_classes()
+pytest_plugins = ['violation_fixtures']
 
 
 @pytest.fixture(scope='session')

--- a/tests/fixtures/noqa_controlled.py
+++ b/tests/fixtures/noqa_controlled.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+
+"""
+This file contains all violations which may be tweaked using 
+`i_control_code` or `i_dont_control_code` options.
+
+It is used for some of e2e tests to check that `i_control_code` works.
+"""
+
+import sys as sys  # noqa: WPS113
+
+def __getattr__():  # noqa: WPS413
+    # See:
+    # https://github.com/wemake-services/wemake-python-styleguide/issues/461
+    anti_z444 = 1

--- a/tests/test_checker/test_noqa.py
+++ b/tests/test_checker/test_noqa.py
@@ -228,6 +228,7 @@ SHOULD_BE_RAISED = types.MappingProxyType({
     'WPS702': 1,
 })
 
+# Violations which may be tweaked by `i_control_code` option
 SHOULD_BE_RAISED_NO_CONTROL = types.MappingProxyType({
     'WPS113': 1,
 

--- a/tests/test_checker/test_noqa.py
+++ b/tests/test_checker/test_noqa.py
@@ -228,6 +228,13 @@ SHOULD_BE_RAISED = types.MappingProxyType({
     'WPS702': 1,
 })
 
+SHOULD_BE_RAISED_NO_CONTROL = types.MappingProxyType({
+    'WPS113': 1,
+
+    'WPS412': 0,
+    'WPS413': 0,
+})
+
 
 def _assert_errors_count_in_output(output, errors, all_violations):
     found_errors = Counter(
@@ -269,6 +276,36 @@ def test_noqa_fixture_disabled(absolute_path, all_violations):
 
     _assert_errors_count_in_output(stdout, SHOULD_BE_RAISED, all_violations)
     assert len(SHOULD_BE_RAISED) == len(all_violations)
+
+
+def test_noqa_fixture_disabled_no_control(
+    absolute_path,
+    all_controlled_violations,
+):
+    """End-to-End test to check rules controlled by `i_control_code` option."""
+    process = subprocess.Popen(
+        [
+            'flake8',
+            '--i-dont-control-code',
+            '--disable-noqa',
+            '--isolated',
+            '--select',
+            'WPS',
+            absolute_path('fixtures', 'noqa_controlled.py'),
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+        encoding='utf8',
+    )
+    stdout, _ = process.communicate()
+
+    _assert_errors_count_in_output(
+        stdout,
+        SHOULD_BE_RAISED_NO_CONTROL,
+        all_controlled_violations,
+    )
+    assert len(SHOULD_BE_RAISED_NO_CONTROL) == len(all_controlled_violations)
 
 
 def test_noqa_fixture(absolute_path):

--- a/tests/violation_fixtures.py
+++ b/tests/violation_fixtures.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+
+import inspect
+from operator import attrgetter, itemgetter
+
+import pytest
+
+from wemake_python_styleguide.violations import (
+    annotations,
+    best_practices,
+    complexity,
+    consistency,
+    naming,
+    oop,
+    refactoring,
+    system,
+)
+from wemake_python_styleguide.violations.base import (
+    ASTViolation,
+    BaseViolation,
+    MaybeASTViolation,
+    SimpleViolation,
+    TokenizeViolation,
+)
+
+
+def _is_violation_class(cls) -> bool:
+    base_classes = {
+        ASTViolation,
+        BaseViolation,
+        SimpleViolation,
+        TokenizeViolation,
+        MaybeASTViolation,
+    }
+    if not inspect.isclass(cls):
+        return False
+
+    return issubclass(cls, BaseViolation) and cls not in base_classes
+
+
+def _load_all_violation_classes():
+    modules = [
+        system,
+        naming,
+        complexity,
+        consistency,
+        best_practices,
+        refactoring,
+        oop,
+        annotations,
+    ]
+
+    classes = {}
+    for module in modules:
+        classes_names_list = inspect.getmembers(module, _is_violation_class)
+        only_classes = map(itemgetter(1), classes_names_list)
+        classes.update({
+            module: list(
+                sorted(only_classes, key=attrgetter('code')),
+            ),
+        })
+    return classes
+
+
+@pytest.fixture(scope='session')
+def all_violations():
+    """Loads all violations from the package and creates a flat list."""
+    classes = _load_all_violation_classes()
+    all_errors_container = []
+    for module_classes in classes.values():
+        all_errors_container.extend(module_classes)
+    return all_errors_container
+
+
+@pytest.fixture(scope='session')
+def all_controlled_violations():
+    """Loads all violations which may be tweaked using `i_control_code`."""
+    classes = _load_all_violation_classes()
+    controlled_errors_container = []
+    for module_classes in classes.values():
+        for violation_class in module_classes:
+            if '--i-control-code' in violation_class.__doc__:
+                controlled_errors_container.append(violation_class)
+    return controlled_errors_container
+
+
+@pytest.fixture(scope='session')
+def all_module_violations():
+    """Loads all violations from the package."""
+    return _load_all_violation_classes()


### PR DESCRIPTION
# I have made things!

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made
- [ ] I have added my changes to the `CHANGELOG.md`

## Related issues

- Closes #957 

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
I had to split `tests/conftest.py` into two modules because WPS202 was raised after I've added `all_controlled_violations` fixture in `conftest.py`.