### PR TITLE
Fix #1437: too long tuple unpacking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ Semantic versioning in our case means:
 - Major releases inidicate significant milestones or serious breaking changes.
 
 
+## 0.16.0
+
+### Features
+
+- Forbids using too many variables in a tuple unpacking
+
+
 ## 0.15.0 aka New runtime
 
 ### Features

--- a/tests/fixtures/noqa/noqa.py
+++ b/tests/fixtures/noqa/noqa.py
@@ -108,9 +108,6 @@ class TooManyPublicAtts(object):  # noqa: WPS230
         self.boom = 7
 
 
-var_a, var_b, var_c, var_d, var_e = (1, 2, 3, 4, 5) # noqa: WPS236
-
-
 def function_name(
     value: int = 0,  # noqa: WPS110
 ):

--- a/tests/fixtures/noqa/noqa.py
+++ b/tests/fixtures/noqa/noqa.py
@@ -108,6 +108,9 @@ class TooManyPublicAtts(object):  # noqa: WPS230
         self.boom = 7
 
 
+var_a, var_b, var_c, var_d, var_e = (1, 2, 3, 4, 5) # noqa: WPS236
+
+
 def function_name(
     value: int = 0,  # noqa: WPS110
 ):
@@ -159,7 +162,7 @@ some._execute()  # noqa: WPS437
 
 
 def many_locals():  # noqa: WPS210
-    arg1, arg2, arg3, arg4, arg5, arg6 = range(6)
+    arg1, arg2, arg3, arg4, arg5, arg6 = range(6)  # noqa: WPS236
 
 
 def many_arguments(_arg1, _arg2, _arg3, _arg4, _arg5, _arg6):  # noqa: WPS211

--- a/tests/test_checker/test_noqa.py
+++ b/tests/test_checker/test_noqa.py
@@ -106,6 +106,7 @@ SHOULD_BE_RAISED = types.MappingProxyType({
     'WPS233': 1,
     'WPS234': 1,
     'WPS235': 1,
+    'WPS236': 2,
 
     'WPS300': 1,
     'WPS301': 1,

--- a/tests/test_checker/test_noqa.py
+++ b/tests/test_checker/test_noqa.py
@@ -106,7 +106,7 @@ SHOULD_BE_RAISED = types.MappingProxyType({
     'WPS233': 1,
     'WPS234': 1,
     'WPS235': 1,
-    'WPS236': 2,
+    'WPS236': 1,
 
     'WPS300': 1,
     'WPS301': 1,

--- a/tests/test_visitors/test_ast/test_complexity/test_counts/test_imports_counts.py
+++ b/tests/test_visitors/test_ast/test_complexity/test_counts/test_imports_counts.py
@@ -5,7 +5,7 @@ from wemake_python_styleguide.violations.complexity import (
     TooManyImportedNamesViolation,
     TooManyImportsViolation,
 )
-from wemake_python_styleguide.visitors.ast.complexity.counts import (
+from wemake_python_styleguide.visitors.ast.complexity.imports import (
     ImportMembersVisitor,
 )
 

--- a/tests/test_visitors/test_ast/test_complexity/test_counts/test_tuple_unpack_length.py
+++ b/tests/test_visitors/test_ast/test_complexity/test_counts/test_tuple_unpack_length.py
@@ -10,15 +10,27 @@ from wemake_python_styleguide.visitors.ast.complexity.counts import (
 short_unpack = 'a, b = (1, 2)'
 short_starred_unpack = 'a, b, *rest = (1, 2, 3, 4, 5)'
 single_unpack = 'result = (1, 2, 3, 4, 5)'
+function_unpack = 'result = some()'
+class_attr_unpack = """
+class foo(object):
+    result = (1, 2, 3, 4, 5)
+"""
 
 long_unpack = 'a, b, c, d, e = (1, 2, 3, 4, 5)'
 long_starred_unpack = 'a, b, c, d, *rest = (1, 2, 3, 4, 5, 6)'
+long_function_unpack = 'a, b, c, d, e = some()'
+long_class_attr_unpack = """
+class foo(object):
+    a, b, c, d, e = (1, 2, 3, 4, 5)
+"""
 
 
 @pytest.mark.parametrize('unpack_expression', [
     short_unpack,
     short_starred_unpack,
     single_unpack,
+    function_unpack,
+    class_attr_unpack,
 ])
 def test_unpack_length_normal(
     assert_errors,
@@ -39,6 +51,8 @@ def test_unpack_length_normal(
 @pytest.mark.parametrize('unpack_expression', [
     long_unpack,
     long_starred_unpack,
+    long_function_unpack,
+    long_class_attr_unpack,
 ])
 def test_unpack_length_violation(
     assert_errors,

--- a/tests/test_visitors/test_ast/test_complexity/test_counts/test_tuple_unpack_length.py
+++ b/tests/test_visitors/test_ast/test_complexity/test_counts/test_tuple_unpack_length.py
@@ -1,0 +1,58 @@
+import pytest
+
+from wemake_python_styleguide.violations.complexity import (
+    TooLongTupleUnpackViolation,
+)
+from wemake_python_styleguide.visitors.ast.complexity.counts import (
+    TupleUnpackVisitor,
+)
+
+short_unpack = 'a, b = (1, 2)'
+short_starred_unpack = 'a, b, *rest = (1, 2, 3, 4, 5)'
+single_unpack = 'result = (1, 2, 3, 4, 5)'
+
+long_unpack = 'a, b, c, d, e = (1, 2, 3, 4, 5)'
+long_starred_unpack = 'a, b, c, d, *rest = (1, 2, 3, 4, 5, 6)'
+
+
+@pytest.mark.parametrize('unpack_expression', [
+    short_unpack,
+    short_starred_unpack,
+    single_unpack,
+])
+def test_unpack_length_normal(
+    assert_errors,
+    parse_ast_tree,
+    unpack_expression,
+    options,
+):
+    """Test that correct usage of unpack expression don't raise excptions."""
+    tree = parse_ast_tree(unpack_expression)
+
+    option_values = options(max_tuple_unpack_length=4)
+    visitor = TupleUnpackVisitor(option_values, tree=tree)
+    visitor.run()
+
+    assert_errors(visitor, [])
+
+
+@pytest.mark.parametrize('unpack_expression', [
+    long_unpack,
+    long_starred_unpack,
+])
+def test_unpack_length_violation(
+    assert_errors,
+    assert_error_text,
+    parse_ast_tree,
+    unpack_expression,
+    options,
+):
+    """Test that violations raise proper exceptions."""
+    tree = parse_ast_tree(unpack_expression)
+
+    option_values = options(max_tuple_unpack_length=4)
+    visitor = TupleUnpackVisitor(option_values, tree=tree)
+    visitor.run()
+
+    assert_errors(visitor, [TooLongTupleUnpackViolation])
+    assert_error_text(visitor, 5, option_values.max_tuple_unpack_length)

--- a/wemake_python_styleguide/options/config.py
+++ b/wemake_python_styleguide/options/config.py
@@ -134,7 +134,9 @@ You can also show all options that ``flake8`` supports by running:
 - ``max-import-from-members`` - maximum number of names that can be imported
     from module, defaults to
     :str:`wemake_python_styleguide.options.defaults.MAX_IMPORT_FROM_MEMBERS`
-
+- ``max-tuple-unpack-length`` - maximum number of variables in tuple unpacking,
+    defaults to
+    :str:`wemake_python_styleguide.options.defaults.MAX_TUPLE_UNPACK_LENGTH`
 """
 
 from typing import ClassVar, Mapping, Optional, Sequence, Union
@@ -393,6 +395,11 @@ class Configuration(object):
             '--max-import-from-members',
             defaults.MAX_IMPORT_FROM_MEMBERS,
             'Maximum number of names that can be imported from module.',
+        ),
+        _Option(
+            '--max-tuple-unpack-length',
+            defaults.MAX_TUPLE_UNPACK_LENGTH,
+            'Maximum number of variables in a tuple unpacking.',
         ),
     ]
 

--- a/wemake_python_styleguide/options/defaults.py
+++ b/wemake_python_styleguide/options/defaults.py
@@ -121,3 +121,6 @@ MAX_ANN_COMPLEXITY: Final = 3  # reasonable enough
 
 #: Maximum number of names that can be imported from module.
 MAX_IMPORT_FROM_MEMBERS: Final = 8  # guessed
+
+#: Maximun number of variables in a ``tuple`` unpacking statement.
+MAX_TUPLE_UNPACK_LENGTH: Final = 4  # guessed

--- a/wemake_python_styleguide/options/validation.py
+++ b/wemake_python_styleguide/options/validation.py
@@ -92,6 +92,7 @@ class _ValidatedOptions(object):
     max_call_level: int = attr.ib(validator=[_min_max(min=1)])
     max_annotation_complexity: int = attr.ib(validator=[_min_max(min=2)])
     max_import_from_members: int = attr.ib(validator=[_min_max(min=1)])
+    max_tuple_unpack_length: int = attr.ib(validator=[_min_max(min=1)])
 
 
 def validate_options(options: ConfigurationOptions) -> _ValidatedOptions:

--- a/wemake_python_styleguide/presets/topics/complexity.py
+++ b/wemake_python_styleguide/presets/topics/complexity.py
@@ -7,6 +7,7 @@ from wemake_python_styleguide.visitors.ast.complexity import (  # noqa: WPS235
     classes,
     counts,
     function,
+    imports,
     jones,
     nested,
     offset,
@@ -18,18 +19,20 @@ PRESET: Final = (
     function.FunctionComplexityVisitor,
     function.CognitiveComplexityVisitor,
 
+    imports.ImportMembersVisitor,
+
     jones.JonesComplexityVisitor,
 
     nested.NestedComplexityVisitor,
 
     offset.OffsetVisitor,
 
-    counts.ImportMembersVisitor,
     counts.ModuleMembersVisitor,
     counts.ConditionsVisitor,
     counts.ElifVisitor,
     counts.TryExceptVisitor,
     counts.YieldTupleVisitor,
+    counts.TupleUnpackVisitor,
 
     classes.ClassComplexityVisitor,
     classes.MethodMembersVisitor,

--- a/wemake_python_styleguide/types.py
+++ b/wemake_python_styleguide/types.py
@@ -244,3 +244,7 @@ class ConfigurationOptions(Protocol):
     @property
     def max_import_from_members(self) -> int:
         ...
+
+    @property
+    def max_tuple_unpack_length(self) -> int:
+        ...

--- a/wemake_python_styleguide/violations/complexity.py
+++ b/wemake_python_styleguide/violations/complexity.py
@@ -1149,13 +1149,14 @@ class TooLongTupleUnpackViolation(ASTViolation):
     Forbids using too many variables to unpack a tuple.
 
     Reasoning:
-        The order is hard to remember.
+        The order and meaning are hard to remember.
 
     Solution:
         If you have more than 2 values in a tuple, consider using
-        typing.NamedTuple instead.
+        ``typing.NamedTuple`` or a dataclass instead.
 
     Example::
+
         # Correct:
         result = foo()
 

--- a/wemake_python_styleguide/violations/complexity.py
+++ b/wemake_python_styleguide/violations/complexity.py
@@ -56,6 +56,7 @@ Summary
    TooLongCallChainViolation
    TooComplexAnnotationViolation
    TooManyImportedModuleMembersViolation
+   TooLongTupleUnpackViolation
 
 
 Module complexity
@@ -96,6 +97,7 @@ Structure complexity
 .. autoclass:: TooLongCallChainViolation
 .. autoclass:: TooComplexAnnotationViolation
 .. autoclass:: TooManyImportedModuleMembersViolation
+.. autoclass:: TooLongTupleUnpackViolation
 
 """
 
@@ -1139,3 +1141,35 @@ class TooManyImportedModuleMembersViolation(ASTViolation):
 
     error_template = 'Found too many imported names from a module: {0}'
     code = 235
+
+
+@final
+class TooLongTupleUnpackViolation(ASTViolation):
+    """
+    Forbids using too many variables to unpack a tuple.
+
+    Reasoning:
+        The order is hard to remember.
+
+    Solution:
+        If you have more than 2 values in a tuple, consider using
+        typing.NamedTuple instead.
+
+    Example::
+        # Correct:
+        result = foo()
+
+        # Wrong:
+        a, b, c, d, e = foo()
+
+    Configuration:
+        This rule is configurable with ``--max-tuple-unpack-length``.
+        Default:
+        :str:`wemake_python_styleguide.options.defaults.MAX_TUPLE_UNPACK_LENGTH`
+
+    .. versionadded:: 0.15.0
+
+    """
+
+    error_template = 'Found too many variables used to unpack a tuple: {0}'
+    code = 236

--- a/wemake_python_styleguide/visitors/ast/complexity/counts.py
+++ b/wemake_python_styleguide/visitors/ast/complexity/counts.py
@@ -7,13 +7,8 @@ from typing_extensions import final
 from wemake_python_styleguide import constants
 from wemake_python_styleguide.logic.nodes import get_parent
 from wemake_python_styleguide.logic.tree.functions import is_method
-from wemake_python_styleguide.types import (
-    AnyFunctionDef,
-    AnyImport,
-    ConfigurationOptions,
-)
+from wemake_python_styleguide.types import AnyFunctionDef
 from wemake_python_styleguide.violations import complexity
-from wemake_python_styleguide.violations.base import ErrorCallback
 from wemake_python_styleguide.visitors.base import BaseNodeVisitor
 from wemake_python_styleguide.visitors.decorators import alias
 
@@ -73,99 +68,6 @@ class ModuleMembersVisitor(BaseNodeVisitor):
                     baseline=self.options.max_module_members,
                 ),
             )
-
-
-@final
-class _ImportFromMembersValidator(object):
-    """Validator of ``ast.ImportFrom`` nodes names."""
-
-    def __init__(
-        self,
-        error_callback: ErrorCallback,
-        options: ConfigurationOptions,
-    ) -> None:
-        self._error_callback = error_callback
-        self._options = options
-
-    def validate(self, node: ast.ImportFrom) -> None:
-        self._check_import_from_names_count(node)
-
-    def _check_import_from_names_count(self, node: ast.ImportFrom) -> None:
-        imported_names_number = len(node.names)
-        if imported_names_number > self._options.max_import_from_members:
-            self._error_callback(
-                complexity.TooManyImportedModuleMembersViolation(
-                    node,
-                    text=str(imported_names_number),
-                    baseline=self._options.max_import_from_members,
-                ),
-            )
-
-
-@final
-class ImportMembersVisitor(BaseNodeVisitor):
-    """Counts imports in a module."""
-
-    def __init__(self, *args, **kwargs) -> None:
-        """Creates a counter for tracked metrics."""
-        super().__init__(*args, **kwargs)
-        self._imports_count = 0
-        self._imported_names_count = 0
-        self._import_from_members_validator = _ImportFromMembersValidator(
-            self.add_violation,
-            self.options,
-        )
-
-    def visit_Import(self, node: ast.Import) -> None:
-        """
-        Counts the number of ``import``.
-
-        Raises:
-            TooManyImportedNamesViolation
-            TooManyImportsViolation
-
-        """
-        self._visit_any_import(node)
-
-    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
-        """
-        Counts the number of ``from ... import ...``.
-
-        Raises:
-            TooManyImported_ModuleMembersViolation
-            TooManyImportedNamesViolation
-            TooManyImportsViolation
-
-        """
-        self._import_from_members_validator.validate(node)
-        self._visit_any_import(node)
-
-    def _visit_any_import(self, node: AnyImport) -> None:
-        self._imports_count += 1
-        self._imported_names_count += len(node.names)
-        self.generic_visit(node)
-
-    def _check_imports_count(self) -> None:
-        if self._imports_count > self.options.max_imports:
-            self.add_violation(
-                complexity.TooManyImportsViolation(
-                    text=str(self._imports_count),
-                    baseline=self.options.max_imports,
-                ),
-            )
-
-    def _check_imported_names_count(self) -> None:
-        if self._imported_names_count > self.options.max_imported_names:
-            self.add_violation(
-                complexity.TooManyImportedNamesViolation(
-                    text=str(self._imported_names_count),
-                    baseline=self.options.max_imported_names,
-                ),
-            )
-
-    def _post_visit(self) -> None:
-        self._check_imports_count()
-        self._check_imported_names_count()
 
 
 @final
@@ -349,5 +251,28 @@ class YieldTupleVisitor(BaseNodeVisitor):
                         node,
                         text=str(len(node.value.elts)),
                         baseline=constants.MAX_LEN_YIELD_TUPLE,
+                    ),
+                )
+
+
+@final
+class TupleUnpackVisitor(BaseNodeVisitor):
+    """Finds statements with too many variables receiving an unpacked tuple."""
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        """
+        Finds statements using too many variables to receive an unpacked tuple.
+
+        Raises:
+            TooLongTupleUnpackViolation
+
+        """
+        if isinstance(node.targets[0], ast.Tuple):
+            if len(node.targets[0].elts) > self.options.max_tuple_unpack_length:
+                self.add_violation(
+                    complexity.TooLongTupleUnpackViolation(
+                        node,
+                        text=str(len(node.targets[0].elts)),
+                        baseline=self.options.max_tuple_unpack_length,
                     ),
                 )

--- a/wemake_python_styleguide/visitors/ast/complexity/imports.py
+++ b/wemake_python_styleguide/visitors/ast/complexity/imports.py
@@ -1,0 +1,101 @@
+import ast
+
+from typing_extensions import final
+
+from wemake_python_styleguide.types import AnyImport, ConfigurationOptions
+from wemake_python_styleguide.violations import complexity
+from wemake_python_styleguide.violations.base import ErrorCallback
+from wemake_python_styleguide.visitors.base import BaseNodeVisitor
+
+
+@final
+class _ImportFromMembersValidator(object):
+    """Validator of ``ast.ImportFrom`` nodes names."""
+
+    def __init__(
+        self,
+        error_callback: ErrorCallback,
+        options: ConfigurationOptions,
+    ) -> None:
+        self._error_callback = error_callback
+        self._options = options
+
+    def validate(self, node: ast.ImportFrom) -> None:
+        self._check_import_from_names_count(node)
+
+    def _check_import_from_names_count(self, node: ast.ImportFrom) -> None:
+        imported_names_number = len(node.names)
+        if imported_names_number > self._options.max_import_from_members:
+            self._error_callback(
+                complexity.TooManyImportedModuleMembersViolation(
+                    node,
+                    text=str(imported_names_number),
+                    baseline=self._options.max_import_from_members,
+                ),
+            )
+
+
+@final
+class ImportMembersVisitor(BaseNodeVisitor):
+    """Counts imports in a module."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        """Creates a counter for tracked metrics."""
+        super().__init__(*args, **kwargs)
+        self._imports_count = 0
+        self._imported_names_count = 0
+        self._import_from_members_validator = _ImportFromMembersValidator(
+            self.add_violation,
+            self.options,
+        )
+
+    def visit_Import(self, node: ast.Import) -> None:
+        """
+        Counts the number of ``import``.
+
+        Raises:
+            TooManyImportedNamesViolation
+            TooManyImportsViolation
+
+        """
+        self._visit_any_import(node)
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        """
+        Counts the number of ``from ... import ...``.
+
+        Raises:
+            TooManyImported_ModuleMembersViolation
+            TooManyImportedNamesViolation
+            TooManyImportsViolation
+
+        """
+        self._import_from_members_validator.validate(node)
+        self._visit_any_import(node)
+
+    def _visit_any_import(self, node: AnyImport) -> None:
+        self._imports_count += 1
+        self._imported_names_count += len(node.names)
+        self.generic_visit(node)
+
+    def _check_imports_count(self) -> None:
+        if self._imports_count > self.options.max_imports:
+            self.add_violation(
+                complexity.TooManyImportsViolation(
+                    text=str(self._imports_count),
+                    baseline=self.options.max_imports,
+                ),
+            )
+
+    def _check_imported_names_count(self) -> None:
+        if self._imported_names_count > self.options.max_imported_names:
+            self.add_violation(
+                complexity.TooManyImportedNamesViolation(
+                    text=str(self._imported_names_count),
+                    baseline=self.options.max_imported_names,
+                ),
+            )
+
+    def _post_visit(self) -> None:
+        self._check_imports_count()
+        self._check_imported_names_count()


### PR DESCRIPTION
# I have made things!

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made
- [x] I have added my changes to the `CHANGELOG.md`

## Related issues

- Closes #1437 

## Changes
* Forbid having too many variable in a tuple unpacking
* Add `noqa` tests and integration tests for #1437
* Update CHANGELOG.md
* Move `ImportMembersVisitor` into a separate file
(complexity/imports.py) due to complexity/count.py becoming too big


🙏 Please, if you or your company is finding wemake-python-styleguide valuable, help us sustain the project by sponsoring it transparently on https://opencollective.com/wemake-python-styleguide. As a thank you, your profile/company logo will be added to our main README which receives hundreds of unique visitors per day.
