### PR TITLE
Update summary strings for conciseness.

### DIFF
--- a/wemake_python_styleguide/violations/best_practices.py
+++ b/wemake_python_styleguide/violations/best_practices.py
@@ -145,7 +145,7 @@ from wemake_python_styleguide.violations.base import (
 @final
 class WrongMagicCommentViolation(SimpleViolation):
     """
-    Restricts to use various control (such as magic) comments.
+    Restrict various control (such as magic) comments.
 
     We do not allow to use:
 
@@ -193,7 +193,7 @@ class WrongMagicCommentViolation(SimpleViolation):
 @final
 class WrongDocCommentViolation(TokenizeViolation):
     """
-    Forbids to use empty doc comments (``#:``).
+    Forbid empty doc comments (``#:``).
 
     Reasoning:
         Doc comments are used to provide documentation.
@@ -226,7 +226,7 @@ class WrongDocCommentViolation(TokenizeViolation):
 @final
 class OveruseOfNoqaCommentViolation(SimpleViolation):
     """
-    Forbids to use too many ``# noqa`` comments.
+    Forbid too many ``# noqa`` comments.
 
     We count it on a per-module basis.
 
@@ -255,7 +255,7 @@ class OveruseOfNoqaCommentViolation(SimpleViolation):
 @final
 class OveruseOfNoCoverCommentViolation(SimpleViolation):
     """
-    Forbids to use too many ``# pragma: no cover`` comments.
+    Forbid too many ``# pragma: no cover`` comments.
 
     We count it on a per-module basis.
     We use :str:`wemake_python_styleguide.constants.MAX_NO_COVER_COMMENTS`
@@ -282,7 +282,7 @@ class OveruseOfNoCoverCommentViolation(SimpleViolation):
 @final
 class ComplexDefaultValueViolation(ASTViolation):
     """
-    Forbids to use complex defaults.
+    Forbid complex defaults.
 
     Anything that is not a ``ast.Name``, ``ast.Attribute``, ``ast.Str``,
     ``ast.NameConstant``, ``ast.Tuple``, ``ast.Bytes``, ``ast.Num``
@@ -317,7 +317,7 @@ class ComplexDefaultValueViolation(ASTViolation):
 @final
 class LoopVariableDefinitionViolation(ASTViolation):
     """
-    Forbids to use anything other than ``ast.Name`` to define loop variables.
+    Forbid anything other than ``ast.Name`` to define loop variables.
 
     Reasoning:
         When defining a ``for`` loop with attributes, indexes, calls,
@@ -351,7 +351,7 @@ class LoopVariableDefinitionViolation(ASTViolation):
 @final
 class ContextManagerVariableDefinitionViolation(ASTViolation):
     """
-    Forbids to use anything other than ``ast.Name`` to define contexts.
+    Forbid anything other than ``ast.Name`` to define contexts.
 
     Reasoning:
         When defining a ``with`` context managers with attributes,
@@ -385,7 +385,7 @@ class ContextManagerVariableDefinitionViolation(ASTViolation):
 @final
 class MutableModuleConstantViolation(ASTViolation):
     """
-    Forbids mutable constants on a module level.
+    Forbid mutable constants on a module level.
 
     Reasoning:
         Constants should be immutable.
@@ -422,7 +422,7 @@ class MutableModuleConstantViolation(ASTViolation):
 @final
 class SameElementsInConditionViolation(ASTViolation):
     """
-    Forbids to use the same logical conditions in one expression.
+    Forbid using the same logical conditions in one expression.
 
     Reasoning:
         Using the same name in a logical condition more than once
@@ -456,7 +456,7 @@ class SameElementsInConditionViolation(ASTViolation):
 @final
 class HeterogenousCompareViolation(ASTViolation):
     """
-    Forbids to heterogenous operators in one compare.
+    Forbid heterogenous operators in one comparison.
 
     Note, that we do allow mixing  ``>`` with ``>=``
     and ``<`` with ``<=`` operators.
@@ -497,7 +497,7 @@ class HeterogenousCompareViolation(ASTViolation):
 @final
 class WrongModuleMetadataViolation(ASTViolation):
     """
-    Forbids to have some module-level variables.
+    Forbid some module-level variables.
 
     Reasoning:
         We discourage using module variables like ``__author__``,
@@ -531,7 +531,7 @@ class WrongModuleMetadataViolation(ASTViolation):
 @final
 class EmptyModuleViolation(SimpleViolation):
     """
-    Forbids to have empty modules.
+    Forbid empty modules.
 
     Reasoning:
         Why is it even there? Do not pollute your project with empty files.
@@ -553,7 +553,7 @@ class EmptyModuleViolation(SimpleViolation):
 @final
 class InitModuleHasLogicViolation(SimpleViolation):
     """
-    Forbids to have logic inside ``__init__`` module.
+    Forbid logic inside ``__init__`` module.
 
     Reasoning:
         If you have logic inside the ``__init__`` module
@@ -593,7 +593,7 @@ class InitModuleHasLogicViolation(SimpleViolation):
 @final
 class BadMagicModuleFunctionViolation(ASTViolation):
     """
-    Forbids to use ``__getattr__`` and ``__dir__`` module magic methods.
+    Forbid ``__getattr__`` and ``__dir__`` module magic methods.
 
     Reasoning:
         It does not bring any features,
@@ -619,7 +619,7 @@ class BadMagicModuleFunctionViolation(ASTViolation):
 @final
 class WrongUnpackingViolation(ASTViolation):
     """
-    Forbids to have tuple unpacking with side-effects.
+    Forbid tuple unpacking with side-effects.
 
     Reasoning:
         Having unpacking with side-effects is very dirty.
@@ -650,7 +650,7 @@ class WrongUnpackingViolation(ASTViolation):
 @final
 class DuplicateExceptionViolation(ASTViolation):
     """
-    Forbids to have the same exception class in multiple ``except`` blocks.
+    Forbid the same exception class in multiple ``except`` blocks.
 
     Reasoning:
         Having the same exception name in different blocks means
@@ -689,7 +689,7 @@ class DuplicateExceptionViolation(ASTViolation):
 @final
 class YieldInComprehensionViolation(ASTViolation):
     """
-    Forbids to have ``yield`` keyword inside comprehensions.
+    Forbid ``yield`` keyword inside comprehensions.
 
     This is a ``SyntaxError`` starting from ``python3.8``.
 
@@ -727,7 +727,7 @@ class YieldInComprehensionViolation(ASTViolation):
 @final
 class NonUniqueItemsInHashViolation(ASTViolation):
     """
-    Forbids to have duplicate items in hashes.
+    Forbid duplicate items in hashes.
 
     Reasoning:
         When you explicitly put duplicate items
@@ -769,7 +769,7 @@ class NonUniqueItemsInHashViolation(ASTViolation):
 @final
 class BaseExceptionSubclassViolation(ASTViolation):
     """
-    Forbids to have exception inherited from ``BaseException``.
+    Forbid exceptions inherited from ``BaseException``.
 
     Reasoning:
         ``BaseException`` is a special case:
@@ -806,7 +806,7 @@ class BaseExceptionSubclassViolation(ASTViolation):
 @final
 class TryExceptMultipleReturnPathViolation(ASTViolation):
     """
-    Forbids to use multiple returning paths with ``try`` / ``except`` case.
+    Forbid multiple returning paths with ``try`` / ``except`` case.
 
     Note, that we check for any ``return``, ``break``, or ``raise`` nodes.
 
@@ -862,7 +862,7 @@ class TryExceptMultipleReturnPathViolation(ASTViolation):
 @final
 class WrongKeywordViolation(ASTViolation):
     """
-    Forbids to use some ``python`` keywords.
+    Forbid some ``python`` keywords.
 
     Reasoning:
         Using some keywords generally gives you more pain than relieves.
@@ -898,7 +898,7 @@ class WrongKeywordViolation(ASTViolation):
 @final
 class WrongFunctionCallViolation(ASTViolation):
     """
-    Forbids to call some built-in functions.
+    Forbid calling some built-in functions.
 
     Reasoning:
         Some functions are only suitable
@@ -923,7 +923,7 @@ class WrongFunctionCallViolation(ASTViolation):
 @final
 class FutureImportViolation(ASTViolation):
     """
-    Forbids to use ``__future__`` imports.
+    Forbid ``__future__`` imports.
 
     Reasoning:
         Almost all ``__future__`` imports are legacy ``python2`` compatibility
@@ -956,7 +956,7 @@ class FutureImportViolation(ASTViolation):
 @final
 class RaiseNotImplementedViolation(ASTViolation):
     """
-    Forbids to use ``NotImplemented`` error.
+    Forbid ``NotImplemented`` exception.
 
     Reasoning:
         These two exceptions look similar.
@@ -989,7 +989,7 @@ class RaiseNotImplementedViolation(ASTViolation):
 @final
 class BaseExceptionViolation(ASTViolation):
     """
-    Forbids to use ``BaseException`` exception.
+    Forbid ``BaseException`` exception.
 
     Reasoning:
         We can silence system exit and keyboard interrupt
@@ -1024,7 +1024,7 @@ class BaseExceptionViolation(ASTViolation):
 @final
 class BooleanPositionalArgumentViolation(ASTViolation):
     """
-    Forbids to pass booleans as non-keyword parameters.
+    Forbid booleans as non-keyword parameters.
 
     Reasoning:
         Passing boolean as regular positional parameters
@@ -1061,7 +1061,7 @@ class BooleanPositionalArgumentViolation(ASTViolation):
 @final
 class LambdaInsideLoopViolation(ASTViolation):
     """
-    Forbids to use ``lambda`` inside loops.
+    Forbid ``lambda`` inside loops.
 
     We check ``while``, ``for``, and ``async for`` loop bodies.
     We also check comprehension value parts.
@@ -1102,7 +1102,7 @@ class LambdaInsideLoopViolation(ASTViolation):
 @final
 class UnreachableCodeViolation(ASTViolation):
     """
-    Forbids to have unreachable code.
+    Forbid unreachable code.
 
     What is unreachable code? It is some lines of code that
     cannot be executed by python's interpreter.
@@ -1148,7 +1148,7 @@ class UnreachableCodeViolation(ASTViolation):
 @final
 class StatementHasNoEffectViolation(ASTViolation):
     """
-    Forbids to have statements that do nothing.
+    Forbid statements that do nothing.
 
     Reasoning:
         Statements that just access the value or expressions
@@ -1184,7 +1184,7 @@ class StatementHasNoEffectViolation(ASTViolation):
 @final
 class MultipleAssignmentsViolation(ASTViolation):
     """
-    Forbids to have multiple assignments on the same line.
+    Forbid multiple assignments on the same line.
 
     Reasoning:
         Multiple assignments on the same line might not do what you think
@@ -1216,7 +1216,7 @@ class MultipleAssignmentsViolation(ASTViolation):
 @final
 class NestedFunctionViolation(ASTViolation):
     """
-    Forbids to have nested functions.
+    Forbid nested functions.
 
     Reasoning:
         Nesting functions is bad practice.
@@ -1256,7 +1256,7 @@ class NestedFunctionViolation(ASTViolation):
 @final
 class NestedClassViolation(ASTViolation):
     """
-    Forbids to use nested classes.
+    Forbid nested classes.
 
     Reasoning:
         Nested classes are really hard to manage.
@@ -1296,9 +1296,9 @@ class NestedClassViolation(ASTViolation):
 @final
 class MagicNumberViolation(ASTViolation):
     """
-    Forbids to use magic numbers in your code.
+    Forbid magic numbers.
 
-    What we call a "magic number"? Well, it is actually any number that
+    What do we call a "magic number"? Well, it is actually any number that
     appears in your code out of nowhere. Like ``42``. Or ``0.32``.
 
     Reasoning:
@@ -1341,7 +1341,7 @@ class MagicNumberViolation(ASTViolation):
 @final
 class NestedImportViolation(ASTViolation):
     """
-    Forbids to have nested imports in functions.
+    Forbid imports nested in functions.
 
     Reasoning:
         Usually, nested imports are used to fix the import cycle.
@@ -1379,7 +1379,7 @@ class NestedImportViolation(ASTViolation):
 @final
 class ReassigningVariableToItselfViolation(ASTViolation):
     """
-    Forbids to assign variable to itself.
+    Forbid assigning a variable to itself.
 
     Reasoning:
         There is no need to do that.
@@ -1408,7 +1408,7 @@ class ReassigningVariableToItselfViolation(ASTViolation):
 @final
 class ListMultiplyViolation(ASTViolation):
     """
-    Forbids to multiply lists.
+    Forbid multiplying lists.
 
     Reasoning:
         When you multiply lists - it does not create new values,
@@ -1437,7 +1437,7 @@ class ListMultiplyViolation(ASTViolation):
 @final
 class ProtectedModuleViolation(ASTViolation):
     """
-    Forbids to import protected modules.
+    Forbid importing protected modules.
 
     Related to :class:`~ProtectedModuleMemberViolation`.
 
@@ -1475,7 +1475,7 @@ class ProtectedModuleViolation(ASTViolation):
 @final
 class ProtectedAttributeViolation(ASTViolation):
     """
-    Forbids to use protected attributes and methods.
+    Forbid protected attributes and methods.
 
     Reasoning:
         When using protected attributes and method we break a contract
@@ -1519,7 +1519,7 @@ class ProtectedAttributeViolation(ASTViolation):
 @final
 class StopIterationInsideGeneratorViolation(ASTViolation):
     """
-    Forbids to raise ``StopIteration`` inside generators.
+    Forbid raising ``StopIteration`` inside generators.
 
     Reasoning:
         ``StopIteration`` should not be raised explicitly in generators.
@@ -1555,7 +1555,7 @@ class StopIterationInsideGeneratorViolation(ASTViolation):
 @final
 class WrongUnicodeEscapeViolation(TokenizeViolation):
     r"""
-    Forbids to use Unicode escape sequences in binary strings.
+    Forbid Unicode escape sequences in binary strings.
 
     Reasoning:
         Binary strings do not work with Unicode.
@@ -1584,7 +1584,7 @@ class WrongUnicodeEscapeViolation(TokenizeViolation):
 @final
 class BlockAndLocalOverlapViolation(ASTViolation):
     """
-    Forbids to local and block variables to overlap.
+    Forbid overlapping local and block variables.
 
     What we call local variables:
 
@@ -1626,7 +1626,7 @@ class BlockAndLocalOverlapViolation(ASTViolation):
 @final
 class ControlVarUsedAfterBlockViolation(ASTViolation):
     """
-    Forbids to use control variables after the block body.
+    Forbid control variables after the block body.
 
     What we call block control variables:
 
@@ -1668,7 +1668,7 @@ class ControlVarUsedAfterBlockViolation(ASTViolation):
 @final
 class OuterScopeShadowingViolation(ASTViolation):
     """
-    Forbids to shadow variables from outer scopes.
+    Forbid shadowing variables from outer scopes.
 
     We check the function, method, and module scopes.
     While we do not check the class scope. Because class level constants
@@ -1707,7 +1707,7 @@ class OuterScopeShadowingViolation(ASTViolation):
 @final
 class UnhashableTypeInHashViolation(ASTViolation):
     """
-    Forbids to use explicit unhashable types of asset items and dict keys.
+    Forbid explicit unhashable types of asset items and dict keys.
 
     Reasoning:
         This will resolve in ``TypeError`` in runtime.
@@ -1734,7 +1734,7 @@ class UnhashableTypeInHashViolation(ASTViolation):
 @final
 class WrongKeywordConditionViolation(ASTViolation):
     """
-    Forbids to use explicit falsely-evaluated conditions with several keywords.
+    Forbid explicit falsely-evaluated conditions with several keywords.
 
     We check:
 
@@ -1777,10 +1777,10 @@ class WrongKeywordConditionViolation(ASTViolation):
 @final
 class WrongNamedKeywordViolation(ASTViolation):
     """
-    Forbids to have incorrectly named keywords in the starred dicts.
+    Forbid incorrectly named keywords in starred dicts.
 
     Reasoning:
-        Using the incorrect keywords in the starred dict.
+        Using the incorrect keywords in a starred dict.
         Eg.: ``print(**{'@': 1})``.
 
     Solution:
@@ -1805,7 +1805,7 @@ class WrongNamedKeywordViolation(ASTViolation):
 @final
 class ApproximateConstantViolation(ASTViolation):
     """
-    Forbids to use approximate constants.
+    Forbid approximate constants.
 
     Reasoning:
         Some constants are already defined.
@@ -1844,7 +1844,7 @@ class ApproximateConstantViolation(ASTViolation):
 @final
 class StringConstantRedefinedViolation(ASTViolation):
     """
-    Forbid to use the alphabet as a string.
+    Forbid using the alphabet as a string.
 
     Reasoning:
         Some constants are already defined.
@@ -1878,7 +1878,7 @@ class StringConstantRedefinedViolation(ASTViolation):
 @final
 class IncorrectExceptOrderViolation(ASTViolation):
     """
-    Forbids the use of incorrect order of ``except``.
+    Forbid incorrect order of ``except``.
 
     Note, we only check for built-in exceptions.
     Because we cannot statically identify
@@ -1923,7 +1923,7 @@ class IncorrectExceptOrderViolation(ASTViolation):
 @final
 class FloatKeyViolation(ASTViolation):
     """
-    Forbids to define and use ``float`` keys.
+    Forbid ``float`` keys.
 
     Reasoning:
         ``float`` is a very ugly data type.
@@ -1955,7 +1955,7 @@ class FloatKeyViolation(ASTViolation):
 @final
 class ProtectedModuleMemberViolation(ASTViolation):
     """
-    Forbids to import protected objects from modules.
+    Forbid importing protected objects from modules.
 
     Related to :class:`~ProtectedModuleViolation`.
 
@@ -1988,7 +1988,7 @@ class ProtectedModuleMemberViolation(ASTViolation):
 @final
 class PositionalOnlyArgumentsViolation(ASTViolation):
     """
-    Forbids to use positional only or ``/`` arguments.
+    Forbid positional only or ``/`` arguments.
 
     This violation is only raised for ``python3.8+``,
     earlier versions do not have this concept.
@@ -2027,7 +2027,7 @@ class PositionalOnlyArgumentsViolation(ASTViolation):
 
 class LoopControlFinallyViolation(ASTViolation):
     """
-    Forbids to use ``break`` and ``continue`` in ``finally`` case.
+    Forbid ``break`` and ``continue`` in a ``finally`` block.
 
     Related to :class:`~TryExceptMultipleReturnPathViolation`.
 
@@ -2071,7 +2071,7 @@ class LoopControlFinallyViolation(ASTViolation):
 @final
 class ShebangViolation(SimpleViolation):
     """
-    Forbids to execute the file with shebang incorrectly set.
+    Forbid executing a file with shebang incorrectly set.
 
     A violation is raised in these cases :
         - Shebang is present but the file is not executable.
@@ -2107,7 +2107,7 @@ class ShebangViolation(SimpleViolation):
 @final
 class BaseExceptionRaiseViolation(ASTViolation):
     """
-    Forbids to raise ``Exception`` or ``BaseException``.
+    Forbid raising ``Exception`` or ``BaseException``.
 
     Reasoning:
         ``Exception`` and ``BaseException`` are inconvenient to catch.

--- a/wemake_python_styleguide/violations/complexity.py
+++ b/wemake_python_styleguide/violations/complexity.py
@@ -113,7 +113,7 @@ from wemake_python_styleguide.violations.base import (
 @final
 class JonesScoreViolation(SimpleViolation):
     """
-    Forbids to have modules with complex lines.
+    Forbid modules with complex lines.
 
     We are using Jones Complexity algorithm to count module's score.
     See
@@ -146,7 +146,7 @@ class JonesScoreViolation(SimpleViolation):
 @final
 class TooManyImportsViolation(SimpleViolation):
     """
-    Forbids to have modules with too many imports.
+    Forbid modules with too many imports.
 
     Namespaces are one honking great idea -- let's do more of those!
 
@@ -185,7 +185,7 @@ class TooManyImportsViolation(SimpleViolation):
 @final
 class TooManyModuleMembersViolation(SimpleViolation):
     """
-    Forbids to have many classes and functions in a single module.
+    Forbid too many classes and functions in a single module.
 
     Reasoning:
         Having many classes and functions in a single module is a bad thing.
@@ -215,7 +215,7 @@ class TooManyModuleMembersViolation(SimpleViolation):
 @final
 class TooManyImportedNamesViolation(SimpleViolation):
     """
-    Forbids to have modules with too many imported names.
+    Forbid modules with too many imported names.
 
     Namespaces are one honking great idea -- let's do more of those!
 
@@ -263,7 +263,7 @@ class TooManyImportedNamesViolation(SimpleViolation):
 @final
 class OverusedExpressionViolation(ASTViolation):
     """
-    Forbids to have overused expressions in a module, function or method.
+    Forbid overused expressions in a module, function or method.
 
     What do we call an "overused expression"? When you use any expression
     (like ``user_dict['age']`` for example) inside your code,
@@ -308,7 +308,7 @@ class OverusedExpressionViolation(ASTViolation):
 @final
 class TooManyLocalsViolation(ASTViolation):
     """
-    Forbids to have too many local variables in the unit of code.
+    Forbid too many local variables in the unit of code.
 
     Reasoning:
         Having too many variables in a single function is a bad thing.
@@ -359,7 +359,7 @@ class TooManyLocalsViolation(ASTViolation):
 @final
 class TooManyArgumentsViolation(ASTViolation):
     """
-    Forbids to have too many arguments for a function or method.
+    Forbid too many arguments for a function or method.
 
     Reasoning:
         This is an indicator of a bad design. When a function requires many
@@ -385,7 +385,7 @@ class TooManyArgumentsViolation(ASTViolation):
 @final
 class TooManyReturnsViolation(ASTViolation):
     """
-    Forbids placing too many ``return`` statements into the function.
+    Forbid placing too many ``return`` statements into the function.
 
     Reasoning:
         When there are too many ``return`` keywords,
@@ -410,7 +410,7 @@ class TooManyReturnsViolation(ASTViolation):
 @final
 class TooManyExpressionsViolation(ASTViolation):
     """
-    Forbids putting too many expressions in a single function.
+    Forbid putting too many expressions in a single function.
 
     This rule is quite similar to "max lines" in a function,
     but is much nicer. Because we don't count lines,
@@ -445,7 +445,7 @@ class TooManyExpressionsViolation(ASTViolation):
 @final
 class TooManyMethodsViolation(ASTViolation):
     """
-    Forbids to have many methods in a single class.
+    Forbid too many methods in a single class.
 
     Reasoning:
         Having too many methods might lead to the "God object".
@@ -561,7 +561,7 @@ class TooManyDecoratorsViolation(ASTViolation):
 @final
 class TooManyAwaitsViolation(ASTViolation):
     """
-    Forbids placing too many ``await`` expressions into a function.
+    Forbid placing too many ``await`` expressions into a function.
 
     Reasoning:
         When there are too many ``await`` keywords,
@@ -586,7 +586,7 @@ class TooManyAwaitsViolation(ASTViolation):
 @final
 class TooManyAssertsViolation(ASTViolation):
     """
-    Forbids placing too many ``assert`` statements into a function.
+    Forbid placing too many ``assert`` statements into a function.
 
     Reasoning:
         When there are too many ``assert`` keywords,
@@ -612,7 +612,7 @@ class TooManyAssertsViolation(ASTViolation):
 @final
 class TooDeepAccessViolation(ASTViolation):
     """
-    Forbids to have consecutive expressions with too deep access level.
+    Forbid consecutive expressions with too deep access level.
 
     We consider only these expressions as accesses:
 
@@ -664,7 +664,7 @@ class TooDeepAccessViolation(ASTViolation):
 @final
 class TooDeepNestingViolation(ASTViolation):
     """
-    Forbids nesting blocks too deep.
+    Forbid nesting blocks too deep.
 
     Reasoning:
         If nesting is too deep that indicates usage of complex logic
@@ -687,7 +687,7 @@ class TooDeepNestingViolation(ASTViolation):
 @final
 class LineComplexityViolation(ASTViolation):
     """
-    Forbids to have complex lines.
+    Forbid complex lines.
 
     We are using Jones Complexity algorithm to count complexity.
     What is Jones Complexity? It is a simple yet powerful method to count
@@ -732,7 +732,7 @@ class LineComplexityViolation(ASTViolation):
 @final
 class TooManyConditionsViolation(ASTViolation):
     """
-    Forbids to have conditions with too many logical operators.
+    Forbid conditions with too many logical operators.
 
     We use :str:`wemake_python_styleguide.constants.MAX_CONDITIONS`
     as a default value.
@@ -761,7 +761,7 @@ class TooManyConditionsViolation(ASTViolation):
 @final
 class TooManyElifsViolation(ASTViolation):
     """
-    Forbids to use many ``elif`` branches.
+    Forbid too many ``elif`` branches.
 
     We use :str:`wemake_python_styleguide.constants.MAX_ELIFS`
     as a default value.
@@ -789,7 +789,7 @@ class TooManyElifsViolation(ASTViolation):
 @final
 class TooManyForsInComprehensionViolation(ASTViolation):
     """
-    Forbids to have too many ``for`` statement within a comprehension.
+    Forbid too many ``for`` statements within a comprehension.
 
     Reasoning:
         When reading through the complex comprehension you will fail
@@ -821,7 +821,7 @@ class TooManyForsInComprehensionViolation(ASTViolation):
 @final
 class TooManyExceptCasesViolation(ASTViolation):
     """
-    Forbids to have too many ``except`` cases in a single ``try`` clause.
+    Forbid too many ``except`` cases in a single ``try`` clause.
 
     We use :str:`wemake_python_styleguide.constants.MAX_EXCEPT_CASES`
     as a default value.
@@ -848,7 +848,7 @@ class TooManyExceptCasesViolation(ASTViolation):
 @final
 class OverusedStringViolation(MaybeASTViolation):
     """
-    Forbids to over-use string constants.
+    Forbid overuse of string constants.
 
     We allow to use strings without any restrictions as annotations for
     variables, arguments, return values, and class attributes.
@@ -878,7 +878,7 @@ class OverusedStringViolation(MaybeASTViolation):
 @final
 class TooLongYieldTupleViolation(ASTViolation):
     """
-    Forbids to yield too long tuples.
+    Forbid yielding too long tuples.
 
     Reasoning:
         Long yield tuples complicate generator using.
@@ -898,7 +898,7 @@ class TooLongYieldTupleViolation(ASTViolation):
 @final
 class TooLongCompareViolation(ASTViolation):
     """
-    Forbids to have too long compare expressions.
+    Forbid too long compare expressions.
 
     Reasoning:
         To long compare expressions indicate
@@ -919,7 +919,7 @@ class TooLongCompareViolation(ASTViolation):
 @final
 class TooLongTryBodyViolation(ASTViolation):
     """
-    Forbids to have ``try`` blocks with too long bodies.
+    Forbid ``try`` blocks with too long bodies.
 
     Reasoning:
         Having too many statements inside your ``try`` block
@@ -951,7 +951,7 @@ class TooLongTryBodyViolation(ASTViolation):
 @final
 class TooManyPublicAttributesViolation(ASTViolation):
     """
-    Forbids to have instances with too many public attributes.
+    Forbid instances with too many public attributes.
 
     We only check static definitions in a form of ``self.public = ...``.
     We do not count parent attributes.
@@ -990,7 +990,7 @@ class TooManyPublicAttributesViolation(ASTViolation):
 @final
 class CognitiveComplexityViolation(ASTViolation):
     """
-    Forbids to have functions with too high cognitive complexity.
+    Forbid functions with too high cognitive complexity.
 
     Reasoning:
         People are not great at reading and iterpretating code in their heads.
@@ -1023,7 +1023,7 @@ class CognitiveComplexityViolation(ASTViolation):
 @final
 class CognitiveModuleComplexityViolation(SimpleViolation):
     """
-    Forbids to have modules with too high average cognitive complexity.
+    Forbid modules with too high average cognitive complexity.
 
     Reasoning:
         Modules with lots of functions might hide cognitive complexity
@@ -1052,7 +1052,7 @@ class CognitiveModuleComplexityViolation(SimpleViolation):
 @final
 class TooLongCallChainViolation(ASTViolation):
     """
-    Forbids too long call chains.
+    Forbid too long call chains.
 
     Reasoning:
         Too long call chains are overcomplicated and
@@ -1078,7 +1078,7 @@ class TooLongCallChainViolation(ASTViolation):
 @final
 class TooComplexAnnotationViolation(ASTViolation):
     """
-    Forbids too complex annotations.
+    Forbid too complex annotations.
 
     Annotation complexity is maximum annotation nesting level.
     Example: ``List[int]`` has complexity of 2
@@ -1111,7 +1111,7 @@ class TooComplexAnnotationViolation(ASTViolation):
 @final
 class TooManyImportedModuleMembersViolation(ASTViolation):
     """
-    Forbids ``from ... import ...`` with too many imported names.
+    Forbid ``from ... import ...`` with too many imported names.
 
     Reasoning:
         Importing too many names from one import is easy way to cause
@@ -1146,7 +1146,7 @@ class TooManyImportedModuleMembersViolation(ASTViolation):
 @final
 class TooLongTupleUnpackViolation(ASTViolation):
     """
-    Forbids using too many variables to unpack a tuple.
+    Forbid using too many variables to unpack a tuple.
 
     Reasoning:
         The order and meaning are hard to remember.

--- a/wemake_python_styleguide/violations/consistency.py
+++ b/wemake_python_styleguide/violations/consistency.py
@@ -159,7 +159,7 @@ from wemake_python_styleguide.violations.base import (
 @final
 class LocalFolderImportViolation(ASTViolation):
     """
-    Forbids to have imports relative to the current folder.
+    Forbid imports relative to the current folder.
 
     Reasoning:
         We should pick one style and stick to it.
@@ -188,7 +188,7 @@ class LocalFolderImportViolation(ASTViolation):
 @final
 class DottedRawImportViolation(ASTViolation):
     """
-    Forbids to use imports like ``import os.path``.
+    Forbid imports like ``import os.path``.
 
     Reasoning:
         There too many different ways to import something.
@@ -217,10 +217,10 @@ class DottedRawImportViolation(ASTViolation):
 @final
 class UnicodeStringViolation(TokenizeViolation):
     """
-    Forbids to use ``u`` string prefix.
+    Forbid ``u`` string prefix.
 
     Reasoning:
-        We do not need this prefix since ``python2``.
+        We haven't needed this prefix since ``python2``.
         But, it is still possible to find it inside the codebase.
 
     Solution:
@@ -246,7 +246,7 @@ class UnicodeStringViolation(TokenizeViolation):
 @final
 class UnderscoredNumberViolation(TokenizeViolation):
     """
-    Forbids to use underscores (``_``) in numbers.
+    Forbid underscores (``_``) in numbers.
 
     Reasoning:
         It is possible to write ``1000`` in three different ways:
@@ -281,7 +281,7 @@ class UnderscoredNumberViolation(TokenizeViolation):
 @final
 class PartialFloatViolation(TokenizeViolation):
     """
-    Forbids to use partial floats like ``.05`` or ``23.``.
+    Forbid partial floats like ``.05`` or ``23.``.
 
     Reasoning:
         Partial numbers are hard to read and they can be confused with
@@ -313,7 +313,7 @@ class PartialFloatViolation(TokenizeViolation):
 @final
 class FormattedStringViolation(ASTViolation):
     """
-    Forbids to use ``f`` strings.
+    Forbid ``f`` strings.
 
     Reasoning:
         ``f`` strings implicitly rely on the context around it.
@@ -351,7 +351,7 @@ class FormattedStringViolation(ASTViolation):
 @final
 class RequiredBaseClassViolation(ASTViolation):
     """
-    Forbids to write classes without base classes.
+    Forbid writing classes without base classes.
 
     Please, note that this rule has nothing to do with ``python2``.
     We care only about consistency here.
@@ -387,7 +387,7 @@ class RequiredBaseClassViolation(ASTViolation):
 @final
 class MultipleIfsInComprehensionViolation(ASTViolation):
     """
-    Forbids to have multiple ``if`` statements inside list comprehensions.
+    Forbid multiple ``if`` statements inside list comprehensions.
 
     Reasoning:
         It is very hard to read multiple ``if`` statements inside
@@ -417,7 +417,7 @@ class MultipleIfsInComprehensionViolation(ASTViolation):
 @final
 class ConstantCompareViolation(ASTViolation):
     """
-    Forbids to have compares between two literals.
+    Forbid comparing between two literals.
 
     Reasoning:
         When two constants are compared it is typically an indication of a
@@ -449,7 +449,7 @@ class ConstantCompareViolation(ASTViolation):
 @final
 class CompareOrderViolation(ASTViolation):
     """
-    Forbids comparison where argument doesn't come first.
+    Forbid comparisons where argument doesn't come first.
 
     Reasoning:
         It is hard to read the code when
@@ -479,7 +479,7 @@ class CompareOrderViolation(ASTViolation):
 @final
 class BadNumberSuffixViolation(TokenizeViolation):
     """
-    Forbids to use capital ``X``, ``O``, ``B``, and ``E`` in numbers.
+    Forbid uppercase ``X``, ``O``, ``B``, and ``E`` in numbers.
 
     Reasoning:
         Octal, hex, binary and scientific notation suffixes could
@@ -517,7 +517,7 @@ class BadNumberSuffixViolation(TokenizeViolation):
 @final
 class MultipleInCompareViolation(ASTViolation):
     """
-    Forbids comparison where multiple ``in`` checks.
+    Forbid comparisons with multiple ``in`` checks.
 
     Reasoning:
         Using multiple ``in`` is unreadable.
@@ -548,7 +548,7 @@ class MultipleInCompareViolation(ASTViolation):
 @final
 class UselessCompareViolation(ASTViolation):
     """
-    Forbids to have compares between the same variable.
+    Forbid comparisons between the same variable.
 
     Reasoning:
         When the same variables are compared it is typically an indication
@@ -580,7 +580,7 @@ class UselessCompareViolation(ASTViolation):
 @final
 class MissingSpaceBetweenKeywordAndParenViolation(TokenizeViolation):
     """
-    Enforces to separate parenthesis from the keywords with spaces.
+    Enforce separation of parenthesis from the keywords with spaces.
 
     Reasoning:
         Some people use ``return`` and ``yield`` keywords as functions.
@@ -615,7 +615,7 @@ class MissingSpaceBetweenKeywordAndParenViolation(TokenizeViolation):
 @final
 class ConstantConditionViolation(ASTViolation):
     """
-    Forbids using ``if`` statements that use invalid conditionals.
+    Forbid using ``if`` statements that use invalid conditionals.
 
     Reasoning:
         When invalid conditional arguments are used
@@ -644,7 +644,7 @@ class ConstantConditionViolation(ASTViolation):
 @final
 class ObjectInBaseClassesListViolation(ASTViolation):
     """
-    Forbids extra ``object`` in parent classes list.
+    Forbid extra ``object`` in parent classes list.
 
     Reasoning:
         We should allow object only when
@@ -675,7 +675,7 @@ class ObjectInBaseClassesListViolation(ASTViolation):
 @final
 class MultipleContextManagerAssignmentsViolation(ASTViolation):
     """
-    Forbids multiple assignment targets for context managers.
+    Forbid multiple assignment targets for context managers.
 
     Reasoning:
         It is hard to distinguish whether ``as`` should unpack into
@@ -709,7 +709,7 @@ class MultipleContextManagerAssignmentsViolation(ASTViolation):
 @final
 class ParametersIndentationViolation(ASTViolation):
     """
-    Forbids to use incorrect parameters indentation.
+    Forbid incorrect indentation for parameters.
 
     Reasoning:
         It is really easy to spoil your perfect, readable code with
@@ -785,7 +785,7 @@ class ParametersIndentationViolation(ASTViolation):
 @final
 class ExtraIndentationViolation(TokenizeViolation):
     """
-    Forbids to use extra indentation.
+    Forbid extra indentation.
 
     Reasoning:
         You can use extra indentation for lines of code.
@@ -826,7 +826,7 @@ class ExtraIndentationViolation(TokenizeViolation):
 @final
 class WrongBracketPositionViolation(TokenizeViolation):
     """
-    Forbids to have brackets in the wrong position.
+    Forbid brackets in the wrong position.
 
     Reasoning:
         You can do bizzare things with bracket positioning in python.
@@ -879,7 +879,7 @@ class WrongBracketPositionViolation(TokenizeViolation):
 @final
 class MultilineFunctionAnnotationViolation(ASTViolation):
     """
-    Forbids to use multi-line function type annotations.
+    Forbid multi-line function type annotations.
 
     Reasoning:
         Functions with multi-line type annotations are unreadable.
@@ -913,7 +913,7 @@ class MultilineFunctionAnnotationViolation(ASTViolation):
 @final
 class UppercaseStringModifierViolation(TokenizeViolation):
     """
-    Forbids to use uppercase string modifiers.
+    Forbid uppercase string modifiers.
 
     Reasoning:
         String modifiers should be consistent.
@@ -942,7 +942,7 @@ class UppercaseStringModifierViolation(TokenizeViolation):
 @final
 class WrongMultilineStringViolation(TokenizeViolation):
     '''
-    Forbids to use triple quotes for singleline strings.
+    Forbid triple quotes for singleline strings.
 
     Reasoning:
         String quotes should be consistent.
@@ -978,7 +978,7 @@ class WrongMultilineStringViolation(TokenizeViolation):
 @final
 class ModuloStringFormatViolation(ASTViolation):
     """
-    Forbids to use ``%`` formatting on strings.
+    Forbid ``%`` formatting on strings.
 
     We check for string formatting. We try not to issue false positives.
     It is better for us to ignore a real (but hard to detect) case,
@@ -1022,7 +1022,7 @@ class ModuloStringFormatViolation(ASTViolation):
 @final
 class InconsistentReturnViolation(ASTViolation):
     """
-    Enforces to have consistent ``return`` statements.
+    Enforce consistent ``return`` statements.
 
     Rules are:
     1. if any ``return`` has a value, all ``return`` nodes should have a value
@@ -1065,7 +1065,7 @@ class InconsistentReturnViolation(ASTViolation):
 @final
 class InconsistentYieldViolation(ASTViolation):
     """
-    Enforces to have consistent ``yield`` statements.
+    Enforce consistent ``yield`` statements.
 
     Rules are:
     1. if any ``yield`` has a value, all ``yield`` nodes should have a value
@@ -1106,7 +1106,7 @@ class InconsistentYieldViolation(ASTViolation):
 @final
 class ImplicitStringConcatenationViolation(TokenizeViolation):
     """
-    Forbids to use implicit string concatenation.
+    Forbid implicit string concatenation.
 
     Reasoning:
         This is error-prone, since you can possibly miss a comma
@@ -1136,15 +1136,15 @@ class ImplicitStringConcatenationViolation(TokenizeViolation):
 @final
 class UselessContinueViolation(ASTViolation):
     """
-    Forbids to use meaningless ``continue`` node in loops.
+    Forbid meaningless ``continue`` in loops.
 
     Reasoning:
-        Placing this keyword in the end of any loop won't make any difference
+        Placing this keyword at the end of any loop won't make any difference
         to your code. And we prefer not to have meaningless
         constructs in our code.
 
     Solution:
-        Remove useless ``continue`` node from the loop.
+        Remove useless ``continue`` from the loop.
 
     Example::
 
@@ -1180,7 +1180,7 @@ class UselessContinueViolation(ASTViolation):
 @final
 class UselessNodeViolation(ASTViolation):
     """
-    Forbids to use meaningless nodes.
+    Forbid meaningless nodes.
 
     Reasoning:
         Some nodes might be completely useless. They will literally do nothing.
@@ -1208,7 +1208,7 @@ class UselessNodeViolation(ASTViolation):
 @final
 class UselessExceptCaseViolation(ASTViolation):
     """
-    Forbids to use meaningless ``except`` cases.
+    Forbid meaningless ``except`` cases.
 
     Reasoning:
         Using ``except`` cases that just reraise the same exception
@@ -1250,7 +1250,7 @@ class UselessExceptCaseViolation(ASTViolation):
 @final
 class UselessOperatorsViolation(ASTViolation):
     """
-    Forbids the use of unnecessary operators in your code.
+    Forbid unnecessary operators in your code.
 
     You can write: ``5.4`` and ``+5.4``. There's no need to use the second
     version. Similarly ``--5.4``, ``---5.4``, ``not not foo``, and ``~~42``
@@ -1288,7 +1288,7 @@ class UselessOperatorsViolation(ASTViolation):
 @final
 class InconsistentReturnVariableViolation(ASTViolation):
     """
-    Forbids local variable that are only used in ``return`` statements.
+    Forbid local variable that are only used in ``return`` statements.
 
     We also allow cases when variable is assigned,
     then there are some other statements without direct variable access,
@@ -1334,7 +1334,7 @@ class InconsistentReturnVariableViolation(ASTViolation):
 @final
 class WalrusViolation(ASTViolation):
     """
-    Forbids local variable that are only used in ``return`` statements.
+    Forbid local variable that are only used in ``return`` statements.
 
     This violation can only be thrown on ``python3.8+``.
 
@@ -1369,7 +1369,7 @@ class WalrusViolation(ASTViolation):
 @final
 class ImplicitComplexCompareViolation(ASTViolation):
     """
-    Forbids to have implicit complex compare expressions.
+    Forbid implicit complex compare expressions.
 
     Reasoning:
         Two compares in python that are joined with ``and`` operator
@@ -1400,7 +1400,7 @@ class ImplicitComplexCompareViolation(ASTViolation):
 @final
 class ReversedComplexCompareViolation(ASTViolation):
     """
-    Forbids to have reversed order complex compare expressions.
+    Forbid reversed order complex compare expressions.
 
     Reasoning:
         Compares where comparators start from the lowest element
@@ -1433,7 +1433,7 @@ class ReversedComplexCompareViolation(ASTViolation):
 @final
 class WrongLoopIterTypeViolation(ASTViolation):
     """
-    Forbids to use wrong ``for`` loop iter targets.
+    Forbid wrong ``for`` loop iter targets.
 
     We forbid to use:
 
@@ -1475,7 +1475,7 @@ class WrongLoopIterTypeViolation(ASTViolation):
 @final
 class ExplicitStringConcatViolation(ASTViolation):
     """
-    Forbids explicit string concat in favour of ``.format`` method.
+    Forbid explicit string concat in favour of ``.format`` method.
 
     However, we still allow multiline string concat
     as a way to write long strings that does not fit the 80-chars rule.
@@ -1507,7 +1507,7 @@ class ExplicitStringConcatViolation(ASTViolation):
 @final
 class MultilineConditionsViolation(ASTViolation):
     """
-    Forbids multiline conditions.
+    Forbid multiline conditions.
 
     Reasoning:
         This way of writing conditions hides the inner complexity this line has.
@@ -1544,7 +1544,7 @@ class MultilineConditionsViolation(ASTViolation):
 @final
 class WrongMethodOrderViolation(ASTViolation):
     """
-    Forbids to have incorrect order of methods inside a class.
+    Forbid incorrect order of methods inside a class.
 
     We follow the same ordering:
 
@@ -1577,7 +1577,7 @@ class WrongMethodOrderViolation(ASTViolation):
 @final
 class NumberWithMeaninglessZeroViolation(TokenizeViolation):
     """
-    Forbids to use meaningless zeros.
+    Forbid meaningless zeros.
 
     We discorauge using meaningless zeros in
     float, binary, octal, hex, and exponential numbers.
@@ -1612,7 +1612,7 @@ class NumberWithMeaninglessZeroViolation(TokenizeViolation):
 @final
 class PositiveExponentViolation(TokenizeViolation):
     """
-    Forbids to extra ``+`` signs in the exponent.
+    Forbid extra ``+`` signs in the exponent.
 
     Reasoning:
         Positive exponent is positive by default,
@@ -1641,7 +1641,7 @@ class PositiveExponentViolation(TokenizeViolation):
 @final
 class WrongHexNumberCaseViolation(TokenizeViolation):
     """
-    Forbids to use letters as hex numbers.
+    Forbid letters as hex numbers.
 
     Reasoning:
         One can write ``0xA`` and ``0xa`` which is inconsistent.
@@ -1669,7 +1669,7 @@ class WrongHexNumberCaseViolation(TokenizeViolation):
 @final
 class ImplicitRawStringViolation(TokenizeViolation):
     r"""
-    Forbids to use ``\\`` escape sequences inside regular strings.
+    Forbid ``\\`` escape sequences inside regular strings.
 
     Reasoning:
         It is hard to read escape sequencse inside regular strings,
@@ -1698,7 +1698,7 @@ class ImplicitRawStringViolation(TokenizeViolation):
 @final
 class BadComplexNumberSuffixViolation(TokenizeViolation):
     """
-    Forbids to use uppercase complex number suffix.
+    Forbid uppercase complex number suffix.
 
     Reasoning:
         Numbers should be consistent.
@@ -1725,7 +1725,7 @@ class BadComplexNumberSuffixViolation(TokenizeViolation):
 @final
 class ZeroDivisionViolation(ASTViolation):
     """
-    Forbids to explicitly divide(or take modulo) by zero.
+    Forbid explicit division (or modulo) by zero.
 
     Reasoning:
         This will just throw ``ZeroDivisionError``
@@ -1757,7 +1757,7 @@ class ZeroDivisionViolation(ASTViolation):
 @final
 class MeaninglessNumberOperationViolation(ASTViolation):
     """
-    Forbids to use meaningless math operations with ``0`` and ``1``.
+    Forbid meaningless math operations with ``0`` and ``1``.
 
     Reasoning:
         Adding and substracting zero does not change the value.
@@ -1799,7 +1799,7 @@ class MeaninglessNumberOperationViolation(ASTViolation):
 @final
 class OperationSignNegationViolation(ASTViolation):
     """
-    Forbids to have double minus operations.
+    Forbid double minus operations.
 
     Reasoning:
         Having two operations is harder than having just one.
@@ -1834,7 +1834,7 @@ class OperationSignNegationViolation(ASTViolation):
 @final
 class VagueImportViolation(ASTViolation):
     """
-    Forbids imports that may cause confusion outside of the module.
+    Forbid imports that may cause confusion outside of the module.
 
     Names that we forbid to import:
 
@@ -1877,7 +1877,7 @@ class VagueImportViolation(ASTViolation):
 @final
 class LineStartsWithDotViolation(TokenizeViolation):
     """
-    Forbids to start lines with a dot.
+    Forbid starting lines with a dot.
 
     Reasoning:
         We enforce strict consitency rules about how to break lines.
@@ -1916,7 +1916,7 @@ class LineStartsWithDotViolation(TokenizeViolation):
 @final
 class RedundantSubscriptViolation(ASTViolation):
     """
-    Forbids the use of redundant components in a subscript's slice.
+    Forbid redundant components in a subscript's slice.
 
     Reasoning:
         We do it for consistency reasons.
@@ -1967,7 +1967,7 @@ class AugmentedAssignPatternViolation(ASTViolation):
 @final
 class UnnecessaryLiteralsViolation(ASTViolation):
     """
-    Forbids the use of unnecessary literals in your code.
+    Forbid unnecessary literals in your code.
 
     Reasoning:
         We discourage using primitive calls to get default type values.
@@ -1995,7 +1995,7 @@ class UnnecessaryLiteralsViolation(ASTViolation):
 @final
 class MultilineLoopViolation(ASTViolation):
     """
-    Forbids multiline loops.
+    Forbid multiline loops.
 
     Reasoning:
         It decreased the readability of the code.
@@ -2028,7 +2028,7 @@ class MultilineLoopViolation(ASTViolation):
 @final
 class IncorrectYieldFromTargetViolation(ASTViolation):
     """
-    Forbids to use ``yield from`` with several nodes.
+    Forbid ``yield from`` with several nodes.
 
     We allow to ``yield from`` tuples,
     names, attributes, calls, and subscripts.
@@ -2062,7 +2062,7 @@ class IncorrectYieldFromTargetViolation(ASTViolation):
 @final
 class ConsecutiveYieldsViolation(ASTViolation):
     """
-    Forbids to have consecutive ``yield`` expressions.
+    Forbid consecutive ``yield`` expressions.
 
     We raise this violation when we find at least
     two consecutive ``yield`` expressions.
@@ -2085,7 +2085,7 @@ class ConsecutiveYieldsViolation(ASTViolation):
 @final
 class BracketBlankLineViolation(TokenizeViolation):
     """
-    Forbids useless blank lines before and after brackets.
+    Forbid useless blank lines before and after brackets.
 
     Reasoning:
         We do this for consistency.
@@ -2120,7 +2120,7 @@ class BracketBlankLineViolation(TokenizeViolation):
 @final
 class IterableUnpackingViolation(ASTViolation):
     """
-    Forbids unnecessary iterable unpacking.
+    Forbid unnecessary iterable unpacking.
 
     Reasoning:
         We do this for consistency.
@@ -2151,7 +2151,7 @@ class IterableUnpackingViolation(ASTViolation):
 @final
 class LineCompriseCarriageReturnViolation(TokenizeViolation):
     r"""
-    Forbids to use ``\r`` (carriage return) in line breaks.
+    Forbid to use ``\r`` (carriage return) in line breaks.
 
     Reasoning:
         We enforce Unix-style newlines.
@@ -2172,7 +2172,7 @@ class LineCompriseCarriageReturnViolation(TokenizeViolation):
 @final
 class FloatZeroViolation(TokenizeViolation):
     """
-    Forbids to use float zeros: ``0.0``.
+    Forbid to use float zeros: ``0.0``.
 
     Reasoning:
         Float zeros can be used as variable values which may lead to

--- a/wemake_python_styleguide/violations/naming.py
+++ b/wemake_python_styleguide/violations/naming.py
@@ -175,7 +175,7 @@ from wemake_python_styleguide.violations.base import (
 @final
 class WrongModuleNameViolation(SimpleViolation):
     """
-    Forbids to use blacklisted module names.
+    Forbid blacklisted module names.
 
     Reasoning:
         Some module names are not expressive enough.
@@ -212,7 +212,7 @@ class WrongModuleNameViolation(SimpleViolation):
 @final
 class WrongModuleMagicNameViolation(SimpleViolation):
     """
-    Forbids to use any magic names except whitelisted ones.
+    Forbid magic names (except some whitelisted ones).
 
     Reasoning:
         Do not fall in love with magic. There's no good reason to use
@@ -242,7 +242,7 @@ class WrongModuleMagicNameViolation(SimpleViolation):
 @final
 class WrongModuleNamePatternViolation(SimpleViolation):
     """
-    Forbids to use module names that do not match our pattern.
+    Forbid module names that do not match our pattern.
 
     Reasoning:
         Module names must be valid python identifiers.
@@ -279,7 +279,7 @@ class WrongModuleNamePatternViolation(SimpleViolation):
 @final
 class WrongVariableNameViolation(ASTViolation):
     """
-    Forbids to have blacklisted variable names.
+    Forbid blacklisted variable names.
 
     Reasoning:
         We have found some names that are not expressive enough.
@@ -327,7 +327,7 @@ class WrongVariableNameViolation(ASTViolation):
 @final
 class TooShortNameViolation(MaybeASTViolation):
     """
-    Forbids to have too short variable or module names.
+    Forbid short variable or module names.
 
     Reasoning:
         It is hard to understand what the variable means and why it is used,
@@ -370,7 +370,7 @@ class TooShortNameViolation(MaybeASTViolation):
 @final
 class PrivateNameViolation(MaybeASTViolation):
     """
-    Forbids to have private name pattern.
+    Forbid private name pattern.
 
     Reasoning:
         Private is not private in ``python``.
@@ -405,7 +405,7 @@ class PrivateNameViolation(MaybeASTViolation):
 @final
 class SameAliasImportViolation(ASTViolation):
     """
-    Forbids to use the same alias as the original name in imports.
+    Forbid using the same alias as the original name in imports.
 
     Reasoning:
         Why would you even do this in the first place?
@@ -442,7 +442,7 @@ class SameAliasImportViolation(ASTViolation):
 @final
 class UnderscoredNumberNameViolation(MaybeASTViolation):
     """
-    Forbids to have names with underscored numbers pattern.
+    Forbid names with underscored numbers pattern.
 
     Reasoning:
         This is done for consistency in naming.
@@ -479,7 +479,7 @@ class UnderscoredNumberNameViolation(MaybeASTViolation):
 @final
 class UpperCaseAttributeViolation(ASTViolation):
     """
-    Forbids to use anything but ``snake_case`` for naming class attributes.
+    Require ``snake_case`` for naming class attributes.
 
     Reasoning:
         Constants with upper-case names belong on a module level.
@@ -511,7 +511,7 @@ class UpperCaseAttributeViolation(ASTViolation):
 @final
 class ConsecutiveUnderscoresInNameViolation(MaybeASTViolation):
     """
-    Forbids to use more than one consecutive underscore in variable names.
+    Forbid using more than one consecutive underscore in variable names.
 
     Reasoning:
         This is done to gain extra readability.
@@ -540,7 +540,7 @@ class ConsecutiveUnderscoresInNameViolation(MaybeASTViolation):
 @final
 class ReservedArgumentNameViolation(ASTViolation):
     """
-    Forbids to name your variables as ``self``, ``cls``, and ``mcs``.
+    Forbid naming variables ``self``, ``cls``, or ``mcs``.
 
     Reasoning:
         These names are special, they should only be used as first
@@ -571,7 +571,7 @@ class ReservedArgumentNameViolation(ASTViolation):
 @final
 class TooLongNameViolation(MaybeASTViolation):
     """
-    Forbids to have long short variable or module names.
+    Forbid long variable or module names.
 
     Reasoning:
         Too long names are unreadable.
@@ -611,7 +611,7 @@ class TooLongNameViolation(MaybeASTViolation):
 @final
 class UnicodeNameViolation(MaybeASTViolation):
     """
-    Forbids to use unicode names.
+    Forbid unicode names.
 
     Reasoning:
         This should be forbidden for sanity, readability, and writability.
@@ -642,7 +642,7 @@ class UnicodeNameViolation(MaybeASTViolation):
 @final
 class TrailingUnderscoreViolation(ASTViolation):
     """
-    Forbids to use trailing ``_`` for names that do not need it.
+    Forbid trailing ``_`` for names that do not need it.
 
     Reasoning:
         We use trailing underscore for a reason:
@@ -675,7 +675,7 @@ class TrailingUnderscoreViolation(ASTViolation):
 @final
 class UnusedVariableIsUsedViolation(ASTViolation):
     """
-    Forbids to have use variables that are marked as unused.
+    Forbid using variables that are marked as unused.
 
     We discourage using variables that start with ``_``
     only inside functions and methods as local variables.
@@ -722,7 +722,7 @@ class UnusedVariableIsUsedViolation(ASTViolation):
 @final
 class UnusedVariableIsDefinedViolation(ASTViolation):
     """
-    Forbids to define explicit unused variables.
+    Forbid explicit unused variables.
 
     Reasoning:
         While it is ok to define unused variables when you have to,
@@ -758,7 +758,7 @@ class UnusedVariableIsDefinedViolation(ASTViolation):
 @final
 class WrongUnusedVariableNameViolation(ASTViolation):
     """
-    Forbids to define unused variables with multiple underscores.
+    Forbid unused variables with multiple underscores.
 
     Reasoning:
         We only use ``_`` as a special definition for an unused variable.
@@ -789,7 +789,7 @@ class WrongUnusedVariableNameViolation(ASTViolation):
 @final
 class UnreadableNameViolation(MaybeASTViolation):
     """
-    Forbids to have variable or module names which could be difficult to read.
+    Forbid variable or module names which could be difficult to read.
 
     Reasoning:
         Currently one can name your classes like so: ``ZerO0``
@@ -826,7 +826,7 @@ class UnreadableNameViolation(MaybeASTViolation):
 @final
 class BuiltinShadowingViolation(ASTViolation):
     """
-    Forbids to have variable or module names which shadows builtin names.
+    Forbid variable or module names which shadow builtin names.
 
     Reasoning:
         Your code simply breaks Python. After you create ``list = 1``,

--- a/wemake_python_styleguide/violations/oop.py
+++ b/wemake_python_styleguide/violations/oop.py
@@ -55,7 +55,7 @@ from wemake_python_styleguide.violations.base import ASTViolation
 @final
 class BuiltinSubclassViolation(ASTViolation):
     """
-    Forbids to subclass lowercase builtins.
+    Forbid subclassing lowercase builtins.
 
     We forbid to subclass builtins like ``int``, ``str``, ``bool``, etc.
     We allow to subclass ``object`` and ``type``, warnings, and exceptions.
@@ -94,7 +94,7 @@ class BuiltinSubclassViolation(ASTViolation):
 @final
 class ShadowedClassAttributeViolation(ASTViolation):
     """
-    Forbids to shadow class level attributes with instance level attributes.
+    Forbid shadowing class level attributes with instance level attributes.
 
     Reasoning:
         This way you will have two attributes inside your ``__mro__`` chain:
@@ -144,7 +144,7 @@ class ShadowedClassAttributeViolation(ASTViolation):
 @final
 class StaticMethodViolation(ASTViolation):
     """
-    Forbids to use ``@staticmethod`` decorator.
+    Forbid ``@staticmethod`` decorator.
 
     Reasoning:
         Static methods are not required to be inside the class.
@@ -166,7 +166,7 @@ class StaticMethodViolation(ASTViolation):
 @final
 class BadMagicMethodViolation(ASTViolation):
     """
-    Forbids to use some magic methods.
+    Forbid certain magic methods.
 
     Reasoning:
         We forbid to use magic methods related to the forbidden language parts.
@@ -197,7 +197,7 @@ class BadMagicMethodViolation(ASTViolation):
 @final
 class WrongClassBodyContentViolation(ASTViolation):
     """
-    Forbids to use incorrect nodes inside ``class`` definitions.
+    Forbid incorrect nodes inside ``class`` definitions.
 
     Reasoning:
         Python allows us to have conditions, context managers,
@@ -234,7 +234,7 @@ class WrongClassBodyContentViolation(ASTViolation):
 @final
 class MethodWithoutArgumentsViolation(ASTViolation):
     """
-    Forbids to have methods without any arguments.
+    Forbid methods without any arguments.
 
     Reasoning:
         Methods without arguments are allowed to be defined,
@@ -270,7 +270,7 @@ class MethodWithoutArgumentsViolation(ASTViolation):
 @final
 class WrongBaseClassViolation(ASTViolation):
     """
-    Forbids to have anything else than a class as a base class.
+    Forbid anything other than a class as a base class.
 
     We only check base classes and not keywords. They can be anything you need.
 
@@ -308,7 +308,7 @@ class WrongBaseClassViolation(ASTViolation):
 @final
 class WrongSlotsViolation(ASTViolation):
     """
-    Forbids to have incorrect ``__slots__`` definition.
+    Forbid incorrect ``__slots__`` definition.
 
     Things that this rule checks:
 
@@ -356,7 +356,7 @@ class WrongSlotsViolation(ASTViolation):
 @final
 class WrongSuperCallViolation(ASTViolation):
     """
-    Forbids to use ``super()`` with parameters or outside of methods.
+    Forbid ``super()`` with parameters or outside of methods.
 
     Reasoning:
         ``super()`` is a very special function.
@@ -388,7 +388,7 @@ class WrongSuperCallViolation(ASTViolation):
 @final
 class DirectMagicAttributeAccessViolation(ASTViolation):
     """
-    Forbids to use direct magic attributes and methods.
+    Forbid direct magic attributes and methods.
 
     Reasoning:
         When using direct magic attributes or method
@@ -424,7 +424,7 @@ class DirectMagicAttributeAccessViolation(ASTViolation):
 @final
 class AsyncMagicMethodViolation(ASTViolation):
     """
-    Forbids to make some magic methods async.
+    Forbid certain async magic methods.
 
     We allow to make ``__anext__``, ``__aenter__``, ``__aexit__`` async.
     We also allow custom magic methods to be async.
@@ -464,7 +464,7 @@ class AsyncMagicMethodViolation(ASTViolation):
 @final
 class YieldMagicMethodViolation(ASTViolation):
     """
-    Forbids to use ``yield`` inside of several magic methods.
+    Forbid ``yield`` inside of certain magic methods.
 
     We allow to make ``__iter__`` a generator.
     See
@@ -509,7 +509,7 @@ class YieldMagicMethodViolation(ASTViolation):
 @final
 class UselessOverwrittenMethodViolation(ASTViolation):
     """
-    Forbids to have useless overwritten methods.
+    Forbid useless overwritten methods.
 
     Reasoning:
         Overwriting method without any changes
@@ -544,7 +544,7 @@ class UselessOverwrittenMethodViolation(ASTViolation):
 @final
 class WrongSuperCallAccessViolation(ASTViolation):
     """
-    Forbids to use ``super()`` with incorrect methods or properties access.
+    Forbid ``super()`` with incorrect method or property access.
 
     Reasoning:
         Can only use ``super()`` method that matches the following context.

--- a/wemake_python_styleguide/violations/refactoring.py
+++ b/wemake_python_styleguide/violations/refactoring.py
@@ -93,7 +93,7 @@ from wemake_python_styleguide.violations.base import (
 @final
 class UselessLoopElseViolation(ASTViolation):
     """
-    Forbids to use ``else`` without ``break`` in a loop.
+    Forbid ``else`` without ``break`` in a loop.
 
     We use the same logic for ``for`` and ``while`` loops.
 
@@ -139,7 +139,7 @@ class UselessLoopElseViolation(ASTViolation):
 @final
 class UselessFinallyViolation(ASTViolation):
     """
-    Forbids to use ``finally`` in ``try`` block without ``except`` block.
+    Forbid ``finally`` in ``try`` block without ``except`` block.
 
     However, we allow to use ``try`` with just ``finally`` block
     when function or method is decorated. Because we cannot control
@@ -180,7 +180,7 @@ class UselessFinallyViolation(ASTViolation):
 @final
 class SimplifiableIfViolation(ASTViolation):
     """
-    Forbids to have simplifiable ``if`` conditions.
+    Forbid simplifiable ``if`` conditions.
 
     Reasoning:
         This complex construction can cause frustration among other developers.
@@ -217,7 +217,7 @@ class SimplifiableIfViolation(ASTViolation):
 @final
 class UselessReturningElseViolation(ASTViolation):
     """
-    Forbids to use useless ``else`` cases in returning functions.
+    Forbid useless ``else`` cases in returning functions.
 
     We check single ``if`` statements that all contain
     ``return`` or ``raise`` or ``break`` statements with this rule.
@@ -260,7 +260,7 @@ class UselessReturningElseViolation(ASTViolation):
 @final
 class NegatedConditionsViolation(ASTViolation):
     """
-    Forbids to use negated conditions together with ``else`` clause.
+    Forbid negated conditions together with ``else`` clause.
 
     Reasoning:
         It easier to read and name regular conditions. Not negated ones.
@@ -304,7 +304,7 @@ class NegatedConditionsViolation(ASTViolation):
 @final
 class NestedTryViolation(ASTViolation):
     """
-    Forbids to use nested ``try`` blocks.
+    Forbid nested ``try`` blocks.
 
     Notice, we check all possible slots for ``try`` block:
     1. the ``try`` block itself
@@ -354,7 +354,7 @@ class NestedTryViolation(ASTViolation):
 @final
 class UselessLambdaViolation(ASTViolation):
     """
-    Forbids to define useless proxy ``lambda`` expressions.
+    Forbid useless proxy ``lambda`` expressions.
 
     Reasoning:
         Sometimes developers tend to overuse ``lambda`` expressions
@@ -386,7 +386,7 @@ class UselessLambdaViolation(ASTViolation):
 @final
 class UselessLenCompareViolation(ASTViolation):
     """
-    Forbids to have unpythonic zero-length compare.
+    Forbid unpythonic zero-length compare.
 
     Note, that we allow to check arbitrary length, like ``len(arr) == 3``.
 
@@ -422,7 +422,7 @@ class UselessLenCompareViolation(ASTViolation):
 @final
 class NotOperatorWithCompareViolation(ASTViolation):
     """
-    Forbids to use ``not`` with compare expressions.
+    Forbid ``not`` with compare expressions.
 
     Reasoning:
         This version of ``not`` operator is unreadable.
@@ -454,7 +454,7 @@ class NotOperatorWithCompareViolation(ASTViolation):
 @final
 class NestedTernaryViolation(ASTViolation):
     """
-    Forbids to nest ternary expressions in some places.
+    Forbid nesting ternary expressions in certain places.
 
     Note, that we restrict to nest ternary expressions inside:
 
@@ -492,7 +492,7 @@ class NestedTernaryViolation(ASTViolation):
 @final
 class WrongInCompareTypeViolation(ASTViolation):
     """
-    Forbids to use ``in`` with static containers except ``set`` nodes.
+    Forbid ``in`` with static containers except ``set`` nodes.
 
     We enforce people to use sets as a static containers.
     You can also use variables, calls, methods, etc.
@@ -531,7 +531,7 @@ class WrongInCompareTypeViolation(ASTViolation):
 @final
 class UnmergedIsinstanceCallsViolation(ASTViolation):
     """
-    Forbids to multiple ``isinstance`` calls with the same variable.
+    Forbid multiple ``isinstance`` calls on the same variable.
 
     Reasoning:
         The best practice is to use ``isinstance`` with tuple
@@ -567,7 +567,7 @@ class UnmergedIsinstanceCallsViolation(ASTViolation):
 @final
 class WrongIsinstanceWithTupleViolation(ASTViolation):
     """
-    Forbids to multiple ``isinstance`` calls with tuples of a single item.
+    Forbid multiple ``isinstance`` calls with single-item tuples.
 
     Reasoning:
         There's no need to use tuples with single elements.
@@ -600,7 +600,7 @@ class WrongIsinstanceWithTupleViolation(ASTViolation):
 @final
 class ImplicitElifViolation(TokenizeViolation):
     """
-    Forbids to have implicit ``elif`` conditions.
+    Forbid implicit ``elif`` conditions.
 
     Reasoning:
         Nested ``if`` in ``else`` cases are bad
@@ -635,7 +635,7 @@ class ImplicitElifViolation(TokenizeViolation):
 @final
 class ImplicitInConditionViolation(ASTViolation):
     """
-    Forbids to use multiple equality compare with the same variable name.
+    Forbid multiple equality comparisons with the same variable.
 
     Reasoning:
         Using double+ equality compare with ``or``
@@ -670,7 +670,7 @@ class ImplicitInConditionViolation(ASTViolation):
 @final
 class OpenWithoutContextManagerViolation(ASTViolation):
     """
-    Forbids to use ``open()`` without a context manager.
+    Forbid ``open()`` without a context manager.
 
     Reasoning:
         When you ``open()`` something, you need to close it.
@@ -701,7 +701,7 @@ class OpenWithoutContextManagerViolation(ASTViolation):
 @final
 class TypeCompareViolation(ASTViolation):
     """
-    Forbids to compare types with ``type()`` function.
+    Forbid comparing types with ``type()`` function.
 
     Reasoning:
         When you compare types with ``type()`` function call
@@ -731,7 +731,7 @@ class TypeCompareViolation(ASTViolation):
 @final
 class PointlessStarredViolation(ASTViolation):
     """
-    Forbids to have useless starred expressions.
+    Forbid useless starred expressions.
 
     Reasoning:
         Using starred expression with constants is useless.
@@ -762,7 +762,7 @@ class PointlessStarredViolation(ASTViolation):
 @final
 class ImplicitEnumerateViolation(ASTViolation):
     """
-    Forbids to have implicit ``enumerate()`` calls.
+    Forbid implicit ``enumerate()`` calls.
 
     Reasoning:
         Using ``range(len(...))`` is not pythonic.
@@ -795,7 +795,7 @@ class ImplicitEnumerateViolation(ASTViolation):
 @final
 class ImplicitSumViolation(ASTViolation):
     """
-    Forbids to have implicit ``sum()`` calls.
+    Forbid implicit ``sum()`` calls.
 
     When summing types different from numbers, you might need to provide
     the second argument to the ``sum`` function: ``sum([[1], [2], [3]], [])``
@@ -835,7 +835,7 @@ class ImplicitSumViolation(ASTViolation):
 @final
 class FalsyConstantCompareViolation(ASTViolation):
     """
-    Forbids to compare with explicit falsy constants.
+    Forbid comparing with explicit falsy constants.
 
     We allow to compare with falsy numbers, strings, booleans, ``None``.
     We disallow complex constants like tuple, dicts, and lists.
@@ -875,7 +875,7 @@ class FalsyConstantCompareViolation(ASTViolation):
 @final
 class WrongIsCompareViolation(ASTViolation):
     """
-    Forbids to compare values with constants using ``is`` or ``is not``.
+    Forbid comparing values with constants using ``is`` or ``is not``.
 
     However, we allow to compare with ``None`` and booleans.
 
@@ -912,7 +912,7 @@ class WrongIsCompareViolation(ASTViolation):
 @final
 class ImplicitPrimitiveViolation(ASTViolation):
     """
-    Forbids to use implicit primitives in a form of ``lambda`` functions.
+    Forbid implicit primitives in the form of ``lambda`` functions.
 
     Reasoning:
         When you use ``lambda`` that returns a primitive value
@@ -942,7 +942,7 @@ class ImplicitPrimitiveViolation(ASTViolation):
 @final
 class AlmostSwappedViolation(ASTViolation):
     """
-    Forbids unpythonic swap variables.
+    Forbid unpythonic variable swaps.
 
     We check for ``a = b; b = a`` sequences.
 
@@ -976,7 +976,7 @@ class AlmostSwappedViolation(ASTViolation):
 @final
 class MisrefactoredAssignmentViolation(ASTViolation):
     """
-    Forbids to use misrefactored self assignment.
+    Forbid misrefactored self assignment.
 
     Reasoning:
         Self assignment does not need to have the same operand
@@ -1009,7 +1009,7 @@ class MisrefactoredAssignmentViolation(ASTViolation):
 @final
 class InCompareWithSingleItemContainerViolation(ASTViolation):
     """
-    Forbids comparisons where ``in`` is compared with single item container.
+    Forbid comparisons where ``in`` is compared with single item container.
 
     Reasoning:
         ``in`` comparison with a container which contains only one item looks
@@ -1037,7 +1037,7 @@ class InCompareWithSingleItemContainerViolation(ASTViolation):
 @final
 class ImplicitYieldFromViolation(ASTViolation):
     """
-    Forbids to use ``yield`` inside ``for`` loop instead of ``yield from``.
+    Forbid ``yield`` inside ``for`` loop instead of ``yield from``.
 
     Reasoning:
         It is known that ``yield from`` is a semantically identical
@@ -1074,7 +1074,7 @@ class ImplicitYieldFromViolation(ASTViolation):
 @final
 class NotATupleArgumentViolation(ASTViolation):
     """
-    Forces using tuples as arguments for some functions.
+    Require tuples as arguments for certain functions.
 
     Reasoning:
         For some functions, it is better to use tuples instead of another
@@ -1106,7 +1106,7 @@ class NotATupleArgumentViolation(ASTViolation):
 @final
 class ImplicitItemsIteratorViolation(ASTViolation):
     """
-    Forbids to use implicit ``.items()`` iterator.
+    Forbid implicit ``.items()`` iterator.
 
     Reasoning:
         When iterating over collection it is easy to forget
@@ -1138,7 +1138,7 @@ class ImplicitItemsIteratorViolation(ASTViolation):
 @final
 class ImplicitDictGetViolation(ASTViolation):
     """
-    Forbids to use implicit ``.get()`` dict method.
+    Forbid implicit ``.get()`` dict method.
 
     Reasoning:
         When using ``in`` with a dict key it is hard to keep the code clean.
@@ -1171,7 +1171,7 @@ class ImplicitDictGetViolation(ASTViolation):
 @final
 class ImplicitNegativeIndexViolation(ASTViolation):
     """
-    Forbids to use implicit negative indexes.
+    Forbid implicit negative indexes.
 
     Reasoning:
         There's no need in getting the length of an iterable


### PR DESCRIPTION
Updating with suggestions from: https://github.com/wemake-services/wemake-python-styleguide/issues/1525#issuecomment-675714883

This also means the summaries are more concise and the tense has changed (to the imperative form, I think), which also matches PEP 257.