### PR TITLE
lru_cache variable_names_blacklist_from() logic function

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -51,6 +51,8 @@ per-file-ignores =
   wemake_python_styleguide/options/defaults.py: WPS432
   # Checker has a lot of imports:
   wemake_python_styleguide/checker.py: WPS201
+  # mypy type hinting - multiple statements per line and ``Ellipsis`` usage
+  wemake_python_styleguide/types.py: D102, E704, WPS220, WPS428
   # There are multiple fixtures, `assert`s, and subprocesses in tests:
   tests/*.py: S101, S105, S404, S603, S607, WPS211, WPS226
   # Docs can have the configuration they need:

--- a/tests/test_visitors/test_ast/test_naming/test_naming_rules/test_correct.py
+++ b/tests/test_visitors/test_ast/test_naming/test_naming_rules/test_correct.py
@@ -45,7 +45,7 @@ def test_name_in_allowed_domain_names_option(
     tree = parse_ast_tree(mode(naming_template.format(allowed_name)))
 
     visitor = WrongNameVisitor(
-        options(allowed_domain_names=[allowed_name]),
+        options(allowed_domain_names=(allowed_name,)),
         tree=tree,
     )
     visitor.run()

--- a/tests/test_visitors/test_ast/test_naming/test_naming_rules/test_wrong_names.py
+++ b/tests/test_visitors/test_ast/test_naming/test_naming_rules/test_wrong_names.py
@@ -49,7 +49,7 @@ def test_name_in_forbidden_domain_names_option(
     tree = parse_ast_tree(mode(naming_template.format(forbidden_name)))
 
     visitor = WrongNameVisitor(
-        options(forbidden_domain_names=[forbidden_name]),
+        options(forbidden_domain_names=(forbidden_name,)),
         tree=tree,
     )
     visitor.run()

--- a/wemake_python_styleguide/logic/naming/blacklists.py
+++ b/wemake_python_styleguide/logic/naming/blacklists.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
 
+from functools import lru_cache
 from typing import FrozenSet
 
 from wemake_python_styleguide.constants import VARIABLE_NAMES_BLACKLIST
 from wemake_python_styleguide.types import ConfigurationOptions
 
 
+@lru_cache()
 def variable_names_blacklist_from(
     options: ConfigurationOptions,
 ) -> FrozenSet[str]:

--- a/wemake_python_styleguide/options/validation.py
+++ b/wemake_python_styleguide/options/validation.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from typing import List, Optional
+from typing import Optional, Tuple
 
 import attr
 from typing_extensions import final
@@ -26,8 +26,8 @@ def _min_max(
 
 
 def validate_domain_names_options(
-    allowed_domain_names: List[str],
-    forbidden_domain_names: List[str],
+    allowed_domain_names: Tuple[str, ...],
+    forbidden_domain_names: Tuple[str, ...],
 ) -> None:
     """Validator to check that allowed and forbidden names doesn't intersect.
 
@@ -64,9 +64,9 @@ class _ValidatedOptions(object):
     max_noqa_comments: int = attr.ib(
         validator=[_min_max(min=1, max=defaults.MAX_NOQA_COMMENTS)],
     )
-    nested_classes_whitelist: List[str]
-    allowed_domain_names: List[str]
-    forbidden_domain_names: List[str]
+    nested_classes_whitelist: Tuple[str, ...] = attr.ib(converter=tuple)
+    allowed_domain_names: Tuple[str, ...] = attr.ib(converter=tuple)
+    forbidden_domain_names: Tuple[str, ...] = attr.ib(converter=tuple)
 
     # Complexity:
     max_arguments: int = attr.ib(validator=[_min_max(min=1)])

--- a/wemake_python_styleguide/options/validation.py
+++ b/wemake_python_styleguide/options/validation.py
@@ -49,7 +49,7 @@ def validate_domain_names_options(
 
 
 @final
-@attr.dataclass(slots=True)
+@attr.dataclass(slots=True, frozen=True)
 class _ValidatedOptions(object):
     """
     Here we write all the required structured validation for the options.

--- a/wemake_python_styleguide/types.py
+++ b/wemake_python_styleguide/types.py
@@ -38,7 +38,7 @@ Reference
 """
 
 import ast
-from typing import List, Tuple, Type, Union
+from typing import Tuple, Type, Union
 
 from typing_extensions import Protocol, final
 
@@ -83,7 +83,7 @@ AnyAccess = Union[
 ]
 
 
-@final
+@final  # noqa: WPS214
 class ConfigurationOptions(Protocol):
     """
     Provides structure for the options we use in our checker and visitors.
@@ -98,35 +98,93 @@ class ConfigurationOptions(Protocol):
     """
 
     # General:
-    min_name_length: int
-    i_control_code: bool
-    max_name_length: int
-    max_noqa_comments: int
-    nested_classes_whitelist: List[str]
-    allowed_domain_names: List[str]
-    forbidden_domain_names: List[str]
+    @property
+    def min_name_length(self) -> int: ...
+
+    @property
+    def i_control_code(self) -> bool: ...
+
+    @property
+    def max_name_length(self) -> int: ...
+
+    @property
+    def max_noqa_comments(self) -> int: ...
+
+    @property
+    def nested_classes_whitelist(self) -> Tuple[str, ...]: ...
+
+    @property
+    def allowed_domain_names(self) -> Tuple[str, ...]: ...
+
+    @property
+    def forbidden_domain_names(self) -> Tuple[str, ...]: ...
 
     # Complexity:
-    max_arguments: int
-    max_local_variables: int
-    max_returns: int
-    max_expressions: int
-    max_module_members: int
-    max_methods: int
-    max_line_complexity: int
-    max_jones_score: int
-    max_imports: int
-    max_imported_names: int
-    max_base_classes: int
-    max_decorators: int
-    max_string_usages: int
-    max_awaits: int
-    max_try_body_length: int
-    max_module_expressions: int
-    max_function_expressions: int
-    max_asserts: int
-    max_access_level: int
-    max_attributes: int
-    max_cognitive_score: int
-    max_cognitive_average: int
-    max_call_level: int
+    @property
+    def max_arguments(self) -> int: ...
+
+    @property
+    def max_local_variables(self) -> int: ...
+
+    @property
+    def max_returns(self) -> int: ...
+
+    @property
+    def max_expressions(self) -> int: ...
+
+    @property
+    def max_module_members(self) -> int: ...
+
+    @property
+    def max_methods(self) -> int: ...
+
+    @property
+    def max_line_complexity(self) -> int: ...
+
+    @property
+    def max_jones_score(self) -> int: ...
+
+    @property
+    def max_imports(self) -> int: ...
+
+    @property
+    def max_imported_names(self) -> int: ...
+
+    @property
+    def max_base_classes(self) -> int: ...
+
+    @property
+    def max_decorators(self) -> int: ...
+
+    @property
+    def max_string_usages(self) -> int: ...
+
+    @property
+    def max_awaits(self) -> int: ...
+
+    @property
+    def max_try_body_length(self) -> int: ...
+
+    @property
+    def max_module_expressions(self) -> int: ...
+
+    @property
+    def max_function_expressions(self) -> int: ...
+
+    @property
+    def max_asserts(self) -> int: ...
+
+    @property
+    def max_access_level(self) -> int: ...
+
+    @property
+    def max_attributes(self) -> int: ...
+
+    @property
+    def max_cognitive_score(self) -> int: ...
+
+    @property
+    def max_cognitive_average(self) -> int: ...
+
+    @property
+    def max_call_level(self) -> int: ...


### PR DESCRIPTION
# I have made things!

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made
- [ ] I have added my changes to the `CHANGELOG.md`

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->
Closes #1130 
<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
To make using [`lru_cache` decorator](https://docs.python.org/3/library/functools.html#functools.lru_cache) on `variable_names_blacklist_from()` possible - `_ValidatedOptions` has to be hashable, which implies its immutability (I've used [`attrs` `frozen`](https://www.attrs.org/en/stable/examples.html#immutability) argument) that btw is really expected in this case, because configuration options shouldn't be changed after they are loaded and validated.
This change also required updating `ConfigurationOptions` protocol - all attributes need to be unsettable, because  `_ValidatedOptions` is now frozen/immutable.

If you dislike current solution (personally I don't like new definition of `ConfigurationOptions` protocol, however according to few issues I have found on `mypy` repo, it's the only way to define unsettable protocol's attributes) we can change current implementation of `variable_names_blacklist_from()` a bit, so it will accept `allowed_domain_names` and `forbidden_domain_names` immutable arguments instead of `_ValidatedOptions`, however then `_ValidatedOptions` will be defined as mutable.

___

🙏 Please, if you or your company is finding wemake-python-styleguide valuable, help us sustain the project by sponsoring it transparently on https://opencollective.com/wemake-python-styleguide. As a thank you, your profile/company logo will be added to our main README which receives hundreds of unique visitors per day.
