### PR TITLE
added __subclasses__ and __mro__ to exclusions of DirectMagicAttributeAccessViolation

### DIFF
--- a/tests/test_visitors/test_ast/test_attributes/test_magic_attributes.py
+++ b/tests/test_visitors/test_ast/test_attributes/test_magic_attributes.py
@@ -140,45 +140,7 @@ def test_magic_attribute_is_restricted(
 
 
 @pytest.mark.parametrize('attribute', [
-    'regular',
-    '__doc__',
-    '__name__',
-    '__class__',
-    '__qualname__',
-])
-@pytest.mark.parametrize('code', [
-    magic_attribute_assigned,
-    magic_attribute_accessed,
-    magic_method_called,
-    magic_method_called_params,
-    magic_container_attribute,
-    magic_container_method,
-    magic_callable_attribute,
-])
-def test_regular_attributes(
-    assert_errors,
-    parse_ast_tree,
-    code,
-    attribute,
-    default_options,
-    mode,
-):
-    """Ensures that it is impossible to use magic attributes."""
-    tree = parse_ast_tree(mode(code.format(attribute)))
-
-    visitor = WrongAttributeVisitor(default_options, tree=tree)
-    visitor.run()
-
-    assert_errors(visitor, [])
-
-
-@pytest.mark.parametrize('attribute', [
-    'regular',
-    '__magic__',  # errors
-    '__doc__',
-    '__name__',
-    '__class__',
-    '__qualname__',
+    '__magic__',
 ])
 @pytest.mark.parametrize('code', [
     magic_name_definition,
@@ -195,7 +157,8 @@ def test_regular_attributes(
     magic_super_cls_attribute,
     magic_super_cls_method,
 ])
-def test_whitelist_magic_attributes_are_allowed(
+
+def test_magic_attribute_correct_contexts(
     assert_errors,
     parse_ast_tree,
     code,
@@ -203,7 +166,57 @@ def test_whitelist_magic_attributes_are_allowed(
     default_options,
     mode,
 ):
-    """Ensures that it is possible to use magic attributes."""
+    """Ensures that it is possible to use magic attributes in the right contexts."""
+    tree = parse_ast_tree(mode(code.format(attribute)))
+
+    visitor = WrongAttributeVisitor(default_options, tree=tree)
+    visitor.run()
+
+    assert_errors(visitor, [])
+
+
+
+@pytest.mark.parametrize('attribute', [
+    'regular',
+    '__doc__',
+    '__name__',
+    '__class__',
+    '__qualname__',
+    '__subclasses__',
+    '__mro__',
+])
+@pytest.mark.parametrize('code', [
+    magic_attribute_assigned,
+    magic_attribute_accessed,
+    magic_method_called,
+    magic_method_called_params,
+    magic_container_attribute,
+    magic_container_method,
+    magic_callable_attribute,
+    magic_name_definition,
+    magic_name_attr_definition,
+    magic_self_attribute,
+    magic_self_method,
+    magic_cls_attribute,
+    magic_cls_method,
+    magic_attribute_definition,
+    magic_method_definition,
+    magic_classmethod_definition,
+    magic_super_attribute,
+    magic_super_method,
+    magic_super_cls_attribute,
+    magic_super_cls_method,
+])
+def test_whitelist_and_regular_attributes_are_allowed(
+    assert_errors,
+    parse_ast_tree,
+    code,
+    attribute,
+    default_options,
+    mode,
+):
+    """Ensures that it is possible to use regular and whitelisted magic attributes,
+    both on 'right' and 'wrong' cases."""
     tree = parse_ast_tree(mode(code.format(attribute)))
 
     visitor = WrongAttributeVisitor(default_options, tree=tree)

--- a/wemake_python_styleguide/visitors/ast/attributes.py
+++ b/wemake_python_styleguide/visitors/ast/attributes.py
@@ -28,6 +28,8 @@ class WrongAttributeVisitor(BaseNodeVisitor):
         '__name__',
         '__qualname__',
         '__doc__',
+        '__subclasses__',
+        '__mro__',
     ))
 
     def visit_Attribute(self, node: ast.Attribute) -> None:


### PR DESCRIPTION
## Checklist

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [ ] I have created at least one test case for the changes I have made
- [ ] I have updated the documentation for the changes I have made
- [ ] I have added my changes to the `CHANGELOG.md`

## Related issues

Closes #1314
