### PR TITLE
Forbid to have getter functions that returns nothing (#1382)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Semantic versioning in our case means:
 - Forbids single element unpacking
 - Forbids to unpack lists with side-effects
 - Forbids to use miltiline strings except for assignments and docstrings
+- Forbids not returning anything in functions and methods starting with `get_`
 
 ### Bugfixes
 

--- a/tests/fixtures/noqa/noqa.py
+++ b/tests/fixtures/noqa/noqa.py
@@ -761,3 +761,7 @@ def many_raises_function(parameter):  # noqa: WPS238
 my_print("""
 text
 """)  # noqa: WPS462
+
+
+def get_item():  # noqa: WPS463
+    return  # noqa: WPS324

--- a/tests/test_checker/test_noqa.py
+++ b/tests/test_checker/test_noqa.py
@@ -134,7 +134,7 @@ SHOULD_BE_RAISED = types.MappingProxyType({
     'WPS321': 1,
     'WPS322': 1,
     'WPS323': 1,
-    'WPS324': 1,
+    'WPS324': 2,
     'WPS325': 1,
     'WPS326': 1,
     'WPS327': 1,
@@ -235,6 +235,7 @@ SHOULD_BE_RAISED = types.MappingProxyType({
     'WPS460': 1,
     'WPS461': 0,  # logically unacceptable.
     'WPS462': 1,
+    'WPS463': 1,
 
     'WPS500': 1,
     'WPS501': 1,

--- a/tests/test_visitors/test_ast/test_functions/test_complex_default_values.py
+++ b/tests/test_visitors/test_ast/test_functions/test_complex_default_values.py
@@ -6,7 +6,7 @@ from wemake_python_styleguide.violations.best_practices import (
     PositionalOnlyArgumentsViolation,
 )
 from wemake_python_styleguide.visitors.ast.functions import (
-    FunctionArgumentsVisitor,
+    FunctionSignatureVisitor,
 )
 
 function_with_defaults = """
@@ -104,7 +104,7 @@ def test_wrong_function_defaults(
     """Testing that wrong function defaults are forbidden."""
     tree = parse_ast_tree(mode(template.format(code)))
 
-    visitor = FunctionArgumentsVisitor(default_options, tree=tree)
+    visitor = FunctionSignatureVisitor(default_options, tree=tree)
     visitor.run()
 
     assert_errors(
@@ -142,7 +142,7 @@ def test_correct_function_defaults(
     """Testing that correct function defaults passes validation."""
     tree = parse_ast_tree(mode(template.format(code)))
 
-    visitor = FunctionArgumentsVisitor(default_options, tree=tree)
+    visitor = FunctionSignatureVisitor(default_options, tree=tree)
     visitor.run()
 
     assert_errors(visitor, [], ignored_types=PositionalOnlyArgumentsViolation)

--- a/tests/test_visitors/test_ast/test_functions/test_getter_without_return.py
+++ b/tests/test_visitors/test_ast/test_functions/test_getter_without_return.py
@@ -1,0 +1,289 @@
+import pytest
+
+from wemake_python_styleguide.violations.best_practices import (
+    GetterWithoutReturnViolation,
+)
+from wemake_python_styleguide.visitors.ast.functions import (
+    FunctionSignatureVisitor,
+)
+
+getter_function_with_implicit_return = """
+def get_foo():
+    print('Hello world!')
+"""
+
+getter_function_with_bare_return = """
+def get_foo():
+    return
+"""
+
+getter_function_with_valued_return = """
+def get_foo():
+    return 1
+"""
+
+getter_function_with_explicit_none_return = """
+def get_foo():
+    return None
+"""
+
+getter_function_with_bare_yield = """
+def get_foo():
+    yield
+"""
+
+getter_function_with_valued_yield = """
+def get_foo():
+    yield 1
+"""
+
+getter_function_with_explicit_none_yield = """
+def get_foo():
+    yield None
+"""
+
+getter_function_with_yield_from = """
+def get_foo():
+    yield from [1]
+"""
+
+getter_method_with_implicit_return = """
+class Foo:
+    def get_foo(self):
+        print('Hello world')
+"""
+
+getter_method_with_bare_return = """
+class Foo:
+    def get_foo(self):
+        return
+"""
+
+getter_method_with_valued_return = """
+class Foo:
+    def get_foo(self):
+        return 1
+"""
+
+getter_method_with_explicit_none_return = """
+class Foo:
+    def get_foo(self):
+        return None
+"""
+
+getter_method_with_bare_yield = """
+class Foo:
+    def get_foo(self):
+        yield
+"""
+
+getter_method_with_valued_yield = """
+class Foo:
+    def get_foo(self):
+        yield 1
+"""
+
+getter_method_with_explicit_none_yield = """
+class Foo:
+    def get_foo(self):
+        yield None
+"""
+
+getter_method_with_yield_from = """
+class Foo:
+    def get_foo(self):
+        yield from [1]
+"""
+
+regular_function_with_bare_return = """
+class Foo:
+    def foo(self):
+        return
+"""
+
+regular_function_with_implicit_return = """
+class Foo:
+    def foo(self):
+        print('Hello World!')
+"""
+
+regular_function_with_bare_return = """
+class Foo:
+    def foo(self):
+        return
+"""
+
+regular_function_with_bare_yield = """
+class Foo:
+    def foo(self):
+        yield
+"""
+
+regular_method_with_bare_return = """
+class Foo:
+    def foo(self):
+        return
+"""
+
+regular_method_with_implicit_return = """
+class Foo:
+    def foo(self):
+        print('Hello world')
+"""
+
+regular_method_with_bare_return = """
+class Foo:
+    def foo(self):
+        return
+"""
+
+regular_method_with_bare_yield = """
+class Foo:
+    def foo(self):
+        yield
+"""
+
+getter_method_with_branched_return = """
+def get_foo():
+    if bar:
+        return 1
+"""
+
+getter_stub_with_docstring = """
+def get_foo():
+    '''Gets foo.'''
+"""
+
+getter_stub_with_ellipsis = """
+def get_foo():
+    ...
+"""
+
+getter_stub_with_raise = """
+def get_foo():
+    raise ValueError('Error')
+"""
+
+getter_stub_with_docstring_and_ellipsis = """
+def get_foo():
+    '''Gets foo.'''
+    ...
+"""
+
+getter_stub_with_docstring_and_raise = """
+def get_foo():
+    '''Gets Foo.'''
+    raise ValueError('Error')
+"""
+
+getter_stub_with_extra_statements = """
+def get_foo():
+    '''Gets foo.'''
+    print('Hello World')
+    ...
+"""
+
+
+@pytest.mark.parametrize('code', [
+    getter_function_with_implicit_return,
+    getter_function_with_bare_return,
+    getter_method_with_implicit_return,
+    getter_method_with_bare_return,
+    getter_stub_with_extra_statements,
+])
+def test_wrong_getters(
+    assert_errors,
+    parse_ast_tree,
+    default_options,
+    code,
+    mode,
+):
+    """Testing that getters which do not output values are forbidden."""
+    tree = parse_ast_tree(mode(code))
+
+    visitor = FunctionSignatureVisitor(default_options, tree=tree)
+    visitor.run()
+
+    assert_errors(visitor, [GetterWithoutReturnViolation])
+
+
+@pytest.mark.parametrize('code', [
+    getter_function_with_valued_return,
+    getter_function_with_explicit_none_return,
+    getter_function_with_bare_yield,
+    getter_function_with_valued_yield,
+    getter_function_with_explicit_none_yield,
+    getter_method_with_valued_return,
+    getter_method_with_explicit_none_return,
+    getter_method_with_bare_yield,
+    getter_method_with_valued_yield,
+    getter_method_with_explicit_none_yield,
+    getter_method_with_branched_return,
+    getter_stub_with_docstring,
+    getter_stub_with_ellipsis,
+    getter_stub_with_raise,
+    getter_stub_with_docstring_and_ellipsis,
+    getter_stub_with_docstring_and_raise,
+])
+def test_correct_getters(
+    assert_errors,
+    parse_ast_tree,
+    default_options,
+    code,
+    mode,
+):
+    """Testing that getters which output values are allowed."""
+    tree = parse_ast_tree(mode(code))
+
+    visitor = FunctionSignatureVisitor(default_options, tree=tree)
+    visitor.run()
+
+    assert_errors(visitor, [])
+
+
+@pytest.mark.parametrize('code', [
+    getter_function_with_yield_from,
+    getter_method_with_yield_from,
+])
+def test_correct_getter_with_yield_from(
+    assert_errors,
+    parse_ast_tree,
+    default_options,
+    code,
+):
+    """
+    Testing that getters with ``yield from`` expressions are allowed.
+
+    They need to be tested separately because ``yield from`` cannot be
+    used in ``async`` functions.
+    """
+    tree = parse_ast_tree(code)
+
+    visitor = FunctionSignatureVisitor(default_options, tree=tree)
+    visitor.run()
+
+    assert_errors(visitor, [])
+
+
+@pytest.mark.parametrize('code', [
+    regular_function_with_bare_return,
+    regular_function_with_implicit_return,
+    regular_function_with_bare_yield,
+    regular_method_with_bare_return,
+    regular_method_with_implicit_return,
+    regular_method_with_bare_yield,
+])
+def test_correct_non_getters(
+    assert_errors,
+    parse_ast_tree,
+    default_options,
+    code,
+    mode,
+):
+    """Testing that non-getter functions are allowed to not output values."""
+    tree = parse_ast_tree(mode(code))
+
+    visitor = FunctionSignatureVisitor(default_options, tree=tree)
+    visitor.run()
+
+    assert_errors(visitor, [])

--- a/tests/test_visitors/test_ast/test_functions/test_positional_only.py
+++ b/tests/test_visitors/test_ast/test_functions/test_positional_only.py
@@ -5,7 +5,7 @@ from wemake_python_styleguide.violations.best_practices import (
     PositionalOnlyArgumentsViolation,
 )
 from wemake_python_styleguide.visitors.ast.functions import (
-    FunctionArgumentsVisitor,
+    FunctionSignatureVisitor,
 )
 
 # Correct:
@@ -67,7 +67,7 @@ def test_not_posonlyargs(
     """Testing that regular code is allowed."""
     tree = parse_ast_tree(mode(code))
 
-    visitor = FunctionArgumentsVisitor(default_options, tree=tree)
+    visitor = FunctionSignatureVisitor(default_options, tree=tree)
     visitor.run()
 
     assert_errors(visitor, [])
@@ -93,7 +93,7 @@ def test_posonyargs(
     """Testing that ``/`` is not allowed."""
     tree = parse_ast_tree(mode(code))
 
-    visitor = FunctionArgumentsVisitor(default_options, tree=tree)
+    visitor = FunctionSignatureVisitor(default_options, tree=tree)
     visitor.run()
 
     assert_errors(visitor, [PositionalOnlyArgumentsViolation])

--- a/wemake_python_styleguide/logic/tree/functions.py
+++ b/wemake_python_styleguide/logic/tree/functions.py
@@ -1,5 +1,5 @@
-from ast import Call, Yield, YieldFrom, arg
-from typing import Container, List, Optional
+from ast import Call, Return, Yield, YieldFrom, arg, walk
+from typing import Container, Iterable, List, Optional, Tuple, Type, Union
 
 from wemake_python_styleguide.compat.functions import get_posonlyargs
 from wemake_python_styleguide.logic import source
@@ -8,6 +8,23 @@ from wemake_python_styleguide.types import (
     AnyFunctionDef,
     AnyFunctionDefAndLambda,
 )
+
+#: Expressions that causes control transfer from a routine
+_AnyControlTransfers = Union[
+    Return,
+    Yield,
+    YieldFrom,
+]
+
+#: Type annotation for an iterable of control transfer nodes
+_ControlTransferIterable = Iterable[_AnyControlTransfers]
+
+#: Type annotation for a tuple of control transfer nodes
+_ControlTransferTuple = Tuple[
+    Type[Return],
+    Type[Yield],
+    Type[YieldFrom],
+]
 
 
 def given_function_called(
@@ -102,3 +119,12 @@ def is_generator(node: AnyFunctionDef) -> bool:
         if is_contained(node=body_item, to_check=(Yield, YieldFrom)):
             return True
     return False
+
+
+def get_function_exit_nodes(node: AnyFunctionDef) -> _ControlTransferIterable:
+    """Yields nodes that cause a control transfer from a function."""
+    control_transfer_nodes = (Return, Yield, YieldFrom)
+    for body_item in node.body:
+        for sub_node in walk(body_item):
+            if isinstance(sub_node, control_transfer_nodes):
+                yield sub_node

--- a/wemake_python_styleguide/logic/tree/stubs.py
+++ b/wemake_python_styleguide/logic/tree/stubs.py
@@ -1,0 +1,52 @@
+from ast import AST, Ellipsis, Expr, Raise, Str
+
+from wemake_python_styleguide.types import AnyFunctionDef
+
+
+def is_stub(node: AnyFunctionDef) -> bool:
+    """
+    Checks if a function is a stub.
+
+    A function (or method) is considered to be a stub if it contains:
+        - only a docstring
+        - only an Ellipsis statement (i.e. `...`)
+        - only a `raise` statement
+        - a docstring + an Ellipsis statement
+        - a docstring + a `raise` statement
+    """
+    function_has_docstring = (
+        isinstance(node.body[0], Expr) and
+        isinstance(node.body[0].value, Str)
+    )
+    if function_has_docstring:
+        return _is_stub_with_docstring(node)
+    return _is_stub_without_docstring(node)
+
+
+def _is_stub_with_docstring(node: AnyFunctionDef) -> bool:
+    statements_in_body = len(node.body)
+    if statements_in_body == 1:
+        return True
+    elif statements_in_body == 2:
+        return (
+            _is_ellipsis(node.body[1]) or
+            isinstance(node.body[1], Raise)
+        )
+    return False
+
+
+def _is_stub_without_docstring(node: AnyFunctionDef) -> bool:
+    return (
+        len(node.body) == 1 and
+        (
+            _is_ellipsis(node.body[0]) or
+            isinstance(node.body[0], Raise)
+        )
+    )
+
+
+def _is_ellipsis(node: AST) -> bool:
+    return (
+        isinstance(node, Expr) and
+        isinstance(node.value, Ellipsis)
+    )

--- a/wemake_python_styleguide/presets/types/tree.py
+++ b/wemake_python_styleguide/presets/types/tree.py
@@ -53,7 +53,7 @@ PRESET: Final = (
     functions.UselessLambdaDefinitionVisitor,
     functions.WrongFunctionCallContextVisitior,
     functions.UnnecessaryLiteralsVisitor,
-    functions.FunctionArgumentsVisitor,
+    functions.FunctionSignatureVisitor,
     functions.FloatingNanCallVisitor,
 
     exceptions.WrongTryExceptVisitor,

--- a/wemake_python_styleguide/violations/best_practices.py
+++ b/wemake_python_styleguide/violations/best_practices.py
@@ -79,6 +79,7 @@ Summary
    SingleElementDestructuringViolation
    ForbiddenInlineIgnoreViolation
    WrongMultilineStringUseViolation
+   GetterWithoutReturnViolation
 
 Best practices
 --------------
@@ -146,6 +147,7 @@ Best practices
 .. autoclass:: SingleElementDestructuringViolation
 .. autoclass:: ForbiddenInlineIgnoreViolation
 .. autoclass:: WrongMultilineStringUseViolation
+.. autoclass:: GetterWithoutReturnViolation
 
 """
 
@@ -2430,3 +2432,36 @@ class WrongMultilineStringUseViolation(TokenizeViolation):
 
     error_template = 'Wrong multiline string usage'
     code = 462
+
+
+@final
+class GetterWithoutReturnViolation(ASTViolation):
+    """
+    Forbids to have functions starting with ``get_`` without returning a value.
+
+    Applies to both methods and functions.
+
+    Reasoning:
+        A ``get_`` function is generally expected to return a value. Otherwise,
+        it is most likely either an error or bad naming.
+
+    Solution:
+        Make sure getter functions ``return`` or ``yield`` a value on all
+        execution paths, or rename the function.
+
+    Example::
+
+        # Correct
+        def get_random_number():
+             return random.randint(1, 10)
+
+        # Wrong
+        def get_random_number():
+             print('I do not return a value!')
+
+    .. versionadded:: 0.15.0
+
+    """
+
+    error_template = 'Found a getter without a return value'
+    code = 463


### PR DESCRIPTION

# I have made things!

- Add `GetterWithoutReturnViolation`, triggered when functions and
  methods whose name starts with `get_` returns nothing

- Rename `FunctionArgumentVisitor` to `FunctionSignatureVisitor`,
  in preparation to add code that checks the function name as well

- Add code checking for `GetterWithoutReturnViolation` to
  `FunctionSignatureVisitor`

- Add noqa tests

- Add unit test for `GetterWithoutReturnViolation` in
  `test_functions/test_getter_without_return.py`

- Update CHANGELOG.md appropriately

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made
- [x] I have added my changes to the `CHANGELOG.md`

- Closes #1382 