### PR TITLE
added __subclasses__ and __mro__ to exclusions of DirectMagicAttributeAccessViolation

### DIFF
--- a/tests/test_visitors/test_ast/test_attributes/test_magic_attributes.py
+++ b/tests/test_visitors/test_ast/test_attributes/test_magic_attributes.py
@@ -157,7 +157,6 @@ def test_magic_attribute_is_restricted(
     magic_super_cls_attribute,
     magic_super_cls_method,
 ])
-
 def test_magic_attribute_correct_contexts(
     assert_errors,
     parse_ast_tree,
@@ -166,7 +165,7 @@ def test_magic_attribute_correct_contexts(
     default_options,
     mode,
 ):
-    """Ensures that it is possible to use magic attributes in the right contexts."""
+    """Ensures that it is possible to use magic attributes."""
     tree = parse_ast_tree(mode(code.format(attribute)))
 
     visitor = WrongAttributeVisitor(default_options, tree=tree)
@@ -207,7 +206,7 @@ def test_magic_attribute_correct_contexts(
     magic_super_cls_attribute,
     magic_super_cls_method,
 ])
-def test_whitelist_and_regular_attributes_are_allowed(
+def test_whitelist_regular_attributes_allowed(
     assert_errors,
     parse_ast_tree,
     code,
@@ -215,8 +214,7 @@ def test_whitelist_and_regular_attributes_are_allowed(
     default_options,
     mode,
 ):
-    """Ensures that it is possible to use regular and whitelisted magic attributes,
-    both on 'right' and 'wrong' cases."""
+    """Ensures that it is possible to use regular and whitelisted magic attributes."""
     tree = parse_ast_tree(mode(code.format(attribute)))
 
     visitor = WrongAttributeVisitor(default_options, tree=tree)

--- a/tests/test_visitors/test_ast/test_attributes/test_magic_attributes.py
+++ b/tests/test_visitors/test_ast/test_attributes/test_magic_attributes.py
@@ -140,45 +140,7 @@ def test_magic_attribute_is_restricted(
 
 
 @pytest.mark.parametrize('attribute', [
-    'regular',
-    '__doc__',
-    '__name__',
-    '__class__',
-    '__qualname__',
-])
-@pytest.mark.parametrize('code', [
-    magic_attribute_assigned,
-    magic_attribute_accessed,
-    magic_method_called,
-    magic_method_called_params,
-    magic_container_attribute,
-    magic_container_method,
-    magic_callable_attribute,
-])
-def test_regular_attributes(
-    assert_errors,
-    parse_ast_tree,
-    code,
-    attribute,
-    default_options,
-    mode,
-):
-    """Ensures that it is impossible to use magic attributes."""
-    tree = parse_ast_tree(mode(code.format(attribute)))
-
-    visitor = WrongAttributeVisitor(default_options, tree=tree)
-    visitor.run()
-
-    assert_errors(visitor, [])
-
-
-@pytest.mark.parametrize('attribute', [
-    'regular',
-    '__magic__',  # errors
-    '__doc__',
-    '__name__',
-    '__class__',
-    '__qualname__',
+    '__magic__',
 ])
 @pytest.mark.parametrize('code', [
     magic_name_definition,
@@ -195,7 +157,8 @@ def test_regular_attributes(
     magic_super_cls_attribute,
     magic_super_cls_method,
 ])
-def test_whitelist_magic_attributes_are_allowed(
+
+def test_magic_attribute_correct_contexts(
     assert_errors,
     parse_ast_tree,
     code,
@@ -203,7 +166,57 @@ def test_whitelist_magic_attributes_are_allowed(
     default_options,
     mode,
 ):
-    """Ensures that it is possible to use magic attributes."""
+    """Ensures that it is possible to use magic attributes in the right contexts."""
+    tree = parse_ast_tree(mode(code.format(attribute)))
+
+    visitor = WrongAttributeVisitor(default_options, tree=tree)
+    visitor.run()
+
+    assert_errors(visitor, [])
+
+
+
+@pytest.mark.parametrize('attribute', [
+    'regular',
+    '__doc__',
+    '__name__',
+    '__class__',
+    '__qualname__',
+    '__subclasses__',
+    '__mro__',
+])
+@pytest.mark.parametrize('code', [
+    magic_attribute_assigned,
+    magic_attribute_accessed,
+    magic_method_called,
+    magic_method_called_params,
+    magic_container_attribute,
+    magic_container_method,
+    magic_callable_attribute,
+    magic_name_definition,
+    magic_name_attr_definition,
+    magic_self_attribute,
+    magic_self_method,
+    magic_cls_attribute,
+    magic_cls_method,
+    magic_attribute_definition,
+    magic_method_definition,
+    magic_classmethod_definition,
+    magic_super_attribute,
+    magic_super_method,
+    magic_super_cls_attribute,
+    magic_super_cls_method,
+])
+def test_whitelist_and_regular_attributes_are_allowed(
+    assert_errors,
+    parse_ast_tree,
+    code,
+    attribute,
+    default_options,
+    mode,
+):
+    """Ensures that it is possible to use regular and whitelisted magic attributes,
+    both on 'right' and 'wrong' cases."""
     tree = parse_ast_tree(mode(code.format(attribute)))
 
     visitor = WrongAttributeVisitor(default_options, tree=tree)

--- a/tests/test_visitors/test_ast/test_attributes/test_magic_attributes.py
+++ b/tests/test_visitors/test_ast/test_attributes/test_magic_attributes.py
@@ -174,7 +174,6 @@ def test_magic_attribute_correct_contexts(
     assert_errors(visitor, [])
 
 
-
 @pytest.mark.parametrize('attribute', [
     'regular',
     '__doc__',
@@ -214,7 +213,12 @@ def test_whitelist_regular_attributes_allowed(
     default_options,
     mode,
 ):
-    """Ensures that it is possible to use regular and whitelisted magic attributes."""
+    """
+    Tests if regular attributes are allowed.
+
+    Ensures that it is possible to use regular and
+    whitelisted magic attributes.
+    """
     tree = parse_ast_tree(mode(code.format(attribute)))
 
     visitor = WrongAttributeVisitor(default_options, tree=tree)

--- a/wemake_python_styleguide/visitors/ast/attributes.py
+++ b/wemake_python_styleguide/visitors/ast/attributes.py
@@ -28,6 +28,8 @@ class WrongAttributeVisitor(BaseNodeVisitor):
         '__name__',
         '__qualname__',
         '__doc__',
+        '__subclasses__',
+        '__mro__',
     ))
 
     def visit_Attribute(self, node: ast.Attribute) -> None:


### PR DESCRIPTION
## Remarks
Title and:
I added the two new whitelisted attributes to the test suite and also changed it in the following ways:
### Before the changes there were 3 tests:

1. "wrong" access to magic attributes not on the whitelist (should raise exception).
2. "wrong" access to magic attributes on whitelist or regular attributes (shouldn't raise exception).
3. "correct" access to magic attributes on whitelist or regular attributes (shouldn't raise exception).

### After the changes there are 3 tests:
1. "wrong" access to magic attributes not on the whitelist (should raise exception).
2. "correct" access to magic attributes not on the whitelist (should'nt raise exception). **I added this one since it wasn't covered before**
3. access to magic attributes on whitelist or regular attributes (shouldn't raise exception). **I merged tests 2. and 3. from the old test to make this one since the contents are identical.**

## Checklist

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [ ] I have updated the documentation for the changes I have made
- [ ] I have added my changes to the `CHANGELOG.md`

## Related issues

Closes #1314
