### PR TITLE
Issue 1406: Allow unused variable in for loop iterator

### DIFF
--- a/tests/test_visitors/test_ast/test_naming/conftest.py
+++ b/tests/test_visitors/test_ast/test_naming/conftest.py
@@ -214,27 +214,38 @@ _FORBIDDEN_UNUSED_TUPLE = frozenset((
     for_variable,
 ))
 
-_FORBIDDEN_UNUSED = _FORBIDDEN_UNUSED_TUPLE | {
+# Raw unused variables return True for logic.naming.access.is_unused().
+# Example: _, __.
+# Protected unused variables return True for logic.naming.access.is_protected().
+# Example: _protected.
+_FORBIDDEN_BOTH_RAW_AND_PROTECTED_UNUSED = frozenset((
+    unpacking_variables,
+    variable_def,
+    with_variable,
     variable_typed_def,
     variable_typed,
     exception,
-}
+))
 
 if PY38:
-    _FORBIDDEN_UNUSED |= {
+    _FORBIDDEN_BOTH_RAW_AND_PROTECTED_UNUSED |= {
         assignment_expression,
     }
+
+_FORBIDDEN_RAW_UNUSED = _FORBIDDEN_BOTH_RAW_AND_PROTECTED_UNUSED | {
+    static_attribute,
+    static_typed_attribute,
+    static_typed_annotation,
+}
+
+_FORBIDDEN_PROTECTED_UNUSED = _FORBIDDEN_BOTH_RAW_AND_PROTECTED_UNUSED | {
+    for_variable,
+}
 
 
 @pytest.fixture(params=_ALL_FIXTURES)
 def naming_template(request):
     """Parametrized fixture that contains all possible naming templates."""
-    return request.param
-
-
-@pytest.fixture(params=_FORBIDDEN_UNUSED)
-def forbidden_unused_template(request):
-    """Returns template that can be used to define wrong unused variables."""
     return request.param
 
 
@@ -244,17 +255,25 @@ def forbidden_tuple_unused_template(request):
     return request.param
 
 
-@pytest.fixture(params=_FORBIDDEN_UNUSED | {
-    static_attribute,
-    static_typed_attribute,
-    static_typed_annotation,
-})
+@pytest.fixture(params=_FORBIDDEN_RAW_UNUSED)
 def forbidden_raw_unused_template(request):
-    """Returns template that can be used to define ``_`` patterns."""
+    """Returns template that forbids defining raw unused variables."""
     return request.param
 
 
-@pytest.fixture(params=_ALL_FIXTURES - _FORBIDDEN_UNUSED)
-def allowed_unused_template(request):
-    """Returns template that can be used to define unused variables."""
+@pytest.fixture(params=_ALL_FIXTURES - _FORBIDDEN_RAW_UNUSED)
+def allowed_raw_unused_template(request):
+    """Returns template that allows defining raw unused variables."""
+    return request.param
+
+
+@pytest.fixture(params=_FORBIDDEN_PROTECTED_UNUSED)
+def forbidden_protected_unused_template(request):
+    """Returns template that forbids defining protected unused variables."""
+    return request.param
+
+
+@pytest.fixture(params=_ALL_FIXTURES - _FORBIDDEN_PROTECTED_UNUSED)
+def allowed_protected_unused_template(request):
+    """Returns template that allows defining protected unused variables."""
     return request.param

--- a/tests/test_visitors/test_ast/test_naming/test_unused/test_unused_definition.py
+++ b/tests/test_visitors/test_ast/test_naming/test_unused/test_unused_definition.py
@@ -195,7 +195,7 @@ def test_protected_unused_variable_definition(
     assert_errors(visitor, [UnusedVariableIsDefinedViolation])
 
 
-@pytest.mark.parametrize(('context', 'indentation'), [  # noqa: WPS118
+@pytest.mark.parametrize(('context', 'indentation'), [
     (module_context, 0),
     (function_context, 4),
     (method_context, 8),
@@ -203,7 +203,7 @@ def test_protected_unused_variable_definition(
 @pytest.mark.parametrize('bad_name', [
     '_protected',
 ])
-def test_protected_unused_variable_definition_allowed(
+def test_protected_unused_var_definition_allowed(
     assert_errors,
     parse_ast_tree,
     context,

--- a/tests/test_visitors/test_ast/test_naming/test_unused/test_unused_definition.py
+++ b/tests/test_visitors/test_ast/test_naming/test_unused/test_unused_definition.py
@@ -28,41 +28,6 @@ class Test(object):
     (method_context, 8),
 ])
 @pytest.mark.parametrize('bad_name', [
-    '_unused',
-    '_',
-    '__',
-])
-def test_unused_variable_definition(
-    assert_errors,
-    parse_ast_tree,
-    context,
-    indentation,
-    bad_name,
-    forbidden_unused_template,
-    default_options,
-    mode,
-):
-    """Testing that any variable cannot be used if it is marked as unused."""
-    tree = parse_ast_tree(
-        mode(context.format(
-            indent(
-                forbidden_unused_template.format(bad_name),
-                ' ' * indentation,
-            ),
-        )),
-    )
-
-    visitor = UnusedVaribaleDefinitionVisitor(default_options, tree=tree)
-    visitor.run()
-
-    assert_errors(visitor, [UnusedVariableIsDefinedViolation])
-
-
-@pytest.mark.parametrize(('context', 'indentation'), [
-    (function_context, 4),
-    (method_context, 8),
-])
-@pytest.mark.parametrize('bad_name', [
     '(_first, _second)',
 ])
 def test_unused_variable_tuple_definition(
@@ -75,7 +40,7 @@ def test_unused_variable_tuple_definition(
     default_options,
     mode,
 ):
-    """Testing that any variable cannot be used if it is marked as unused."""
+    """Testing tuples with all unused variables cannot be defined."""
     tree = parse_ast_tree(
         mode(context.format(
             indent(
@@ -101,7 +66,7 @@ def test_unused_variable_tuple_definition(
     '(first, _second)',
     '(_first, second)',
 ])
-def test_used_variable_tuple_definition(
+def test_used_variable_tuple_definition_allowed(
     assert_errors,
     parse_ast_tree,
     context,
@@ -111,46 +76,11 @@ def test_used_variable_tuple_definition(
     default_options,
     mode,
 ):
-    """Testing that any variable can be used if it is marked as unused."""
+    """Testing tuples with at least one used variable can be defined."""
     tree = parse_ast_tree(
         mode(context.format(
             indent(
                 forbidden_tuple_unused_template.format(bad_name),
-                ' ' * indentation,
-            ),
-        )),
-    )
-
-    visitor = UnusedVaribaleDefinitionVisitor(default_options, tree=tree)
-    visitor.run()
-
-    assert_errors(visitor, [])
-
-
-@pytest.mark.parametrize(('context', 'indentation'), [
-    (module_context, 0),
-    (function_context, 4),
-    (method_context, 8),
-])
-@pytest.mark.parametrize('bad_name', [
-    '_protected',
-    '_unused',
-])
-def test_unused_variable_definition_allowed(
-    assert_errors,
-    parse_ast_tree,
-    context,
-    indentation,
-    bad_name,
-    allowed_unused_template,
-    default_options,
-    mode,
-):
-    """Testing that any variable can be used in some cases."""
-    tree = parse_ast_tree(
-        mode(context.format(
-            indent(
-                allowed_unused_template.format(bad_name),
                 ' ' * indentation,
             ),
         )),
@@ -181,7 +111,7 @@ def test_raw_unused_variable_definition(
     default_options,
     mode,
 ):
-    """Testing that any variable can be used in some cases."""
+    """Testing raw variable definition is forbidden in some cases."""
     tree = parse_ast_tree(
         mode(context.format(
             indent(
@@ -203,10 +133,112 @@ def test_raw_unused_variable_definition(
     (method_context, 8),
 ])
 @pytest.mark.parametrize('bad_name', [
+    '_',
+    '__',
+])
+def test_raw_unused_variable_definition_allowed(
+    assert_errors,
+    parse_ast_tree,
+    context,
+    indentation,
+    bad_name,
+    allowed_raw_unused_template,
+    default_options,
+    mode,
+):
+    """Testing raw variable definition is allowed in some cases."""
+    tree = parse_ast_tree(
+        mode(context.format(
+            indent(
+                allowed_raw_unused_template.format(bad_name),
+                ' ' * indentation,
+            ),
+        )),
+    )
+
+    visitor = UnusedVaribaleDefinitionVisitor(default_options, tree=tree)
+    visitor.run()
+
+    assert_errors(visitor, [])
+
+
+@pytest.mark.parametrize(('context', 'indentation'), [
+    (function_context, 4),
+    (method_context, 8),
+])
+@pytest.mark.parametrize('bad_name', [
+    '_protected',
+])
+def test_protected_unused_variable_definition(
+    assert_errors,
+    parse_ast_tree,
+    context,
+    indentation,
+    bad_name,
+    forbidden_protected_unused_template,
+    default_options,
+    mode,
+):
+    """Testing protected variable definition is forbidden in certain cases."""
+    tree = parse_ast_tree(
+        mode(context.format(
+            indent(
+                forbidden_protected_unused_template.format(bad_name),
+                ' ' * indentation,
+            ),
+        )),
+    )
+
+    visitor = UnusedVaribaleDefinitionVisitor(default_options, tree=tree)
+    visitor.run()
+
+    assert_errors(visitor, [UnusedVariableIsDefinedViolation])
+
+
+@pytest.mark.parametrize(('context', 'indentation'), [  # noqa: WPS118
+    (module_context, 0),
+    (function_context, 4),
+    (method_context, 8),
+])
+@pytest.mark.parametrize('bad_name', [
+    '_protected',
+])
+def test_protected_unused_variable_definition_allowed(
+    assert_errors,
+    parse_ast_tree,
+    context,
+    indentation,
+    bad_name,
+    allowed_protected_unused_template,
+    default_options,
+    mode,
+):
+    """Testing protected variable definition is allowed in certain cases."""
+    tree = parse_ast_tree(
+        mode(context.format(
+            indent(
+                allowed_protected_unused_template.format(bad_name),
+                ' ' * indentation,
+            ),
+        )),
+    )
+
+    visitor = UnusedVaribaleDefinitionVisitor(default_options, tree=tree)
+    visitor.run()
+
+    assert_errors(visitor, [])
+
+
+@pytest.mark.parametrize(('context', 'indentation'), [
+    (module_context, 0),
+    (function_context, 4),
+    (method_context, 8),
+])
+@pytest.mark.parametrize('bad_name', [
     'regular',
     'list_',
 ])
-def test_used_variable_definition(
+def test_used_variable_definition_allowed(
     assert_errors,
     parse_ast_tree,
     context,
@@ -216,7 +248,7 @@ def test_used_variable_definition(
     default_options,
     mode,
 ):
-    """Testing that any variable cannot be used if it is marked as unused."""
+    """Testing that any variable can be used if it is marked as used."""
     tree = parse_ast_tree(
         mode(context.format(
             indent(

--- a/wemake_python_styleguide/visitors/ast/naming.py
+++ b/wemake_python_styleguide/visitors/ast/naming.py
@@ -424,11 +424,16 @@ class UnusedVaribaleDefinitionVisitor(BaseNodeVisitor):
             UnusedVariableIsDefinedViolation
 
         """
-        self._check_assign_unused(
-            node,
-            name_nodes.get_variables_from_node(node.target),
-            is_local=True,
+        target_names = name_nodes.get_variables_from_node(node.target)
+        is_target_no_op_variable = (
+            len(target_names) == 1 and access.is_unused(target_names[0])
         )
+        if not is_target_no_op_variable:  # see issue 1406
+            self._check_assign_unused(
+                node,
+                target_names,
+                is_local=True,
+            )
         self.generic_visit(node)
 
     def visit_ExceptHandler(self, node: ast.ExceptHandler) -> None:


### PR DESCRIPTION
# I have made things!

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [ ] I have created at least one test case for the changes I have made
   (Moved a test case from unallowed to allowed)
- [ ] I have updated the documentation for the changes I have made
   (The [documentation](https://wemake-python-stylegui.de/en/latest/pages/usage/violations/naming.html#wemake_python_styleguide.violations.naming.UnusedVariableIsDefinedViolation) makes no mention of this specific case)
- [ ] I have added my changes to the `CHANGELOG.md`

## Related issues
Closes #1406
<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
(The issue description talks about comprehensions, but I didn't find any place,including the [comprehension tests](https://github.com/wemake-services/wemake-python-styleguide/tree/58b96219a39390c35353aa9a29d483d5ed3f1cf7/tests/test_visitors/test_ast/test_loops/test_comprehensions), where comprehensions were being checked for WPS122, and manually testing code such as `my_list = [3 for _ in range(4)]` was throwing no WPS122 errors, so I ended up doing nothing for that)