### PR TITLE
'NamedExpr' in 'FalsyConstantCompareViolation', Closes #1201

### DIFF
--- a/tests/test_visitors/test_ast/test_compares/test_constant_compares/test_falsy_constant.py
+++ b/tests/test_visitors/test_ast/test_compares/test_constant_compares/test_falsy_constant.py
@@ -1,5 +1,6 @@
 import pytest
 
+from wemake_python_styleguide.compat.constants import PY38
 from wemake_python_styleguide.violations.refactoring import (
     FalsyConstantCompareViolation,
     WrongIsCompareViolation,
@@ -8,13 +9,26 @@ from wemake_python_styleguide.visitors.ast.compares import (
     WrongConstantCompareVisitor,
 )
 
-wrong_comparators = (
+wrong_comparators = [
     ('some', '[]'),
     ('some', '{}'),  # noqa: P103
     ('some', '()'),
     ('[]', 'some'),
     ('{}', 'some'),  # noqa: P103
     ('()', 'some'),
+]
+
+if PY38:
+    wrong_comparators.extend([
+        ('some', '(x := [])'),
+        ('(x := [])', 'some'),
+    ])
+
+correct_walrus = pytest.param(
+    ['(x := [1, 2])', 'some'],
+    marks=pytest.mark.skipif(
+        not PY38, reason='walrus appeared in 3.8',
+    ),
 )
 
 
@@ -92,8 +106,8 @@ def test_falsy_constant_not_eq(
     ('some', 'other.attr'),
     ('some', 'other.method()'),
     ('some', 'other[0]'),
-
     ('None', 'some'),
+    correct_walrus,
 ])
 def test_correct_constant_compare(
     assert_errors,

--- a/wemake_python_styleguide/visitors/ast/compares.py
+++ b/wemake_python_styleguide/visitors/ast/compares.py
@@ -169,13 +169,13 @@ class WrongConstantCompareVisitor(BaseNodeVisitor):
     def _check_constant(self, op: ast.cmpop, comparator: ast.expr) -> None:
         if not isinstance(op, (ast.Eq, ast.NotEq, ast.Is, ast.IsNot)):
             return
-
-        if not isinstance(comparator, (ast.List, ast.Dict, ast.Tuple)):
+        real = get_assigned_expr(comparator)
+        if not isinstance(real, (ast.List, ast.Dict, ast.Tuple)):
             return
 
-        length = len(comparator.keys) if isinstance(
-            comparator, ast.Dict,
-        ) else len(comparator.elts)
+        length = len(real.keys) if isinstance(
+            real, ast.Dict,
+        ) else len(real.elts)
 
         if not length:
             self.add_violation(FalsyConstantCompareViolation(comparator))


### PR DESCRIPTION
# I have made things!

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Checklist

-

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [ ] I have updated the documentation for the changes I have made
- [ ] I have added my changes to the `CHANGELOG.md`

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->
Closes #1201 
<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->

🙏 Please, if you or your company is finding wemake-python-styleguide valuable, help us sustain the project by sponsoring it transparently on https://opencollective.com/wemake-python-styleguide. As a thank you, your profile/company logo will be added to our main README which receives hundreds of unique visitors per day.
