### PR TITLE
Fix typo: "isisntance" -> "isinstance"

### DIFF
--- a/wemake_python_styleguide/violations/refactoring.py
+++ b/wemake_python_styleguide/violations/refactoring.py
@@ -575,7 +575,7 @@ class WrongIsinstanceWithTupleViolation(ASTViolation):
 
         # Correct:
         isinstance(some, (int, float))
-        isisntance(some, int)
+        isinstance(some, int)
 
         # Wrong:
         isinstance(some, (int, ))


### PR DESCRIPTION
A typo error in doc string.