### PR TITLE
introduce violation WPS358

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Semantic versioning in our case means:
 - Minor releases do bring new features and configuration options. New violations can be added. Code that passes `x.0.y` might not pass on `x.1.y` release.
 - Major releases inidicate significant milestones or serious breaking changes.
 
+## 0.15.0 WIP
+
+### Features
+
+- Forbids to unpack iterable objects to lists #1259
+
 
 ## 0.16.0
 

--- a/tests/fixtures/noqa/noqa.py
+++ b/tests/fixtures/noqa/noqa.py
@@ -707,6 +707,7 @@ extra_new_line = [  # noqa: WPS355
     'wrong',
 ]
 *numbers, = [4, 7]  # noqa: WPS356
+[first_number, second_number] = [4, 7]  # noqa: WPS359
 
 for element in range(10):
     try:  # noqa: WPS452

--- a/tests/test_checker/test_noqa.py
+++ b/tests/test_checker/test_noqa.py
@@ -167,6 +167,7 @@ SHOULD_BE_RAISED = types.MappingProxyType({
     'WPS356': 1,
     'WPS357': 0,  # logically unacceptable.
     'WPS358': 1,
+    'WPS359': 1,
 
     'WPS400': 0,  # defined in ignored violations.
     'WPS401': 0,  # logically unacceptable.

--- a/tests/test_visitors/test_ast/test_builtins/test_assign/test_unpacking_rules.py
+++ b/tests/test_visitors/test_ast/test_builtins/test_assign/test_unpacking_rules.py
@@ -3,9 +3,6 @@ import pytest
 from wemake_python_styleguide.violations.best_practices import (
     WrongUnpackingViolation,
 )
-from wemake_python_styleguide.violations.consistency import (
-    IterableUnpackingToListViolation,
-)
 from wemake_python_styleguide.visitors.ast.builtins import (
     WrongAssignmentVisitor,
 )
@@ -15,26 +12,8 @@ single_assignment = '{0} = 1'
 tuple_assignment1 = 'first, {0} = (1, 2)'
 tuple_assignment2 = '{0}, second = (1, 2)'
 
-list_assignment = '[first, second] = (1, 2)'
-
-nested_list_assignment0 = '[first, second], third = ((1, 2), 3)'
-nested_list_assignment1 = 'first, [second, third] = (1, (2, 3))'
-nested_list_assignment2 = 'first, (second, [third, fourth]) = (1, (2, (3, 4)))'
-
-multiple_level_nested_list_assignment = (
-    'first, [second, [third, fourth]] = (1, (2, (3, 4)))'
-)
-
 spread_assignment1 = '{0}, *second = [1, 2, 3]'
 spread_assignment2 = 'first, *{0} = [1, 2, 3]'
-
-spread_assignment_in_list = '[first, *rest] = [1, 2, 3]'
-
-nested_spread_assignment_in_list = 'first, [second, *rest] = [1, (2, 3, 4)]'
-
-multiple_level_nested_spread_assign_in_list = (
-    'first, [second, [*rest, last]] = (1, (2, (3, 4, 5)))'
-)
 
 for_assignment = """
 def wrapper():
@@ -184,72 +163,3 @@ def test_multiple_assignments(
     visitor.run()
 
     assert_errors(visitor, [WrongUnpackingViolation])
-
-
-@pytest.mark.parametrize('code', [
-    list_assignment,
-    spread_assignment_in_list,
-])
-def test_unpacking_to_list(
-    assert_errors,
-    parse_ast_tree,
-    code,
-    default_options,
-):
-    """Ensure that unpacking iterable to list is restricted."""
-    tree = parse_ast_tree(code)
-
-    visitor = WrongAssignmentVisitor(default_options, tree=tree)
-    visitor.run()
-
-    assert_errors(visitor, [IterableUnpackingToListViolation])
-
-
-@pytest.mark.parametrize('code', [
-    nested_list_assignment0,
-    nested_list_assignment1,
-    nested_list_assignment2,
-    nested_spread_assignment_in_list,
-])
-def test_unpacking_to_nested_list(
-    assert_errors,
-    parse_ast_tree,
-    code,
-    default_options,
-):
-    """Ensure that unpacking iterable to nested list is restricted."""
-    tree = parse_ast_tree(code)
-
-    visitor = WrongAssignmentVisitor(default_options, tree=tree)
-    visitor.run()
-
-    assert_errors(
-        visitor,
-        [IterableUnpackingToListViolation, WrongUnpackingViolation],
-    )
-
-
-@pytest.mark.parametrize('code', [
-    multiple_level_nested_list_assignment,
-    multiple_level_nested_spread_assign_in_list,
-])
-def test_unpacking_to_multiple_level_nested_list(
-    assert_errors,
-    parse_ast_tree,
-    code,
-    default_options,
-):
-    """Test unpacking iterable to multiple levels nested list."""
-    tree = parse_ast_tree(code)
-
-    visitor = WrongAssignmentVisitor(default_options, tree=tree)
-    visitor.run()
-
-    assert_errors(
-        visitor,
-        [
-            IterableUnpackingToListViolation,
-            IterableUnpackingToListViolation,
-            WrongUnpackingViolation,
-        ],
-    )

--- a/tests/test_visitors/test_ast/test_builtins/test_assign/test_unpacking_to_list.py
+++ b/tests/test_visitors/test_ast/test_builtins/test_assign/test_unpacking_to_list.py
@@ -1,0 +1,163 @@
+import pytest
+
+from wemake_python_styleguide.violations.best_practices import (
+    MultipleAssignmentsViolation,
+    WrongUnpackingViolation,
+)
+from wemake_python_styleguide.violations.consistency import (
+    IterableUnpackingToListViolation,
+)
+from wemake_python_styleguide.visitors.ast.builtins import (
+    WrongAssignmentVisitor,
+)
+
+list_target = '[first, second]'
+nested_list_target0 = '([first, second], third)'
+nested_list_tatget1 = '(first, [second, third])'
+nested_list_target2 = '(first, (second, [third, fourth]))'
+multiple_level_nested_list_target = '(first, (second, [third, fourth]))'
+
+spread_assignment_in_list_target = '[first, *rest]'
+nested_spread_assignment_in_list = '(first, [second, *rest])'
+multiple_level_nested_spread_assign_in_list = (
+    '(first, (second, [*rest, last]))'
+)
+
+regular_assignment = '{0} = some()'
+
+regular_multiple_assignment = 'result = {0} = some_other_result = some()'
+
+for_assignment = """
+def wrapper():
+    for {0} in iterable:
+        ...
+"""
+
+list_comprehension = """
+def wrapper():
+    comp = [1 for {0} in some()]
+"""
+
+generator_expression = """
+def wrapper():
+    comp = (1 for {0} in some())
+"""
+
+set_comprehension = """
+def wrapper():
+    comp = {{1 for {0} in some()}}
+"""
+
+dict_comprehension = """
+def wrapper():
+    comp = {{'1': 1 for {0} in some()}}
+"""
+
+with_assignment = """
+def wrapper():
+    with some() as {0}:
+        ...
+"""
+
+with_multiple_assignments = """
+def wrapper():
+    with some() as s, some_other() as {0} :
+        ...
+"""
+
+
+@pytest.mark.parametrize('assignment', [
+    list_target,
+    spread_assignment_in_list_target,
+])
+@pytest.mark.parametrize('code', [
+    regular_assignment,
+    for_assignment,
+    list_comprehension,
+    generator_expression,
+    set_comprehension,
+    dict_comprehension,
+    with_assignment,
+    with_multiple_assignments,
+])
+def test_unpacking_to_list(
+    assert_errors,
+    parse_ast_tree,
+    default_options,
+    code,
+    assignment,
+):
+    """Ensure that unpacking iterable to list is restricted."""
+    tree = parse_ast_tree(code.format(assignment))
+
+    visitor = WrongAssignmentVisitor(default_options, tree=tree)
+    visitor.run()
+
+    assert_errors(visitor, [IterableUnpackingToListViolation])
+
+
+@pytest.mark.parametrize('assignment', [
+    nested_list_target0,
+    nested_list_tatget1,
+    nested_list_target2,
+    multiple_level_nested_list_target,
+    nested_spread_assignment_in_list,
+    multiple_level_nested_spread_assign_in_list,
+])
+@pytest.mark.parametrize('code', [
+    regular_assignment,
+    for_assignment,
+    list_comprehension,
+    generator_expression,
+    set_comprehension,
+    dict_comprehension,
+    with_assignment,
+    with_multiple_assignments,
+])
+def test_unpacking_to_nested_list(
+    assert_errors,
+    parse_ast_tree,
+    default_options,
+    code,
+    assignment,
+):
+    """Ensure that unpacking iterable to nested list is restricted."""
+    tree = parse_ast_tree(code.format(assignment))
+
+    visitor = WrongAssignmentVisitor(default_options, tree=tree)
+    visitor.run()
+
+    assert_errors(
+        visitor,
+        [IterableUnpackingToListViolation, WrongUnpackingViolation],
+    )
+
+
+@pytest.mark.parametrize('assignment', [
+    list_target,
+    nested_list_target0,
+    nested_list_tatget1,
+    nested_list_target2,
+    multiple_level_nested_list_target,
+    spread_assignment_in_list_target,
+    nested_spread_assignment_in_list,
+    multiple_level_nested_spread_assign_in_list,
+])
+@pytest.mark.parametrize('code', [regular_multiple_assignment])
+def test_unpacking_to_list_in_middle_target(
+    assert_errors,
+    parse_ast_tree,
+    default_options,
+    code,
+    assignment,
+):
+    """Ensure that unpacking iterable to list in middle target is restricted."""
+    tree = parse_ast_tree(code.format(assignment))
+
+    visitor = WrongAssignmentVisitor(default_options, tree=tree)
+    visitor.run()
+
+    assert_errors(
+        visitor,
+        [MultipleAssignmentsViolation, IterableUnpackingToListViolation],
+    )

--- a/tests/test_visitors/test_ast/test_builtins/test_assign/test_unpacking_to_list.py
+++ b/tests/test_visitors/test_ast/test_builtins/test_assign/test_unpacking_to_list.py
@@ -5,7 +5,7 @@ from wemake_python_styleguide.violations.best_practices import (
     WrongUnpackingViolation,
 )
 from wemake_python_styleguide.violations.consistency import (
-    IterableUnpackingToListViolation,
+    UnpackingIterableToListViolation,
 )
 from wemake_python_styleguide.visitors.ast.builtins import (
     WrongAssignmentVisitor,
@@ -93,7 +93,7 @@ def test_unpacking_to_list(
     visitor = WrongAssignmentVisitor(default_options, tree=tree)
     visitor.run()
 
-    assert_errors(visitor, [IterableUnpackingToListViolation])
+    assert_errors(visitor, [UnpackingIterableToListViolation])
 
 
 @pytest.mark.parametrize('assignment', [
@@ -129,7 +129,7 @@ def test_unpacking_to_nested_list(
 
     assert_errors(
         visitor,
-        [IterableUnpackingToListViolation, WrongUnpackingViolation],
+        [UnpackingIterableToListViolation, WrongUnpackingViolation],
     )
 
 
@@ -159,5 +159,5 @@ def test_unpacking_to_list_in_middle_target(
 
     assert_errors(
         visitor,
-        [MultipleAssignmentsViolation, IterableUnpackingToListViolation],
+        [MultipleAssignmentsViolation, UnpackingIterableToListViolation],
     )

--- a/wemake_python_styleguide/violations/consistency.py
+++ b/wemake_python_styleguide/violations/consistency.py
@@ -82,7 +82,7 @@ Summary
    IterableUnpackingViolation
    LineCompriseCarriageReturnViolation
    FloatZeroViolation
-   IterableUnpackingToListViolation
+   UnpackingIterableToListViolation
 
 Consistency checks
 ------------------
@@ -146,7 +146,7 @@ Consistency checks
 .. autoclass:: IterableUnpackingViolation
 .. autoclass:: LineCompriseCarriageReturnViolation
 .. autoclass:: FloatZeroViolation
-.. autoclass:: IterableUnpackingToListViolation
+.. autoclass:: UnpackingIterableToListViolation
 
 """
 
@@ -2217,7 +2217,6 @@ class UnpackingIterableToListViolation(ASTViolation):
         # Correct:
         first, second = (7, 4)
         first, *iterable = other_iterable
-
 
         # Wrong:
         [first, second] = (7, 4)

--- a/wemake_python_styleguide/violations/consistency.py
+++ b/wemake_python_styleguide/violations/consistency.py
@@ -82,6 +82,7 @@ Summary
    IterableUnpackingViolation
    LineCompriseCarriageReturnViolation
    FloatZeroViolation
+   IterableUnpackingToListViolation
 
 Consistency checks
 ------------------
@@ -145,6 +146,7 @@ Consistency checks
 .. autoclass:: IterableUnpackingViolation
 .. autoclass:: LineCompriseCarriageReturnViolation
 .. autoclass:: FloatZeroViolation
+.. autoclass:: IterableUnpackingToListViolation
 
 """
 
@@ -2197,3 +2199,33 @@ class FloatZeroViolation(TokenizeViolation):
 
     code = 358
     error_template = 'Found a float zero (0.0)'
+
+
+@final
+class UnpackingIterableToListViolation(ASTViolation):
+    """
+    Forbids to unpack iterable objects to lists.
+
+    Reasoning:
+        We do this for consistency.
+
+    Solution:
+        Do not unpack iterables to lists, use tuples for that.
+
+    Example::
+
+        # Correct:
+        first, second = (7, 4)
+        first, *iterable = other_iterable
+
+
+        # Wrong:
+        [first, second] = (7, 4)
+        [first, *iterable] = other_iterable
+
+    .. versionadded:: 0.15.0
+
+    """
+
+    error_template = 'Found an iterable unpacking to list'
+    code = 359

--- a/wemake_python_styleguide/visitors/ast/builtins.py
+++ b/wemake_python_styleguide/visitors/ast/builtins.py
@@ -208,7 +208,7 @@ class WrongAssignmentVisitor(base.BaseNodeVisitor):
         Checks assignments inside context managers to be correct.
 
         Raises:
-            IterableUnpackingToListViolation
+            UnpackingIterableToListViolation
             WrongUnpackingViolation
 
         """
@@ -225,7 +225,7 @@ class WrongAssignmentVisitor(base.BaseNodeVisitor):
         Checks comprehensions for the correct assignments.
 
         Raises:
-            IterableUnpackingToListViolation
+            UnpackingIterableToListViolation
             WrongUnpackingViolation
 
         """
@@ -239,7 +239,7 @@ class WrongAssignmentVisitor(base.BaseNodeVisitor):
         Checks assignments inside ``for`` loops to be correct.
 
         Raises:
-            IterableUnpackingToListViolation
+            UnpackingIterableToListViolation
             WrongUnpackingViolation
 
         """
@@ -256,7 +256,7 @@ class WrongAssignmentVisitor(base.BaseNodeVisitor):
         because it does not have problems that we check.
 
         Raises:
-            IterableUnpackingToListViolation
+            UnpackingIterableToListViolation
             MultipleAssignmentsViolation
             WrongUnpackingViolation
 
@@ -293,7 +293,7 @@ class WrongAssignmentVisitor(base.BaseNodeVisitor):
             return
         for subnode in walk.get_subnodes_by_type(node, ast.List):
             self.add_violation(
-                consistency.IterableUnpackingToListViolation(subnode),
+                consistency.UnpackingIterableToListViolation(subnode),
             )
 
 

--- a/wemake_python_styleguide/visitors/ast/builtins.py
+++ b/wemake_python_styleguide/visitors/ast/builtins.py
@@ -23,7 +23,7 @@ from wemake_python_styleguide.compat.aliases import (
     FunctionNodes,
     TextNodes,
 )
-from wemake_python_styleguide.logic import nodes, safe_eval, source
+from wemake_python_styleguide.logic import nodes, safe_eval, source, walk
 from wemake_python_styleguide.logic.naming.name_nodes import extract_name
 from wemake_python_styleguide.logic.tree import operators, strings
 from wemake_python_styleguide.types import AnyFor, AnyNodes, AnyText, AnyWith
@@ -256,7 +256,7 @@ class WrongAssignmentVisitor(base.BaseNodeVisitor):
 
         """
         self._check_assign_targets(node)
-        self._check_unpacking_target_type(node)
+        self._check_unpacking_target_type(node.targets[0])
         if isinstance(node.targets[0], ast.Tuple):
             self._check_unpacking_targets(node, node.targets[0].elts)
         self.generic_visit(node)
@@ -279,8 +279,8 @@ class WrongAssignmentVisitor(base.BaseNodeVisitor):
                     best_practices.WrongUnpackingViolation(node),
                 )
 
-    def _check_unpacking_target_type(self, node: ast.Assign) -> None:
-        if isinstance(node.targets[0], ast.List):
+    def _check_unpacking_target_type(self, target: ast.AST) -> None:
+        for node in walk.get_subnodes_by_type(target, ast.List):
             self.add_violation(
                 consistency.IterableUnpackingToListViolation(node),
             )

--- a/wemake_python_styleguide/visitors/ast/builtins.py
+++ b/wemake_python_styleguide/visitors/ast/builtins.py
@@ -250,11 +250,13 @@ class WrongAssignmentVisitor(base.BaseNodeVisitor):
         because it does not have problems that we check.
 
         Raises:
+            IterableUnpackingToListViolation
             MultipleAssignmentsViolation
             WrongUnpackingViolation
 
         """
         self._check_assign_targets(node)
+        self._check_unpacking_target_type(node)
         if isinstance(node.targets[0], ast.Tuple):
             self._check_unpacking_targets(node, node.targets[0].elts)
         self.generic_visit(node)
@@ -276,6 +278,12 @@ class WrongAssignmentVisitor(base.BaseNodeVisitor):
                 self.add_violation(
                     best_practices.WrongUnpackingViolation(node),
                 )
+
+    def _check_unpacking_target_type(self, node: ast.Assign) -> None:
+        if isinstance(node.targets[0], ast.List):
+            self.add_violation(
+                consistency.IterableUnpackingToListViolation(node),
+            )
 
 
 @final


### PR DESCRIPTION
Add violation WPS358 forbidding unpacking iterables to lists.

# I have made things!

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made
- [x] I have added my changes to the `CHANGELOG.md`

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->
Closes #1256 
<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->

🙏 Please, if you or your company is finding wemake-python-styleguide valuable, help us sustain the project by sponsoring it transparently on https://opencollective.com/wemake-python-styleguide. As a thank you, your profile/company logo will be added to our main README which receives hundreds of unique visitors per day.
