### PR TITLE
Update docstring TooLongTryBodyViolation()

### DIFF
--- a/wemake_python_styleguide/violations/complexity.py
+++ b/wemake_python_styleguide/violations/complexity.py
@@ -899,6 +899,9 @@ class TooLongTryBodyViolation(ASTViolation):
         This rule is configurable with ``--max-try-body-length``.
         Default:
         :str:`wemake_python_styleguide.options.defaults.MAX_TRY_BODY_LENGTH`
+        
+    See also:
+        https://adamj.eu/tech/2019/10/02/limit-your-try-clauses-in-python/
 
     .. versionadded:: 0.12.0
 

--- a/wemake_python_styleguide/violations/complexity.py
+++ b/wemake_python_styleguide/violations/complexity.py
@@ -899,7 +899,7 @@ class TooLongTryBodyViolation(ASTViolation):
         This rule is configurable with ``--max-try-body-length``.
         Default:
         :str:`wemake_python_styleguide.options.defaults.MAX_TRY_BODY_LENGTH`
-        
+
     See also:
         https://adamj.eu/tech/2019/10/02/limit-your-try-clauses-in-python/
 


### PR DESCRIPTION
# I have made things!
Update docstring 'See also' link for the TooLongTryBodyViolation()

## Checklist
- [ x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [ ] I have created at least one test case for the changes I have made
- [ ] I have updated the documentation for the changes I have made
- [ ] I have added my changes to the `CHANGELOG.md`

## Related issues
- Closes https://github.com/wemake-services/wemake-python-styleguide/issues/1076
