### PR TITLE
Make WPS326 work when there is comment between string literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Semantic versioning in our case means:
 
 - Fixes how wrong variable names were checked case sensitive with `WPS110`
 - Fixes false positives DirectMagicAttributeAccessViolation with `__mro__`, `__subclasses__` and `__version__`
+- Make `WPS326` work when there is comment between string literals
 
 ### Misc
 

--- a/tests/test_visitors/test_tokenize/test_primitives/test_string_tokens/test_implicit_string_concatenation.py
+++ b/tests/test_visitors/test_tokenize/test_primitives/test_string_tokens/test_implicit_string_concatenation.py
@@ -48,11 +48,19 @@ some = (
 )
 """
 
+wrong_inline_string_concatenation_w_comment = """
+some = (
+    'a'  # Comment
+    'b'
+)
+"""
+
 
 @pytest.mark.parametrize('code', [
     wrong_inline_string_concatenation,
     wrong_inline_string_concatenation_nextline,
     wrong_inline_string_concatenation_multiline,
+    wrong_inline_string_concatenation_w_comment,
 ])
 def test_implicit_string_concatenation(
     parse_tokens,

--- a/wemake_python_styleguide/visitors/tokenize/primitives.py
+++ b/wemake_python_styleguide/visitors/tokenize/primitives.py
@@ -238,6 +238,7 @@ class WrongStringConcatenationVisitor(BaseTokenVisitor):
         tokenize.NL,
         tokenize.NEWLINE,
         tokenize.INDENT,
+        tokenize.COMMENT,
     ))
 
     def __init__(self, *args, **kwargs) -> None:


### PR DESCRIPTION
# I have made things!


## Checklist

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [ ] I have updated the documentation for the changes I have made
  - IMO it is not required to document this change...
- [x] I have added my changes to the `CHANGELOG.md`

## Related issues

None