### PR TITLE
Fixed 2 grammatical errors in docs/pages/api/index.rst

### DIFF
--- a/docs/pages/api/index.rst
+++ b/docs/pages/api/index.rst
@@ -31,13 +31,13 @@ Philosophy
 ----------
 
 1. Done is better than perfect
-2. However, we pursuit perfect software
+2. However, we pursue perfect software
 3. False negatives over false positives
 4. If you cannot sustain your promise - do not promise
 5. Code must be written for people to read,
    and only incidentally for machines to execute
 6. Value consistency over syntax-ish readability
-7. Consistent code is more readable then inconsistent
+7. Consistent code is more readable than inconsistent
 8. Do not force people to choose, they will make mistakes
 9. Made choices must be respected
 


### PR DESCRIPTION
# Fixed grammatical errors in documentation

Nothing major, just fixed the two grammatical errors in docs/pages/api/index.rst.

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Related issues

- Refs #1829 

Documentation: https://wemake-python-stylegui.de/en/latest/pages/api/index.html
