### PR TITLE
remove quoting from GitHub actions entrypoint

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -8,7 +8,7 @@ flake8 --version
 echo '================================='
 echo
 
-# Runs flake8, possibly with reviewdog:
+# Runs `flake8`, possibly with `reviewdog`:
 if [ "$INPUT_REPORTER" == 'terminal' ]; then
   output=$(flake8 $INPUT_PATH)
   status="$?"
@@ -17,7 +17,7 @@ elif [ "$INPUT_REPORTER" == 'github-pr-review' ] ||
   # We will need this token for `reviewdog` to work:
   export REVIEWDOG_GITHUB_API_TOKEN="$GITHUB_TOKEN"
 
-  # Running special version of `flake8` to mathc the `reviewdog` format:
+  # Running special version of `flake8` to match the `reviewdog` format:
   output=$(flake8 $INPUT_PATH --append-config='/action-config.cfg')
   echo "$output" | reviewdog -f=pep8 -reporter="$INPUT_REPORTER" -level=error
   # `reviewdog` does not fail with any status code, so we have to get dirty:

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -10,7 +10,7 @@ echo
 
 # Runs flake8, possibly with reviewdog:
 if [ "$INPUT_REPORTER" == 'terminal' ]; then
-  output=$(flake8 "$INPUT_PATH")
+  output=$(flake8 $INPUT_PATH)
   status="$?"
 elif [ "$INPUT_REPORTER" == 'github-pr-review' ] ||
      [ "$INPUT_REPORTER" == 'github-pr-check' ]; then
@@ -18,7 +18,7 @@ elif [ "$INPUT_REPORTER" == 'github-pr-review' ] ||
   export REVIEWDOG_GITHUB_API_TOKEN="$GITHUB_TOKEN"
 
   # Running special version of `flake8` to mathc the `reviewdog` format:
-  output=$(flake8 "$INPUT_PATH" --append-config='/action-config.cfg')
+  output=$(flake8 $INPUT_PATH --append-config='/action-config.cfg')
   echo "$output" | reviewdog -f=pep8 -reporter="$INPUT_REPORTER" -level=error
   # `reviewdog` does not fail with any status code, so we have to get dirty:
   status=$(test "$output" = ''; echo $?)


### PR DESCRIPTION
# I have made things!

Remove quoting of `$INPUT_PATH`, because it was generating wrong `flake8` invocations for multiple space-separated files, that causes errors like the following one:

> wemake_python_styleguide/types.py wemake_python_styleguide/visitors/tokenize/comments.py :0:1: E902 FileNotFoundError: [Errno 2] No such file or directory: 'wemake_python_styleguide/types.py wemake_python_styleguide/visitors/tokenize/comments.py '

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [ ] I have created at least one test case for the changes I have made
- [ ] I have updated the documentation for the changes I have made
- [ ] I have added my changes to the `CHANGELOG.md`

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

This bug was discovered during working on #1751 

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->

🙏 Please, if you or your company is finding wemake-python-styleguide valuable, help us sustain the project by sponsoring it transparently on https://opencollective.com/wemake-python-styleguide. As a thank you, your profile/company logo will be added to our main README which receives hundreds of unique visitors per day.
