### PR TITLE
--allowed-no-effect-binary-operators implemented

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,14 @@ Semantic versioning in our case means:
 - Updates `reviewdog` version to `0.11.0` and adds `action-depup`
 
 
+## 0.14.2
+
+### Features
+
+- Adds an option: `--allowed-no-effect-binary-operators`, which allows ignoring
+  no effect violation for selected binary operators #1737.
+
+
 ## 0.14.0 aka The Walrus fighter
 
 This release was focused on adding `python3.8` support,

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ FROM python:3.8.6-alpine
 LABEL maintainer="sobolevn@wemake.services"
 LABEL vendor="wemake.services"
 
-ENV WPS_VERSION='0.14.1'
+ENV WPS_VERSION='0.14.2'
 ENV REVIEWDOG_VERSION='v0.11.0'
 
 RUN apk add --no-cache bash git wget

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ style = "styles/nitpick-style-wemake.toml"
 
 [tool.poetry]
 name = "wemake-python-styleguide"
-version = "0.14.1"
+version = "0.14.2"
 description = "The strictest and most opinionated python linter ever"
 
 license = "MIT"

--- a/wemake_python_styleguide/options/config.py
+++ b/wemake_python_styleguide/options/config.py
@@ -59,9 +59,10 @@ You can also show all options that ``flake8`` supports by running:
 - ``forbidden-inline-ignore`` - list of codes of violations or
     class of violations that are forbidden to ignore inline, defaults to
     :str:`wemake_python_styleguide.options.defaults.FORBIDDEN_NOQA`
-- ``allowed-no-effect-binary-operators`` - list of binary operators that are
-    ignored by no effect violation, defaults to
-    :str:`wemake_python_styleguide.options.defaults.ALLOWED_NO_EFFECT_BINARY_OPERATORS`
+- ``allowed-no-effect-binary-operators`` - comma separated binary operators that
+    are ignored by no effect violation, defaults to
+    :str:`wemake_python_styleguide.options.defaults.ALLOWED_NO_EFFECT_BINARY_OPERATORS`,
+    example: ``--allowed-no-effect-binary-operators '>>,&'``.
 
 
 .. rubric:: Complexity options

--- a/wemake_python_styleguide/options/config.py
+++ b/wemake_python_styleguide/options/config.py
@@ -59,6 +59,9 @@ You can also show all options that ``flake8`` supports by running:
 - ``forbidden-inline-ignore`` - list of codes of violations or
     class of violations that are forbidden to ignore inline, defaults to
     :str:`wemake_python_styleguide.options.defaults.FORBIDDEN_NOQA`
+- ``allowed-no-effect-binary-operators`` - list of binary operators that are
+    ignored by no effect violation, defaults to
+    :str:`wemake_python_styleguide.options.defaults.ALLOWED_NO_EFFECT_BINARY_OPERATORS`
 
 
 .. rubric:: Complexity options
@@ -259,6 +262,14 @@ class Configuration(object):
             defaults.FORBIDDEN_INLINE_IGNORE,
             'Codes of violations or class of violations forbidden to ignore.',
             type='string',
+            comma_separated_list=True,
+        ),
+
+        _Option(
+            '--allowed-no-effect-binary-operators',
+            defaults.ALLOWED_NO_EFFECT_BINARY_OPERATORS,
+            'Binary operators that are ignored by no effect violation.',
+            type=string,
             comma_separated_list=True,
         ),
 

--- a/wemake_python_styleguide/options/defaults.py
+++ b/wemake_python_styleguide/options/defaults.py
@@ -45,6 +45,9 @@ FORBIDDEN_DOMAIN_NAMES: Final = ()
 #: Violation codes that are forbidden to use.
 FORBIDDEN_INLINE_IGNORE: Final = ()
 
+#: Binary operators that are ignored by no effect violation.
+ALLOWED_NO_EFFECT_BINARY_OPERATORS: Final = ()
+
 # ===========
 # Complexity:
 # ===========

--- a/wemake_python_styleguide/options/validation.py
+++ b/wemake_python_styleguide/options/validation.py
@@ -66,6 +66,9 @@ class _ValidatedOptions(object):
     allowed_domain_names: Tuple[str, ...] = attr.ib(converter=tuple)
     forbidden_domain_names: Tuple[str, ...] = attr.ib(converter=tuple)
     forbidden_inline_ignore: Tuple[str, ...] = attr.ib(converter=tuple)
+    allowed_no_effect_binary_operators: Tuple[str, ...] = attr.ib(
+        converter=tuple,
+    )
 
     # Complexity:
     max_arguments: int = attr.ib(validator=[_min_max(min=1)])

--- a/wemake_python_styleguide/types.py
+++ b/wemake_python_styleguide/types.py
@@ -155,6 +155,10 @@ class ConfigurationOptions(Protocol):
     def forbidden_domain_names(self) -> Tuple[str, ...]:
         ...
 
+    @property
+    def allowed_no_effect_binary_operators(self) -> Tuple[str, ...]:
+        ...
+
     # Complexity:
     @property
     def max_arguments(self) -> int:

--- a/wemake_python_styleguide/violations/best_practices.py
+++ b/wemake_python_styleguide/violations/best_practices.py
@@ -1202,8 +1202,13 @@ class StatementHasNoEffectViolation(ASTViolation):
             8 + 2
             print
 
+    Configuration:
+        This rule is configurable with `--allowed-no-effect-binary-operators``.
+        Default:
+        :str:`wemake_python_styleguide.options.defaults.ALLOWED_NO_EFFECT_BINARY_OPERATORS`
+
     .. versionadded:: 0.5.0
-    .. versionchanged:: 0.11.0
+    .. versionchanged:: 0.14.2
     """
 
     error_template = 'Found statement that has no effect'


### PR DESCRIPTION
This PR introduces `--allowed-no-effect-binary-operators` configuration option which allows to ignore StatementHasNoEffectViolation for selected binary operators. As stated in the issue, this is useful to disable the check for binary shift operators (`>>` and `<<`) in specific domains like Airflow DAG codebases: these operators are used to define dependencies between tasks and a hardly ever used as numbers-related shift operators (e.g. `1 << 2`). This allows to safely disable check for such codebase.

I need some help with the following:
* Current code violates WPS rules and does not pass flake8 check due to the following reasons:
  * A new added test (`test_ignored_statement_with_no_effect`) is the 8th function within `tests/test_visitors/test_ast/test_statements/test_statements_with_no_effect.py` file. Maximum number of module members is set to 7 (WPS202). I have tried to move the test to a separate module but I need all these templates defined in the file (`module_template`, `if_template`, etc, parameterized by pytest). And the full module name is too long (`from tests.test_visitors.test_ast.test_statements.test_statements_with_no_effect` is already >80 characters long). So what should I do? Put this file to per-file-ignores? Or still move the test to a dedicated file and copy-paste templates? They are used by all the tests in `test_statements_with_no_effect.py` file.
  * The new option parameterizes `StatementsWithBodiesVisitor` so I had to add `__init__` method and it is the 8th method within `StatementsWithBodiesVisitor` class. Maximum class members is set to 7 (WPS214). How should I avoid the violation? Create a mixin class with `allowed_no_effect_binary_operators`-related logic? Or use a `noqa` comment on a class?
* Finally I want `--allowed-no-effect-binary-operators` option to be in sync with set of available values defined in `StatementsWithBodiesVisitor._string_to_binary_operator`. Currently if unsupported operator is provided, a `KeyError` is raised at `StatementsWithBodiesVisitor.__init__` which is unobvious. Any ideas on how to do that more user-friendly? `--allowed-no-effect-binary-operators` seems to be the first string-typed comma-separated option with fixed set of values so I have not seen an example on how to implement this.
* Should I manually change html docs? Or are they built automatically? I have found nothing related in [the contribution guide](https://wemake-python-stylegui.de/en/latest/pages/api/contributing.html#before-submitting). Or is it what mentioned in action point no.5? I have changed docstrings but not html files.

## Checklist

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made
- [x] I have added my changes to the `CHANGELOG.md`

## Related issues

- Closes #1737 
