### PR TITLE
Fix #1689: lambda in loop false positive WPS426

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Semantic versioning in our case means:
 - Allowed yield statements in call method
 - Allow to use `^` with `1`
 - Fixes false positives in WPS513 and WPS323
+- Fixes false positive WPS426 if `lambda` in loop uses only its arguments
 
 ### Misc
 

--- a/tests/test_visitors/test_ast/test_loops/test_loops/test_lambda_in_loop.py
+++ b/tests/test_visitors/test_ast/test_loops/test_loops/test_lambda_in_loop.py
@@ -17,14 +17,7 @@ nested_lambda_inside_for_loop = """
 def wrapper():
     for index in range(10):
         if some:
-            print(lambda: index)
-"""
-
-nested_argument_lambda_inside_for_loop = """
-def wrapper():
-    for index in range(10):
-        if some:
-            print(lambda index=inde: index)
+            print(lambda x: x + index)
 """
 
 lambda_inside_while_loop = """
@@ -42,17 +35,17 @@ while True:
 
 lambda_inside_set = """
 def wrapper():
-    return {lambda x=x: x for x in some()}
+    return {lambda: x for x in some()}
 """
 
 lambda_inside_list = """
 def wrapper():
-    return [lambda x: x for x in some()]
+    return [lambda: x for x in some()]
 """
 
 lambda_inside_gen = """
 def wrapper():
-    return (lambda x: x for x in some())
+    return (lambda: x for x in some())
 """
 
 lambda_inside_dict_key = """
@@ -69,6 +62,12 @@ def wrapper():
 
 correct_lambda_inside_for = """
 def wrapper():
+    for index in range(10):
+        print(lambda x: x)
+"""
+
+correct_lambda_inside_map = """
+def wrapper():
     for some in map(lambda x: x * 2, items):
         ...
 """
@@ -80,14 +79,20 @@ def wrapper():
 
 correct_lambda_inside_list = """
 def wrapper():
-    return [x for x in some() if callback(lambda: x)]
+    return [x for x in some() if callback(lambda x: x)]
+"""
+
+correct_lambda_nested_argument_for = """
+def wrapper():
+    for index in range(10):
+        if some:
+            print(lambda index=some: index)
 """
 
 
 @pytest.mark.parametrize('code', [
     lambda_inside_for_loop,
     nested_lambda_inside_for_loop,
-    nested_argument_lambda_inside_for_loop,
     lambda_inside_while_loop,
     nested_lambda_inside_while_loop,
     lambda_inside_list,
@@ -114,8 +119,10 @@ def test_lambda_body(
 
 @pytest.mark.parametrize('code', [
     correct_lambda_inside_for,
+    correct_lambda_inside_map,
     correct_lambda_inside_list,
     correct_lambda_inside_set,
+    correct_lambda_nested_argument_for,
 ])
 def test_correct_lambda_body(
     assert_errors,

--- a/wemake_python_styleguide/visitors/ast/loops.py
+++ b/wemake_python_styleguide/visitors/ast/loops.py
@@ -177,15 +177,8 @@ class WrongLoopVisitor(base.BaseNodeVisitor):
         self,
         node: Union[AnyLoop, AnyComprehension],
     ) -> None:
-        container_names = self._containers.get(type(node), ())
-        for container in container_names:
-            body = getattr(node, container, [])
-            if not isinstance(body, list):
-                body = [body]
-
-            for subnode in body:
-                if walk.is_contained(subnode, ast.Lambda):
-                    self.add_violation(LambdaInsideLoopViolation(node))
+        for _ in walk.get_subnodes_by_type(node, ast.Lambda):
+            self.add_violation(LambdaInsideLoopViolation(node))
 
     def _check_useless_continue(self, node: AnyLoop) -> None:
         nodes_at_line: DefaultDict[int, List[ast.AST]] = defaultdict(list)

--- a/wemake_python_styleguide/visitors/ast/loops.py
+++ b/wemake_python_styleguide/visitors/ast/loops.py
@@ -177,8 +177,17 @@ class WrongLoopVisitor(base.BaseNodeVisitor):
         self,
         node: Union[AnyLoop, AnyComprehension],
     ) -> None:
-        for _ in walk.get_subnodes_by_type(node, ast.Lambda):
-            self.add_violation(LambdaInsideLoopViolation(node))
+        for lambda_node in walk.get_subnodes_by_type(node, ast.Lambda):
+            arguments = (
+                arg.arg for arg
+                in walk.get_subnodes_by_type(lambda_node, ast.arg)
+            )
+            body = (
+                subnode.id for subnode
+                in walk.get_subnodes_by_type(lambda_node.body, ast.Name)
+            )
+            if not all(symbol in arguments for symbol in body):
+                self.add_violation(LambdaInsideLoopViolation(node))
 
     def _check_useless_continue(self, node: AnyLoop) -> None:
         nodes_at_line: DefaultDict[int, List[ast.AST]] = defaultdict(list)


### PR DESCRIPTION
# I have made things!

Allow a `lambda` in a loop as long as it does not act on variables outside of its scope. 

Lambda functions using only their own arguments are considered safe.

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Checklist

<!-- Please check everything that applies: -->

- [X] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [X] I have created at least one test case for the changes I have made
- [X] I have updated the documentation for the changes I have made
- [X] I have added my changes to the `CHANGELOG.md`

## Related issues

Closes #1689 
<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->

🙏 Please, if you or your company is finding wemake-python-styleguide valuable, help us sustain the project by sponsoring it transparently on https://opencollective.com/wemake-python-styleguide. As a thank you, your profile/company logo will be added to our main README which receives hundreds of unique visitors per day.
