### PR TITLE
Add `__call__` to list of methods that should be on top #1125

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Semantic versioning in our case means:
 
 - Extracts new violation - WPS450 from WPS436 #1118
 - Adds domain names options, that are used to create variable names' blacklist #1106
+- Add `__call__` to list of methods that should be on top #1125
 
 ### Bugfixes
 

--- a/tests/test_visitors/test_ast/test_classes/test_method_order.py
+++ b/tests/test_visitors/test_ast/test_classes/test_method_order.py
@@ -17,6 +17,9 @@ class Test(object):
     def __init__(self):
         ...
 
+    def __call__(self):
+        ...
+
     def public(self):
         ...
 
@@ -79,19 +82,25 @@ def test_correct_method_order(
 
 @pytest.mark.parametrize(('first', 'second'), [
     ('__init__', '__new__'),
+    ('__call__', '__init__'),
+    ('__call__', '__new__'),
 
     ('public', '__new__'),
     ('public', '__init__'),
+    ('public', '__call__'),
     ('__magic__', '__new__'),
     ('__magic__', '__init__'),
+    ('__magic__', '__call__'),
 
     ('_protected', '__new__'),
     ('_protected', '__init__'),
+    ('_protected', '__call__'),
     ('_protected', 'public'),
     ('_protected', '__magic__'),
 
     ('__private', '__new__'),
     ('__private', '__init__'),
+    ('__private', '__call__'),
     ('__private', 'public'),
     ('__private', '__magic__'),
     ('__private', '_protected'),

--- a/wemake_python_styleguide/violations/consistency.py
+++ b/wemake_python_styleguide/violations/consistency.py
@@ -1486,6 +1486,7 @@ class WrongMethodOrderViolation(ASTViolation):
 
     - ``__new__``
     - ``__init__``
+    - ``__call__``
     - public and magic methods
     - protected methods
     - private methods (we discourage using them)

--- a/wemake_python_styleguide/visitors/ast/classes.py
+++ b/wemake_python_styleguide/visitors/ast/classes.py
@@ -412,10 +412,10 @@ class ClassMethodOrderVisitor(base.BaseNodeVisitor):
             '__init__': 4,
             '__call__': 3,
         }
-        public_magic_methods_priority = 2
+        public_and_magic_methods_priority = 2
 
         if access.is_protected(first):
             return 1
         if access.is_private(first):
             return 0  # lowest priority
-        return base_methods_order.get(first, public_magic_methods_priority)
+        return base_methods_order.get(first, public_and_magic_methods_priority)

--- a/wemake_python_styleguide/visitors/ast/classes.py
+++ b/wemake_python_styleguide/visitors/ast/classes.py
@@ -407,12 +407,15 @@ class ClassMethodOrderVisitor(base.BaseNodeVisitor):
                 return
 
     def _ideal_order(self, first: str) -> int:
-        if first == '__new__':
-            return 4  # highest priority
-        if first == '__init__':
-            return 3
+        base_methods_order = {
+            '__new__': 5,  # highest priority
+            '__init__': 4,
+            '__call__': 3,
+        }
+        public_magic_methods_priority = 2
+
         if access.is_protected(first):
             return 1
         if access.is_private(first):
             return 0  # lowest priority
-        return 2  # public and magic methods
+        return base_methods_order.get(first, public_magic_methods_priority)


### PR DESCRIPTION
# I have made things!

## Checklist

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made
- [x] I have added my changes to the `CHANGELOG.md`

## Related issues
* Too many returns for the` _ideal_order` method (classes.py), had to refactor a bit...
