### PR TITLE
Update wps329 docs

### DIFF
--- a/wemake_python_styleguide/violations/consistency.py
+++ b/wemake_python_styleguide/violations/consistency.py
@@ -1228,6 +1228,11 @@ class UselessExceptCaseViolation(ASTViolation):
             sentry.log()
             raise ValueError()
 
+        try:
+            ...
+        except ValueError as exc:
+            raise CustomReadableException from exc
+
         # Wrong:
         try:
             ...


### PR DESCRIPTION
# I have made things!

Related #1620

It's valid to raise an exception from another exception and do nothing else. For example `socket.gaierror` hard to read/understand.

Also, not many people know/use this python feature.
