### PR TITLE
Fix a missing "number" reference in the WPS114 msg

### DIFF
--- a/wemake_python_styleguide/violations/naming.py
+++ b/wemake_python_styleguide/violations/naming.py
@@ -472,7 +472,7 @@ class UnderscoredNumberNameViolation(MaybeASTViolation):
 
     """
 
-    error_template = 'Found underscored name pattern: {0}'
+    error_template = 'Found underscored number name pattern: {0}'
     code = 114
 
 


### PR DESCRIPTION
This is pretty trivial. Saying `WPS114: Found underscored name pattern:
IS_PYTEST_4_PLUS` is confusing and doesn't match the class name/purpose.
I uncovered this confusion when I hit #1448.
I don't think this deserves even a log entry.