### PR TITLE
Issue #1186 Handle exception on string annotation complexity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Semantic versioning in our case means:
 - Fixes that annotation complexity was not reported for `async` functions
 - Fixes that annotation complexity was not reported for lists
 - Fixes that annotation complexity was not reported for `*` and `/` args
+- Fixes that annotation complexity fails on string expressions
 - Fixes bug when `TooManyPublicAttributesViolation`
   was counting duplicate fields
 - Fixes negated conditions `WPS504` was not reported for `if` expressions

--- a/tests/test_visitors/test_ast/test_complexity/test_annotation_complexity/test_annotation_complexity_nesting.py
+++ b/tests/test_visitors/test_ast/test_complexity/test_annotation_complexity/test_annotation_complexity_nesting.py
@@ -68,6 +68,7 @@ class Test(object):
     'Dict[int, str]',
     'Callable[[str, int], int]',
     'List[List[int]]',
+    '"String Annontation"',
 ])
 def test_correct_annotations(
     assert_errors,

--- a/wemake_python_styleguide/logic/complexity/annotations.py
+++ b/wemake_python_styleguide/logic/complexity/annotations.py
@@ -24,9 +24,12 @@ def get_annotation_compexity(annotation_node: _Annotation) -> int:
     we additionally parse them to ``ast`` nodes.
     """
     if isinstance(annotation_node, ast.Str):
-        annotation_node = ast.parse(  # type: ignore
-            annotation_node.s,
-        ).body[0].value
+        try:
+            annotation_node = ast.parse(  # type: ignore
+                annotation_node.s,
+            ).body[0].value
+        except SyntaxError:
+            return 1
 
     if isinstance(annotation_node, ast.Subscript):
         return 1 + get_annotation_compexity(


### PR DESCRIPTION
# I have made things!
AST can't parse string expressions in annotations, so we ignore this case silently.

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [ ] I have updated the documentation for the changes I have made
- [x] I have added my changes to the `CHANGELOG.md`

## Related issues
Closes #1186 

🙏 Please, if you or your company is finding wemake-python-styleguide valuable, help us sustain the project by sponsoring it transparently on https://opencollective.com/wemake-python-styleguide. As a thank you, your profile/company logo will be added to our main README which receives hundreds of unique visitors per day.
