### PR TITLE
fix checking wrong variable naming should be case insensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Semantic versioning in our case means:
 - Minor releases do bring new features and configuration options. New violations can be added. Code that passes `x.0.y` might not pass on `x.1.y` release.
 - Major releases inidicate significant milestones or serious breaking changes.
 
+## 0.15.0 aka New runtime
+
+### Bugfixes
+
+- Fixes how wrong variable names were checked case sensitive with `WPS110`
 
 ## 0.14.0 aka The Walrus fighter
 

--- a/tests/fixtures/noqa/noqa.py
+++ b/tests/fixtures/noqa/noqa.py
@@ -131,6 +131,7 @@ def some():  # noqa: WPS110
 del {'a': 1}['a']  # noqa: WPS420
 hasattr(object, 'some')  # noqa: WPS421
 value = 1  # noqa: WPS110
+VALUE = 1  # noqa: WPS110
 x = 2  # noqa: WPS111
 __private = 3  # noqa: WPS112
 star_wars_episode_7 = 'the worst episode ever after 8'  # noqa: WPS114

--- a/tests/test_checker/test_noqa.py
+++ b/tests/test_checker/test_noqa.py
@@ -57,7 +57,7 @@ SHOULD_BE_RAISED = types.MappingProxyType({
     'WPS100': 0,  # logically unacceptable.
     'WPS101': 0,  # logically unacceptable.
     'WPS102': 0,  # logically unacceptable.
-    'WPS110': 3,
+    'WPS110': 4,
     'WPS111': 1,
     'WPS112': 1,
     'WPS113': 1,

--- a/tests/test_visitors/test_ast/test_naming/conftest.py
+++ b/tests/test_visitors/test_ast/test_naming/conftest.py
@@ -12,6 +12,11 @@ from_import_alias = """
 from os import path as {0}
 """
 
+# Class names:
+
+class_name = 'class {0}: ...'
+
+
 # Function names:
 
 function_name = 'def {0}(): ...'
@@ -153,6 +158,9 @@ _ALL_FIXTURES = frozenset((
     # Imports:
     import_alias,
     from_import_alias,
+
+    # Class names:
+    class_name,
 
     # Function names, we don't use async function because we generate them:
     function_name,

--- a/tests/test_visitors/test_ast/test_naming/test_naming_rules/test_wrong_names.py
+++ b/tests/test_visitors/test_ast/test_naming/test_naming_rules/test_wrong_names.py
@@ -1,8 +1,8 @@
 import pytest
 
 from wemake_python_styleguide.violations.naming import (
-    WrongVariableNameViolation,
     UpperCaseAttributeViolation,
+    WrongVariableNameViolation,
 )
 from wemake_python_styleguide.visitors.ast.naming import WrongNameVisitor
 
@@ -34,6 +34,7 @@ def test_wrong_variable_name_case_insensitive(
         ignored_types=UpperCaseAttributeViolation,
     )
     assert_error_text(visitor, wrong_name, multiple=True)
+
 
 @pytest.mark.parametrize('wrong_name', [
     'value',

--- a/tests/test_visitors/test_ast/test_naming/test_naming_rules/test_wrong_names.py
+++ b/tests/test_visitors/test_ast/test_naming/test_naming_rules/test_wrong_names.py
@@ -2,9 +2,38 @@ import pytest
 
 from wemake_python_styleguide.violations.naming import (
     WrongVariableNameViolation,
+    UpperCaseAttributeViolation,
 )
 from wemake_python_styleguide.visitors.ast.naming import WrongNameVisitor
 
+
+@pytest.mark.parametrize('wrong_name', [
+    'SOME',
+    'Value',
+    'nO',
+    'dATa',
+])
+def test_wrong_variable_name_case_insensitive(
+    assert_errors,
+    assert_error_text,
+    parse_ast_tree,
+    naming_template,
+    default_options,
+    mode,
+    wrong_name,
+):
+    """Ensures that wrong names are not allowed, case insensitive."""
+    tree = parse_ast_tree(mode(naming_template.format(wrong_name)))
+
+    visitor = WrongNameVisitor(default_options, tree=tree)
+    visitor.run()
+
+    assert_errors(
+        visitor,
+        [WrongVariableNameViolation],
+        ignored_types=UpperCaseAttributeViolation,
+    )
+    assert_error_text(visitor, wrong_name, multiple=True)
 
 @pytest.mark.parametrize('wrong_name', [
     'value',

--- a/tests/test_visitors/test_ast/test_naming/test_naming_rules/test_wrong_names.py
+++ b/tests/test_visitors/test_ast/test_naming/test_naming_rules/test_wrong_names.py
@@ -31,7 +31,7 @@ def test_wrong_variable_name_case_insensitive(
     assert_errors(
         visitor,
         [WrongVariableNameViolation],
-        ignored_types=UpperCaseAttributeViolation,
+        ignored_types=(UpperCaseAttributeViolation,),
     )
     assert_error_text(visitor, wrong_name, multiple=True)
 

--- a/wemake_python_styleguide/logic/naming/logical.py
+++ b/wemake_python_styleguide/logic/naming/logical.py
@@ -33,7 +33,7 @@ def is_wrong_name(name: str, to_check: Iterable[str]) -> bool:
             '_{0}'.format(name_to_check),
             '{0}_'.format(name_to_check),
         }
-        if name in choices_to_check:
+        if name.lower() in choices_to_check:
             return True
     return False
 


### PR DESCRIPTION
Fix checking wrong variable naming should be case insensitive.

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [ ] I have updated the documentation for the changes I have made
- [x] I have added my changes to the `CHANGELOG.md`


## Related issues

- Closes #1275 


