### PR TITLE
Add rule forbidding `raise Exception` and `raise BaseException`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Semantic versioning in our case means:
 - Forbids to use single `return None`
 - Add `__await__` to the list of priority magic methods
 - Forbids to use float zeros (`0.0`)
+- Forbids `raise Exception` and `raise BaseException`
 
 ### Bugfixes
 

--- a/tests/fixtures/noqa/noqa.py
+++ b/tests/fixtures/noqa/noqa.py
@@ -712,3 +712,6 @@ for element in range(10):
         # https://github.com/wemake-services/wemake-python-styleguide/issues/1082
         break
     my_print(4)
+
+def raise_bad_exception():
+    raise Exception  # noqa: WPS454

--- a/tests/test_checker/test_noqa.py
+++ b/tests/test_checker/test_noqa.py
@@ -222,6 +222,7 @@ SHOULD_BE_RAISED = types.MappingProxyType({
     'WPS451': 0,  # defined in version specific table.
     'WPS452': 1,  # also defined in version specific table.
     'WPS453': 0,
+    'WPS454': 1,
 
     'WPS500': 1,
     'WPS501': 1,

--- a/tests/test_visitors/test_ast/test_keywords/test_raise.py
+++ b/tests/test_visitors/test_ast/test_keywords/test_raise.py
@@ -1,36 +1,37 @@
 import pytest
 
 from wemake_python_styleguide.violations.best_practices import (
+    BaseExceptionRaiseViolation,
     RaiseNotImplementedViolation,
 )
 from wemake_python_styleguide.visitors.ast.keywords import WrongRaiseVisitor
 
-raise_not_implemented_method = """
+raise_exception_method = """
 class CheckAbstractMethods():
-    def check_not_implemented(self):
+    def check_exception(self):
         raise {0}
 """
 
-raise_not_implemented_function = """
-def check_not_implemented_without_call():
+raise_exception_function = """
+def check_exception_without_call():
     raise {0}
 """
 
-raise_not_implemented_property = """
+raise_exception_property = """
 class CheckAbstractMethods():
     @property
-    def check_not_implemented(self):
+    def check_exception(self):
         raise {0}
 """
 
-raise_not_implemented_raw = 'raise {0}'
+raise_exception_raw = 'raise {0}'
 
 
 @pytest.mark.parametrize('code', [
-    raise_not_implemented_method,
-    raise_not_implemented_function,
-    raise_not_implemented_raw,
-    raise_not_implemented_property,
+    raise_exception_method,
+    raise_exception_function,
+    raise_exception_raw,
+    raise_exception_property,
 ])
 @pytest.mark.parametrize('exception', [
     'NotImplemented',
@@ -54,16 +55,18 @@ def test_raise_not_implemented(
 
 
 @pytest.mark.parametrize('code', [
-    raise_not_implemented_method,
-    raise_not_implemented_function,
-    raise_not_implemented_raw,
-    raise_not_implemented_property,
+    raise_exception_method,
+    raise_exception_function,
+    raise_exception_raw,
+    raise_exception_property,
 ])
 @pytest.mark.parametrize('exception', [
-    'NotImplementedError',
-    'NotImplementedError()',
+    'BaseException',
+    'BaseException()',
+    'Exception',
+    'Exception()',
 ])
-def test_raise_not_implemented_error(
+def test_raise_base_exception(
     assert_errors,
     parse_ast_tree,
     code,
@@ -71,7 +74,36 @@ def test_raise_not_implemented_error(
     default_options,
     mode,
 ):
-    """Testing that `raise NotImplementedError` is allowed."""
+    """Testing `raise BaseException` and `raise Exception` are restricted."""
+    tree = parse_ast_tree(mode(code.format(exception)))
+
+    visitor = WrongRaiseVisitor(default_options, tree=tree)
+    visitor.run()
+
+    assert_errors(visitor, [BaseExceptionRaiseViolation])
+
+
+@pytest.mark.parametrize('code', [
+    raise_exception_method,
+    raise_exception_function,
+    raise_exception_raw,
+    raise_exception_property,
+])
+@pytest.mark.parametrize('exception', [
+    'NotImplementedError',
+    'NotImplementedError()',
+    'UserDefinedError',
+    'UserDefinedError()',
+])
+def test_raise_good_errors(
+    assert_errors,
+    parse_ast_tree,
+    code,
+    exception,
+    default_options,
+    mode,
+):
+    """Testing that good `raise` usages are allowed."""
     tree = parse_ast_tree(mode(code.format(exception)))
 
     visitor = WrongRaiseVisitor(default_options, tree=tree)

--- a/wemake_python_styleguide/violations/best_practices.py
+++ b/wemake_python_styleguide/violations/best_practices.py
@@ -2136,5 +2136,5 @@ class BaseExceptionRaiseViolation(ASTViolation):
 
     """
 
-    error_template = 'Found wrong `raise` exception type: `{0}`'
+    error_template = 'Found wrong `raise` exception type: {0}'
     code = 454

--- a/wemake_python_styleguide/violations/best_practices.py
+++ b/wemake_python_styleguide/violations/best_practices.py
@@ -70,6 +70,7 @@ Summary
    PositionalOnlyArgumentsViolation
    LoopControlFinallyViolation
    ShebangViolation
+   BaseExceptionRaiseViolation
 
 Best practices
 --------------
@@ -128,6 +129,7 @@ Best practices
 .. autoclass:: PositionalOnlyArgumentsViolation
 .. autoclass:: LoopControlFinallyViolation
 .. autoclass:: ShebangViolation
+.. autoclass:: BaseExceptionRaiseViolation
 
 """
 
@@ -2100,3 +2102,39 @@ class ShebangViolation(SimpleViolation):
 
     error_template = 'Found executable mismatch: {0}'
     code = 453
+
+
+@final
+class BaseExceptionRaiseViolation(ASTViolation):
+    """
+    Forbids to raise ``Exception`` or ``BaseException``.
+
+    Reasoning:
+        ``Exception`` and ``BaseException`` are inconvenient to catch.
+        And when you catch them you can accidentally supress other exceptions.
+
+    Solution:
+        Use a user-defined exception, subclassed from ``Exception``.
+
+    Example::
+
+        # Correct:
+        raise UserNotFoundError
+        raise UserNotFoundError("cannot find user with the given id")
+
+        # Wrong:
+        raise Exception
+        raise Exception("user not found")
+        raise BaseException
+        raise BaseException("user not found")
+
+    See also:
+        https://docs.python.org/3/library/exceptions.html#exception-hierarchy
+        https://docs.python.org/3/tutorial/errors.html#user-defined-exceptions
+
+    .. versionadded:: 0.15.0
+
+    """
+
+    error_template = 'Found wrong `raise` exception type: `{0}`'
+    code = 454

--- a/wemake_python_styleguide/visitors/ast/keywords.py
+++ b/wemake_python_styleguide/visitors/ast/keywords.py
@@ -1,5 +1,5 @@
 import ast
-from typing import ClassVar, Dict, List, Optional, Type, Union, cast
+from typing import ClassVar, Dict, FrozenSet, List, Optional, Type, Union, cast
 
 from typing_extensions import final
 
@@ -18,6 +18,7 @@ from wemake_python_styleguide.logic.tree.variables import (
 )
 from wemake_python_styleguide.types import AnyFunctionDef, AnyNodes, AnyWith
 from wemake_python_styleguide.violations.best_practices import (
+    BaseExceptionRaiseViolation,
     ContextManagerVariableDefinitionViolation,
     RaiseNotImplementedViolation,
     WrongKeywordConditionViolation,
@@ -45,6 +46,11 @@ _ReturningViolations = Union[
 class WrongRaiseVisitor(BaseNodeVisitor):
     """Finds wrong ``raise`` keywords."""
 
+    _base_exceptions: ClassVar[FrozenSet[str]] = frozenset((
+        'Exception',
+        'BaseException',
+    ))
+
     def visit_Raise(self, node: ast.Raise) -> None:
         """
         Checks how ``raise`` keyword is used.
@@ -60,6 +66,10 @@ class WrongRaiseVisitor(BaseNodeVisitor):
         exception_name = get_exception_name(node)
         if exception_name == 'NotImplemented':
             self.add_violation(RaiseNotImplementedViolation(node))
+        elif exception_name in self._base_exceptions:
+            self.add_violation(
+                BaseExceptionRaiseViolation(node, text=exception_name),
+            )
 
 
 @final


### PR DESCRIPTION

# I have made things!


Add a new rule `BaseExceptionRaiseViolation` in best-practices section.
The rule is checked via `WrongRaiseVisitor`.

Add unit tests for `BaseExceptionRaiseViolation`. Put formerly existing
tests for `RaiseNotImplementedViolation` and and newly added tests into
a new file `test_keywords/test_raise.py`.

Add e2e tests to `noqa.py` and `test_noqa.py`.

Update`CHANGELOG.md`.

## Checklist

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made
- [x] I have added my changes to the `CHANGELOG.md`

## Related issues

Closes: issue #1523.
