### PR TITLE
Fix #1373: add pprint.pprint() to function blacklist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Semantic versioning in our case means:
 - Allow to use `^` with `1`
 - Fixes false positives in WPS513 and WPS323
 - Fixes false positive WPS426 if `lambda` in loop uses only its arguments
+- Fixes false negative WPS421 with `pprint.pprint`
 
 ### Misc
 

--- a/tests/test_visitors/test_ast/test_functions/test_wrong_function_calls.py
+++ b/tests/test_visitors/test_ast/test_functions/test_wrong_function_calls.py
@@ -42,6 +42,33 @@ def test_wrong_function_called(
     assert_error_text(visitor, bad_function)
 
 
+@pytest.mark.parametrize('bad_module_and_function', [
+    'pprint.pprint',
+])
+@pytest.mark.parametrize('code', [
+    regular_call,
+    assignment_call,
+    nested_function_call,
+])
+def test_wrong_function_call_with_module(
+    assert_errors,
+    assert_error_text,
+    parse_ast_tree,
+    bad_module_and_function,
+    code,
+    default_options,
+    mode,
+):
+    """Testing that a module.function() call can be restricted."""
+    tree = parse_ast_tree(mode(code.format(bad_module_and_function)))
+
+    visitor = WrongFunctionCallVisitor(default_options, tree=tree)
+    visitor.run()
+
+    assert_errors(visitor, [WrongFunctionCallViolation])
+    assert_error_text(visitor, bad_module_and_function)
+
+
 @pytest.mark.parametrize('good_function', [
     'len',
     'abs',

--- a/wemake_python_styleguide/constants.py
+++ b/wemake_python_styleguide/constants.py
@@ -36,6 +36,7 @@ FUNCTIONS_BLACKLIST: Final = frozenset((
     # IO:
     'print',
     'pprint',
+    'pprint.pprint',
     'input',
     'breakpoint',
 


### PR DESCRIPTION
# I have made things!

Previously `pprint()` was only caught by WPS421 if imported with a `from import`.
i.e The following would pass all checks:
```py
import pprint
pprint.pprint('hi')
```

This PR adds `pprint.pprint` to the function blacklist to correct this and adds an explicit test for it (consequently it also tests that a callable attribute can be caught by blacklisting it)

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Checklist

<!-- Please check everything that applies: -->

- [X] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [X] I have created at least one test case for the changes I have made
- [X] I have updated the documentation for the changes I have made
- [X] I have added my changes to the `CHANGELOG.md`

## Related issues

Closes #1373 
<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->

🙏 Please, if you or your company is finding wemake-python-styleguide valuable, help us sustain the project by sponsoring it transparently on https://opencollective.com/wemake-python-styleguide. As a thank you, your profile/company logo will be added to our main README which receives hundreds of unique visitors per day.
