### PR TITLE
improve boolean non-keyword arguments validation

### DIFF
--- a/tests/fixtures/noqa.py
+++ b/tests/fixtures/noqa.py
@@ -347,7 +347,7 @@ try:
 except BaseException:  # noqa: WPS424
     anti_wps428 = 1
 
-call_with_positional_bool(True)  # noqa: WPS425
+call_with_positional_bool(True, keyword=1)  # noqa: WPS425
 
 
 class MyInt(int):  # noqa: WPS600

--- a/tests/test_visitors/test_ast/test_functions/test_boolean_args.py
+++ b/tests/test_visitors/test_ast/test_functions/test_boolean_args.py
@@ -11,6 +11,7 @@ from wemake_python_styleguide.visitors.ast.functions import (
 
 correct_argument = 'some(0, 1, keyword={0}, other={0})'
 wrong_argument = 'some({0}, {0})'
+single_argument = 'some({0})'
 
 
 @pytest.mark.parametrize('argument', [
@@ -83,3 +84,24 @@ def test_wrong_boolean_argument(
         BooleanPositionalArgumentViolation,
         BooleanPositionalArgumentViolation,
     ])
+
+
+@pytest.mark.parametrize('argument', [True, False])
+def test_single_boolean_argument_allowed(
+    assert_errors,
+    parse_ast_tree,
+    argument,
+    default_options,
+):
+    """Test calls with single boolean argument.
+
+    Ensure boolean argument can be passed as positional argument when
+    it is the only call's argument.
+
+    """
+    tree = parse_ast_tree(single_argument.format(argument))
+
+    visitor = WrongFunctionCallVisitor(default_options, tree=tree)
+    visitor.run()
+
+    assert_errors(visitor, [])

--- a/wemake_python_styleguide/violations/best_practices.py
+++ b/wemake_python_styleguide/violations/best_practices.py
@@ -1025,6 +1025,8 @@ class BooleanPositionalArgumentViolation(ASTViolation):
         It is almost impossible to tell, what does this parameter means.
         And you almost always have to look up the implementation to tell
         what is going on.
+        The only exception from this rule is passing booleans as
+        non-keyword argument when it is the only passed argument.
 
     Solution:
         Pass booleans as keywords only.
@@ -1033,10 +1035,11 @@ class BooleanPositionalArgumentViolation(ASTViolation):
     Example::
 
         # Correct:
-        UsersRepository.update(cache=True)
+        UserRepository.update(True)
+        UsersRepository.add(user, cache=True)
 
         # Wrong:
-        UsersRepository.update(True)
+        UsersRepository.add(user, True)
 
     .. versionadded:: 0.6.0
 

--- a/wemake_python_styleguide/visitors/ast/functions.py
+++ b/wemake_python_styleguide/visitors/ast/functions.py
@@ -82,6 +82,9 @@ class WrongFunctionCallVisitor(base.BaseNodeVisitor):
             )
 
     def _check_boolean_arguments(self, node: ast.Call) -> None:
+        # Calls with single boolean argument are allowed
+        if len(node.args) == 1 and not node.keywords:
+            return
         for arg in node.args:
             if isinstance(arg, ast.NameConstant):
                 # We do not check for `None` values here:


### PR DESCRIPTION
# I have made things!

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made
- [ ] I have added my changes to the `CHANGELOG.md`

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->
Closes: #1104 
<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
Allow passing booleans as non-keyword argument when it is the only
one passed argument.

🙏 Please, if you or your company is finding wemake-python-styleguide valuable, help us sustain the project by sponsoring it transparently on https://opencollective.com/wemake-python-styleguide. As a thank you, your profile/company logo will be added to our main README which receives hundreds of unique visitors per day.
