### PR TITLE
Forbidding negated conditions in if expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ We used to have incremental versioning before `0.1.0`.
   `else` in combination with `elif`
 - Fixes `WPS528` false positive on augmented assigns
 - Fixes that `reviewdog` was not able to create more than `30` comments per PR
+- Checks for negated predicates in if expressions in addition to just if statements
 
 
 ## 0.13.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 We follow Semantic Versions since the `0.1.0` release.
 We used to have incremental versioning before `0.1.0`.
 
+## 0.15
+
+### Features
+- Checks for negated predicates in `if` expressions in addition to just `if` statements
 
 ## 0.13.2 WIP
 
@@ -14,7 +18,6 @@ We used to have incremental versioning before `0.1.0`.
   `else` in combination with `elif`
 - Fixes `WPS528` false positive on augmented assigns
 - Fixes that `reviewdog` was not able to create more than `30` comments per PR
-- Checks for negated predicates in if expressions in addition to just if statements
 
 
 ## 0.13.1

--- a/tests/test_visitors/test_ast/test_conditions/test_negated_conditions.py
+++ b/tests/test_visitors/test_ast/test_conditions/test_negated_conditions.py
@@ -35,6 +35,10 @@ else:
     ...
 """
 
+simple_if_exp = """
+... if {0} else ...
+"""
+
 
 @pytest.mark.parametrize('code', [
     'not some',
@@ -87,6 +91,7 @@ def test_negated_complex_elif_conditions(
 @pytest.mark.parametrize('template', [
     complex_conditions,
     complex_elif_else_conditions,
+    simple_if_exp,
 ])
 @pytest.mark.parametrize('code', [
     'not some',
@@ -112,6 +117,7 @@ def test_wrong_negated_complex_conditions(
 @pytest.mark.parametrize('template', [
     complex_conditions,
     complex_elif_else_conditions,
+    simple_if_exp,
 ])
 @pytest.mark.parametrize('code', [
     'some',

--- a/tests/test_visitors/test_ast/test_conditions/test_useless_len_call.py
+++ b/tests/test_visitors/test_ast/test_conditions/test_useless_len_call.py
@@ -5,14 +5,19 @@ import pytest
 from wemake_python_styleguide.violations.refactoring import (
     UselessLenCompareViolation,
 )
-from wemake_python_styleguide.visitors.ast.conditions import IfStatementVisitor
+from wemake_python_styleguide.visitors.ast.conditions import (
+    IfExpressionVisitor,
+    IfStatementVisitor,
+)
 
 correct_call1 = 'print(len([]))'
 correct_call2 = 'assert len([]) == len([])'
 correct_call3 = 'if sum(x): ...'
+correct_call4 = 'a if sum(x) else b'
 
 wrong_len_call1 = 'if len(x): ...'
 wrong_len_call2 = 'a = 1 if len(x) else 0'
+wrong_len_call3 = 'a if len(x) else b'
 
 
 @pytest.mark.parametrize('code', [
@@ -33,6 +38,42 @@ def test_useful_len_call(
     visitor.run()
 
     assert_errors(visitor, [])
+
+
+@pytest.mark.parametrize('code', [
+    correct_call4,
+])
+def test_useful_if_exp_len_call(
+    assert_errors,
+    parse_ast_tree,
+    code,
+    default_options,
+):
+    """Testing that correct code on if exps works."""
+    tree = parse_ast_tree(code)
+
+    visitor = IfExpressionVisitor(default_options, tree=tree)
+    visitor.run()
+
+    assert_errors(visitor, [])
+
+
+@pytest.mark.parametrize('code', [
+    wrong_len_call3,
+])
+def test_useless_if_exp_len_call(
+    assert_errors,
+    parse_ast_tree,
+    code,
+    default_options,
+):
+    """Testing that incorrect code on if exps raises viol."""
+    tree = parse_ast_tree(code)
+
+    visitor = IfExpressionVisitor(default_options, tree=tree)
+    visitor.run()
+
+    assert_errors(visitor, [UselessLenCompareViolation])
 
 
 @pytest.mark.parametrize('code', [

--- a/wemake_python_styleguide/presets/types/tree.py
+++ b/wemake_python_styleguide/presets/types/tree.py
@@ -84,6 +84,7 @@ PRESET: Final = (
     conditions.IfStatementVisitor,
     conditions.BooleanConditionVisitor,
     conditions.ImplicitBoolPatternsVisitor,
+    conditions.IfExpressionVisitor,
 
     # Classes:
     classes.WrongClassVisitor,

--- a/wemake_python_styleguide/transformations/ast/bugfixes.py
+++ b/wemake_python_styleguide/transformations/ast/bugfixes.py
@@ -29,7 +29,7 @@ def fix_async_offset(tree: ast.AST) -> ast.AST:
     )
     for node in ast.walk(tree):
         if isinstance(node, nodes_to_fix):
-            error = 6 if node.col_offset % 4 != 0 else 0
+            error = 0 if node.col_offset % 4 == 0 else 6
             node.col_offset = node.col_offset - error
     return tree
 

--- a/wemake_python_styleguide/violations/refactoring.py
+++ b/wemake_python_styleguide/violations/refactoring.py
@@ -256,7 +256,9 @@ class UselessReturningElseViolation(ASTViolation):
 @final
 class NegatedConditionsViolation(ASTViolation):
     """
-    Forbids to use negated conditions together with ``else`` clause in if statements, and in all if expressions.
+    Forbids to use negated conditions.
+
+    Together with ``else`` clause in if statements, and in all if expressions.
 
     Reasoning:
         It easier to read and name regular conditions. Not negated ones.
@@ -266,15 +268,16 @@ class NegatedConditionsViolation(ASTViolation):
         condition.
 
     Example::
+
         # If Statements
         # Correct:
         if some == 1:
-             ...
+            ...
         else:
-             ...
+            ...
 
         if not some:
-             ...
+            ...
 
         if not some:
             ...
@@ -283,16 +286,13 @@ class NegatedConditionsViolation(ASTViolation):
 
         # Wrong:
         if not some:
-             ...
+            ...
         else:
-             ...
+            ...
 
         # If Expressions
         # Correct:
-        ... if some == 1 else ...
-
-        # Wrong:
-        ... if not some else ...
+        a if some == 1 else b
 
 
     .. versionadded:: 0.8.0

--- a/wemake_python_styleguide/violations/refactoring.py
+++ b/wemake_python_styleguide/violations/refactoring.py
@@ -269,7 +269,6 @@ class NegatedConditionsViolation(ASTViolation):
 
     Example::
 
-        # If Statements
         # Correct:
         if some == 1:
             ...
@@ -284,16 +283,15 @@ class NegatedConditionsViolation(ASTViolation):
         elif other:
             ...
 
+        a if some == 1 else b
+
         # Wrong:
         if not some:
             ...
         else:
             ...
 
-        # If Expressions
-        # Correct:
-        a if some == 1 else b
-
+        a if some != 1 else b
 
     .. versionadded:: 0.8.0
     .. versionchanged:: 0.11.0

--- a/wemake_python_styleguide/violations/refactoring.py
+++ b/wemake_python_styleguide/violations/refactoring.py
@@ -256,7 +256,7 @@ class UselessReturningElseViolation(ASTViolation):
 @final
 class NegatedConditionsViolation(ASTViolation):
     """
-    Forbids to use negated conditions together with ``else`` clause.
+    Forbids to use negated conditions together with ``else`` clause in if statements, and in all if expressions.
 
     Reasoning:
         It easier to read and name regular conditions. Not negated ones.
@@ -266,7 +266,7 @@ class NegatedConditionsViolation(ASTViolation):
         condition.
 
     Example::
-
+        # If Statements
         # Correct:
         if some == 1:
              ...
@@ -286,6 +286,14 @@ class NegatedConditionsViolation(ASTViolation):
              ...
         else:
              ...
+
+        # If Expressions
+        # Correct:
+        ... if some == 1 else ...
+
+        # Wrong:
+        ... if not some else ...
+
 
     .. versionadded:: 0.8.0
     .. versionchanged:: 0.11.0

--- a/wemake_python_styleguide/visitors/ast/conditions.py
+++ b/wemake_python_styleguide/visitors/ast/conditions.py
@@ -181,7 +181,7 @@ class IfStatementVisitor(BaseNodeVisitor):
                     UselessReturningElseViolation(chained_if[0]),
                 )
 
-    def _check_useless_len(self, node: AnyIf) -> None:
+    def _check_useless_len(self, node: ast.If) -> None:
         if isinstance(node.test, ast.Call):
             if given_function_called(node.test, {'len'}):
                 self.add_violation(UselessLenCompareViolation(node))

--- a/wemake_python_styleguide/visitors/ast/conditions.py
+++ b/wemake_python_styleguide/visitors/ast/conditions.py
@@ -101,6 +101,15 @@ class IfStatementVisitor(BaseNodeVisitor):
         """
         self._check_useless_len(node)
         self.generic_visit(node)
+        self._check_if_exp_negated_conditions(node)
+
+    def _check_if_exp_negated_conditions(self, node: ast.IfExp) -> None:
+        if isinstance(node.test, ast.UnaryOp):
+            if isinstance(node.test.op, ast.Not):
+                self.add_violation(NegatedConditionsViolation(node))
+        elif isinstance(node.test, ast.Compare):
+            if any(isinstance(elem, ast.NotEq) for elem in node.test.ops):
+                self.add_violation(NegatedConditionsViolation(node))
 
     def _check_negated_conditions(self, node: ast.If) -> None:
         if not ifs.has_else(node):


### PR DESCRIPTION
Extended ast visitor to check `if` expression conditions for negated
predicates that affect readibility. That is prefer `A if some_pred else
B` over `B if not some_pred else A`. Using the exisiting violation for
alerting the same for `if` statements.

# I have made things!

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made
- [x] I have added my changes to the `CHANGELOG.md`

## Related issues
Closes #1041.
<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
