### PR TITLE
Fix WPS323 false positive thrown when using some psycopg2 and datetime functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,6 @@ Semantic versioning in our case means:
 - WPS531: Forbids testing conditions to just return booleans when it is possible to simply return the condition itself
 - Forbids to use unsafe infinite loops
 - Forbids to use raw strings `r''` when not necessary
-- Add parameter to `given_function_called` so that it checks if a function has been called by its name regardless of the modules or classes it is in
 - Forbids to use too complex f-strings
 
 ### Bugfixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Semantic versioning in our case means:
 - Allowed yield statements in call method
 - Allow to use `^` with `1`
 - Fixes false positives in WPS513
+- Fixes false positives in WPS323
 
 ### Misc
 

--- a/tests/test_visitors/test_ast/test_builtins/test_strings/test_modulo_formatting.py
+++ b/tests/test_visitors/test_ast/test_builtins/test_strings/test_modulo_formatting.py
@@ -145,6 +145,32 @@ def test_regular_modulo_string(
 
 
 @pytest.mark.parametrize('code', [
+    'datetime.strftime("%d-%m-%Y (%H:%M:%S)")',
+    'datetime.strptime("01-01-2020 (10:20:30)", "%d-%m-%Y (%H:%M:%S)")',
+    'date.strftime("%d-%m-%Y (%H:%M:%S)")',
+    'date.strptime("01-01-2020", "%d-%m-%Y")',
+    'time.strftime("%H:%M:%S")',
+    'time.strptime("10:20:30", "%H:%M:%S")',
+    'strptime("01-01-2020 (10:20:30)", "%d-%m-%Y (%H:%M:%S)")',
+    'cur.execute("SELECT * FROM table WHERE column = %s", ("some_column"))',
+    'execute("SELECT * FROM table WHERE column = %s", ("some_column"))',
+])
+def test_functions_modulo_string(
+    assert_errors,
+    parse_ast_tree,
+    code,
+    default_options,
+):
+    """Testing that the strings violate the rules."""
+    tree = parse_ast_tree(code)
+
+    visitor = WrongStringVisitor(default_options, tree=tree)
+    visitor.run()
+
+    assert_errors(visitor, [], (FormattedStringViolation,))
+
+
+@pytest.mark.parametrize('code', [
     'x % 1',
     '"str" % 1',
     'name % value',

--- a/tests/test_visitors/test_ast/test_builtins/test_strings/test_modulo_formatting.py
+++ b/tests/test_visitors/test_ast/test_builtins/test_strings/test_modulo_formatting.py
@@ -145,6 +145,7 @@ def test_regular_modulo_string(
 
 
 @pytest.mark.parametrize('code', [
+    'dt.strftime("%A, %d. %B %Y %I:%M%p")',
     'datetime.strftime("%d-%m-%Y (%H:%M:%S)")',
     'datetime.strptime("01-01-2020 (10:20:30)", "%d-%m-%Y (%H:%M:%S)")',
     'date.strftime("%d-%m-%Y (%H:%M:%S)")',

--- a/wemake_python_styleguide/visitors/ast/builtins.py
+++ b/wemake_python_styleguide/visitors/ast/builtins.py
@@ -26,6 +26,7 @@ from wemake_python_styleguide.compat.aliases import (
 from wemake_python_styleguide.logic import nodes, safe_eval, source, walk
 from wemake_python_styleguide.logic.naming.name_nodes import extract_name
 from wemake_python_styleguide.logic.tree import operators, strings
+from wemake_python_styleguide.logic.tree.functions import given_function_called
 from wemake_python_styleguide.types import AnyFor, AnyNodes, AnyText, AnyWith
 from wemake_python_styleguide.violations import best_practices, consistency
 from wemake_python_styleguide.visitors import base, decorators
@@ -127,12 +128,7 @@ class WrongStringVisitor(base.BaseNodeVisitor):
         )
 
         if parent and isinstance(parent, ast.Call):
-
-            func_name = getattr(parent.func, 'attr', None)
-            if not func_name:
-                func_name = getattr(parent.func, 'id', None)
-
-            return func_name in exceptions
+            return bool(given_function_called(parent, exceptions))
         return False
 
     def _check_modulo_patterns(

--- a/wemake_python_styleguide/visitors/ast/builtins.py
+++ b/wemake_python_styleguide/visitors/ast/builtins.py
@@ -112,7 +112,7 @@ class WrongStringVisitor(base.BaseNodeVisitor):
                 ),
             )
 
-    def _is_exception(self, node: AnyText) -> bool:
+    def _is_exception(self, parent: Optional[ast.AST]) -> bool:
         """
         Check if the string with modulo patterns is in an exceptional situation.
 
@@ -126,7 +126,6 @@ class WrongStringVisitor(base.BaseNodeVisitor):
             'execute',  # For psycopg2's cur.execute()
         )
 
-        parent = nodes.get_parent(node)
         if parent and isinstance(parent, ast.Call):
 
             func_name = getattr(parent.func, 'attr', None)
@@ -146,7 +145,7 @@ class WrongStringVisitor(base.BaseNodeVisitor):
             return  # we allow `%s` in docstrings: they cannot be formatted.
 
         if self._modulo_string_pattern.search(text_data):
-            if not self._is_exception(node):
+            if not self._is_exception(parent):
                 self.add_violation(
                     consistency.ModuloStringFormatViolation(node),
                 )

--- a/wemake_python_styleguide/visitors/ast/builtins.py
+++ b/wemake_python_styleguide/visitors/ast/builtins.py
@@ -49,6 +49,14 @@ from wemake_python_styleguide.visitors import base, decorators
 _HashItems = Sequence[Optional[ast.AST]]
 
 
+#: names of functions in which we allow strings with modulo patterns.
+_modulo_pattern_exceptions: ClassVar[FrozenSet[str]] = frozenset((
+    'strftime',  # For date, time, and datetime.strftime()
+    'strptime',  # For date, time, and datetime.strptime()
+    'execute',  # For psycopg2's cur.execute()
+))
+
+
 @final
 @decorators.alias('visit_any_string', (
     'visit_Str',
@@ -124,16 +132,10 @@ class WrongStringVisitor(base.BaseNodeVisitor):
         modulo patterns because they must have them for the functions to work
         properly.
         """
-        exceptions = (
-            'strftime',  # For date, time, and datetime.strftime()
-            'strptime',  # For date, time, and datetime.strptime()
-            'execute',  # For psycopg2's cur.execute()
-        )
-
         if parent and isinstance(parent, ast.Call):
             return bool(functions.given_function_called(
                 parent,
-                exceptions,
+                _modulo_pattern_exceptions,
                 split_modules=True,
             ))
         return False

--- a/wemake_python_styleguide/visitors/ast/builtins.py
+++ b/wemake_python_styleguide/visitors/ast/builtins.py
@@ -49,14 +49,6 @@ from wemake_python_styleguide.visitors import base, decorators
 _HashItems = Sequence[Optional[ast.AST]]
 
 
-#: names of functions in which we allow strings with modulo patterns.
-_modulo_pattern_exceptions: ClassVar[FrozenSet[str]] = frozenset((
-    'strftime',  # For date, time, and datetime.strftime()
-    'strptime',  # For date, time, and datetime.strptime()
-    'execute',  # For psycopg2's cur.execute()
-))
-
-
 @final
 @decorators.alias('visit_any_string', (
     'visit_Str',
@@ -98,6 +90,13 @@ class WrongStringVisitor(base.BaseNodeVisitor):
         flags=re.X,  # flag to ignore comments and whitespaces.
     )
 
+    #: Names of functions in which we allow strings with modulo patterns.
+    _modulo_pattern_exceptions: ClassVar[FrozenSet[str]] = frozenset((
+        'strftime',  # For date, time, and datetime.strftime()
+        'strptime',  # For date, time, and datetime.strptime()
+        'execute',  # For psycopg2's cur.execute()
+    ))
+
     def visit_any_string(self, node: AnyText) -> None:
         """
         Forbids incorrect usage of strings.
@@ -135,7 +134,7 @@ class WrongStringVisitor(base.BaseNodeVisitor):
         if parent and isinstance(parent, ast.Call):
             return bool(functions.given_function_called(
                 parent,
-                _modulo_pattern_exceptions,
+                self._modulo_pattern_exceptions,
                 split_modules=True,
             ))
         return False

--- a/wemake_python_styleguide/visitors/ast/builtins.py
+++ b/wemake_python_styleguide/visitors/ast/builtins.py
@@ -25,7 +25,12 @@ from wemake_python_styleguide.compat.aliases import (
 )
 from wemake_python_styleguide.logic import nodes, safe_eval, source, walk
 from wemake_python_styleguide.logic.naming.name_nodes import extract_name
-from wemake_python_styleguide.logic.tree import attributes, operators, strings
+from wemake_python_styleguide.logic.tree import (
+    attributes,
+    functions,
+    operators,
+    strings,
+)
 from wemake_python_styleguide.types import (
     AnyChainable,
     AnyFor,
@@ -111,7 +116,7 @@ class WrongStringVisitor(base.BaseNodeVisitor):
                 ),
             )
 
-    def _is_exception(self, parent: Optional[ast.AST]) -> bool:
+    def _is_modulo_pattern_exception(self, parent: Optional[ast.AST]) -> bool:
         """
         Check if the string with modulo patterns is in an exceptional situation.
 
@@ -126,7 +131,11 @@ class WrongStringVisitor(base.BaseNodeVisitor):
         )
 
         if parent and isinstance(parent, ast.Call):
-            return bool(given_function_called(parent, exceptions))
+            return bool(functions.given_function_called(
+                parent,
+                exceptions,
+                split_modules=True,
+            ))
         return False
 
     def _check_modulo_patterns(
@@ -139,7 +148,7 @@ class WrongStringVisitor(base.BaseNodeVisitor):
             return  # we allow `%s` in docstrings: they cannot be formatted.
 
         if self._modulo_string_pattern.search(text_data):
-            if not self._is_exception(parent):
+            if not self._is_modulo_pattern_exception(parent):
                 self.add_violation(
                     consistency.ModuloStringFormatViolation(node),
                 )


### PR DESCRIPTION
# I have made things!

Fix that WPS323 is thrown when executing functions such as:

```python
some_date = datetime.strptime("01-01-2020 (10:20:30)", "%d-%m-%Y (%H:%M:%S)")
formatted_datetime = some_date.strftime("%d-%m-%Y (%H:%M:%S)")
cur.execute
```

## Checklist

- [X] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [X] I have created at least one test case for the changes I have made
- [X] I have updated the documentation for the changes I have made
- [X] I have added my changes to the `CHANGELOG.md`

## Related issues

- Closes #1329 
