### PR TITLE
Improve given_function_called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Semantic versioning in our case means:
 - WPS531: Forbids testing conditions to just return booleans when it is possible to simply return the condition itself
 - Forbids to use unsafe infinite loops
 - Forbids to use raw strings `r''` when not necessary
+- Add parameter to `given_function_called` so that it checks if a function has been called by its name regardless of the modules or classes it is in
 
 ### Bugfixes
 

--- a/tests/test_logic/test_tree/test_functions.py
+++ b/tests/test_logic/test_tree/test_functions.py
@@ -1,0 +1,59 @@
+import pytest
+
+from wemake_python_styleguide.logic.tree import functions
+
+
+@pytest.mark.parametrize(('function_call', 'function_name'), [
+    # Simple builtin functions
+    ('print("Hello world!")', 'print'),
+    ('int("10")', 'int'),
+    ('bool(1)', 'bool'),
+    ('open("/tmp/file.txt", "r")', 'open'),
+    ('str(10)', 'str'),
+
+    # Functions in modules
+    ('datetime.timedelta(days=1)', 'datetime.timedelta'),
+    ('cmath.sqrt(100)', 'cmath.sqrt'),
+
+    # Functions in (made up) objects
+    ('dt.strftime("%H:%M")', 'dt.strftime'),
+    ('obj.funct()', 'obj.funct'),
+])
+def test_given_function_called_no_split(
+    parse_ast_tree, function_call: str, function_name: str,
+) -> None:
+    """Test given_function_called without splitting the modules."""
+    tree = parse_ast_tree(function_call)
+    node = tree.body[0].value
+    called_function = functions.given_function_called(node, [function_name])
+    assert called_function == function_name
+
+
+@pytest.mark.parametrize(('function_call', 'function_name'), [
+    # Simple builtin functions
+    ('print("Hello world!")', 'print'),
+    ('int("10")', 'int'),
+    ('bool(1)', 'bool'),
+    ('open("/tmp/file.txt", "r")', 'open'),
+    ('str(10)', 'str'),
+
+    # Functions in modules
+    ('datetime.timedelta(days=1)', 'timedelta'),
+    ('cmath.sqrt(100)', 'sqrt'),
+
+    # Functions in (made up) objects
+    ('dt.strftime("%H:%M")', 'strftime'),
+    ('obj.funct()', 'funct'),
+])
+def test_given_function_called_with_split(
+    parse_ast_tree, function_call: str, function_name: str,
+) -> None:
+    """Test given_function_called splitting the modules."""
+    tree = parse_ast_tree(function_call)
+    node = tree.body[0].value
+    called_function = functions.given_function_called(
+        node,
+        [function_name],
+        split_modules=True,
+    )
+    assert called_function == function_name

--- a/wemake_python_styleguide/logic/tree/functions.py
+++ b/wemake_python_styleguide/logic/tree/functions.py
@@ -10,9 +10,16 @@ from wemake_python_styleguide.types import (
 )
 
 
-def given_function_called(node: Call, to_check: Container[str]) -> str:
+def given_function_called(
+    node: Call,
+    to_check: Container[str],
+    split_modules: bool = False,
+) -> str:
     """
     Returns function name if it is called and contained in the container.
+
+    If `split_modules`, takes the modules or objects into account. Otherwise,
+    it only cares about the function's name.
 
     >>> import ast
     >>> module = ast.parse('print(123, 456)')
@@ -24,9 +31,23 @@ def given_function_called(node: Call, to_check: Container[str]) -> str:
 
     >>> module = ast.parse('datetime.timedelta(days=1)')
     >>> given_function_called(module.body[0].value, ['timedelta'])
+    ''
+
+    >>> module = ast.parse('datetime.timedelta(days=1)')
+    >>> given_function_called(module.body[0].value, ['datetime.timedelta'])
+    'datetime.timedelta'
+
+    >>> module = ast.parse('datetime.timedelta(days=1)')
+    >>> given_function_called(
+    ...     module.body[0].value,
+    ...     ['timedelta'],
+    ...     split_modules=True,
+    ... )
     'timedelta'
     """
-    function_name = source.node_to_string(node.func).split('.')[-1]
+    function_name = source.node_to_string(node.func)
+    if split_modules:
+        function_name = function_name.split('.')[-1]
     if function_name in to_check:
         return function_name
     return ''

--- a/wemake_python_styleguide/logic/tree/functions.py
+++ b/wemake_python_styleguide/logic/tree/functions.py
@@ -22,8 +22,11 @@ def given_function_called(node: Call, to_check: Container[str]) -> str:
     >>> given_function_called(module.body[0].value, ['adjust'])
     ''
 
+    >>> module = ast.parse('datetime.timedelta(days=1)')
+    >>> given_function_called(module.body[0].value, ['timedelta'])
+    'timedelta'
     """
-    function_name = source.node_to_string(node.func)
+    function_name = source.node_to_string(node.func).split('.')[-1]
     if function_name in to_check:
         return function_name
     return ''

--- a/wemake_python_styleguide/logic/tree/functions.py
+++ b/wemake_python_styleguide/logic/tree/functions.py
@@ -13,6 +13,7 @@ from wemake_python_styleguide.types import (
 def given_function_called(
     node: Call,
     to_check: Container[str],
+    *,
     split_modules: bool = False,
 ) -> str:
     """
@@ -20,30 +21,6 @@ def given_function_called(
 
     If `split_modules`, takes the modules or objects into account. Otherwise,
     it only cares about the function's name.
-
-    >>> import ast
-    >>> module = ast.parse('print(123, 456)')
-    >>> given_function_called(module.body[0].value, ['print'])
-    'print'
-
-    >>> given_function_called(module.body[0].value, ['adjust'])
-    ''
-
-    >>> module = ast.parse('datetime.timedelta(days=1)')
-    >>> given_function_called(module.body[0].value, ['timedelta'])
-    ''
-
-    >>> module = ast.parse('datetime.timedelta(days=1)')
-    >>> given_function_called(module.body[0].value, ['datetime.timedelta'])
-    'datetime.timedelta'
-
-    >>> module = ast.parse('datetime.timedelta(days=1)')
-    >>> given_function_called(
-    ...     module.body[0].value,
-    ...     ['timedelta'],
-    ...     split_modules=True,
-    ... )
-    'timedelta'
     """
     function_name = source.node_to_string(node.func)
     if split_modules:


### PR DESCRIPTION
# I have made things!

Added a parameter `split_modules: bool` to `given_function_called` in `wemake_python_styleguide.logic.tree.functions`. Defaults to False.

When False, behaves as always.
When True, it only checks that a function has been called, regardless of the modules it comes from. For example:

```python
import ast

module = ast.parse('datetime.timedelta(days=1)')
called_function = given_function_called(module.body[0].value, ['datetime.timedelta'], split_modules=False)
print(called_function) 
# Prints `datetime.timedelta`

called_function = given_function_called(module.body[0].value, ['timedelta'], split_modules=False)
print(called_function)
# Prints `` (empty string)

called_function = given_function_called(module.body[0].value, ['timedelta'], split_modules=True)
print(called_function)
# Prints `timedelta`
```

## Checklist

- [X] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [X] I have created at least one test case for the changes I have made
- [X] I have updated the documentation for the changes I have made
- [X] I have added my changes to the `CHANGELOG.md`

## Related issues

- Closes #1682 