### PR TITLE
use abc stdlib module to mark abstract classes

### DIFF
--- a/tests/test_visitors/test_base.py
+++ b/tests/test_visitors/test_base.py
@@ -2,30 +2,21 @@
 
 from unittest.mock import MagicMock
 
-import pytest
-
 from wemake_python_styleguide import constants
-from wemake_python_styleguide.visitors.base import (
-    BaseFilenameVisitor,
-    BaseVisitor,
-)
+from wemake_python_styleguide.visitors.base import BaseFilenameVisitor
 
 
-def test_visitor_raises_not_implemented(default_options):
-    """Ensures that `BaseChecker` raises `NotImplementedError`."""
-    with pytest.raises(NotImplementedError):
-        BaseVisitor(default_options).run()
-
-
-def test_base_filename_raises_not_implemented(default_options):
-    """Ensures that `BaseFilenameVisitor` raises `NotImplementedError`."""
-    with pytest.raises(NotImplementedError):
-        BaseFilenameVisitor(default_options, filename='some.py').run()
+class _TestingFilenameVisitor(BaseFilenameVisitor):
+    def visit_filename(self):
+        """Overridden to satisfy abstract base class."""
 
 
 def test_base_filename_run_do_not_call_visit(default_options):
     """Ensures that `run()` does not call `visit()` method for stdin."""
-    instance = BaseFilenameVisitor(default_options, filename=constants.STDIN)
+    instance = _TestingFilenameVisitor(
+        default_options,
+        filename=constants.STDIN,
+    )
     instance.visit_filename = MagicMock()
     instance.run()
 

--- a/wemake_python_styleguide/violations/base.py
+++ b/wemake_python_styleguide/violations/base.py
@@ -54,7 +54,7 @@ ErrorNode = Union[
 ]
 
 
-class BaseViolation(abc.ABC):
+class BaseViolation(object, metaclass=abc.ABCMeta):
     """
     Abstract base class for all style violations.
 
@@ -121,7 +121,7 @@ class BaseViolation(abc.ABC):
         return 0, 0
 
 
-class _BaseASTViolation(BaseViolation):
+class _BaseASTViolation(BaseViolation, metaclass=abc.ABCMeta):
     """Used as a based type for all ``ast`` violations."""
 
     _node: Optional[ast.AST]
@@ -133,13 +133,13 @@ class _BaseASTViolation(BaseViolation):
         return line_number, column_offset
 
 
-class ASTViolation(_BaseASTViolation):
+class ASTViolation(_BaseASTViolation, metaclass=abc.ABCMeta):
     """Violation for ``ast`` based style visitors."""
 
     _node: ast.AST
 
 
-class MaybeASTViolation(_BaseASTViolation):
+class MaybeASTViolation(_BaseASTViolation, metaclass=abc.ABCMeta):
     """
     Violation for ``ast`` and modules visitors.
 
@@ -152,7 +152,7 @@ class MaybeASTViolation(_BaseASTViolation):
         super().__init__(node, text=text)
 
 
-class TokenizeViolation(BaseViolation):
+class TokenizeViolation(BaseViolation, metaclass=abc.ABCMeta):
     """Violation for ``tokenize`` based visitors."""
 
     _node: tokenize.TokenInfo
@@ -162,7 +162,7 @@ class TokenizeViolation(BaseViolation):
         return self._node.start
 
 
-class SimpleViolation(BaseViolation):
+class SimpleViolation(BaseViolation, metaclass=abc.ABCMeta):
     """Violation for cases where there's no associated nodes."""
 
     _node: None

--- a/wemake_python_styleguide/violations/base.py
+++ b/wemake_python_styleguide/violations/base.py
@@ -39,6 +39,7 @@ Reference
 
 """
 
+import abc
 import ast
 import tokenize
 from typing import ClassVar, Optional, Set, Tuple, Union
@@ -53,7 +54,7 @@ ErrorNode = Union[
 ]
 
 
-class BaseViolation(object):
+class BaseViolation(abc.ABC):
     """
     Abstract base class for all style violations.
 

--- a/wemake_python_styleguide/visitors/base.py
+++ b/wemake_python_styleguide/visitors/base.py
@@ -75,7 +75,7 @@ from wemake_python_styleguide.types import ConfigurationOptions
 from wemake_python_styleguide.violations.base import BaseViolation
 
 
-class BaseVisitor(abc.ABC):
+class BaseVisitor(object, metaclass=abc.ABCMeta):
     """
     Abstract base class for different types of visitors.
 
@@ -137,7 +137,7 @@ class BaseVisitor(abc.ABC):
         """
 
 
-class BaseNodeVisitor(ast.NodeVisitor, BaseVisitor):
+class BaseNodeVisitor(ast.NodeVisitor, BaseVisitor, metaclass=abc.ABCMeta):
     """
     Allows to store violations while traversing node tree.
 
@@ -179,7 +179,7 @@ class BaseNodeVisitor(ast.NodeVisitor, BaseVisitor):
         self._post_visit()
 
 
-class BaseFilenameVisitor(BaseVisitor):
+class BaseFilenameVisitor(BaseVisitor, metaclass=abc.ABCMeta):
     """
     Abstract base class that allows to visit and check module file names.
 
@@ -211,7 +211,7 @@ class BaseFilenameVisitor(BaseVisitor):
             self._post_visit()
 
 
-class BaseTokenVisitor(BaseVisitor):
+class BaseTokenVisitor(BaseVisitor, metaclass=abc.ABCMeta):
     """
     Allows to check ``tokenize`` sequences.
 

--- a/wemake_python_styleguide/visitors/base.py
+++ b/wemake_python_styleguide/visitors/base.py
@@ -62,6 +62,7 @@ Reference
 
 """
 
+import abc
 import ast
 import tokenize
 from typing import List, Sequence, Type
@@ -74,7 +75,7 @@ from wemake_python_styleguide.types import ConfigurationOptions
 from wemake_python_styleguide.violations.base import BaseViolation
 
 
-class BaseVisitor(object):
+class BaseVisitor(abc.ABC):
     """
     Abstract base class for different types of visitors.
 
@@ -118,15 +119,14 @@ class BaseVisitor(object):
         """Adds violation to the visitor."""
         self.violations.append(violation)
 
+    @abc.abstractmethod
     def run(self) -> None:
         """
-        Abstract method to run a visitor.
+        Runs a visitor.
 
         Each visitor should know what exactly it needs
         to do when it was told to ``run``.
-        This method should be defined in all subclasses.
         """
-        raise NotImplementedError('Should be defined in a subclass')
 
     def _post_visit(self) -> None:
         """
@@ -192,13 +192,9 @@ class BaseFilenameVisitor(BaseVisitor):
 
     stem: str
 
+    @abc.abstractmethod
     def visit_filename(self) -> None:
-        """
-        Abstract method to check module file names.
-
-        This method should be overridden in a subclass.
-        """
-        raise NotImplementedError('Should be defined in a subclass')
+        """Checks module file names."""
 
     @final
     def run(self) -> None:


### PR DESCRIPTION
# I have made things!

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [ ] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made
- [ ] I have added my changes to the `CHANGELOG.md`

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->
Closes #1121 
<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->

🙏 Please, if you or your company is finding wemake-python-styleguide valuable, help us sustain the project by sponsoring it transparently on https://opencollective.com/wemake-python-styleguide. As a thank you, your profile/company logo will be added to our main README which receives hundreds of unique visitors per day.
