### PR TITLE
Fix BitwiseAndBooleanMixupViolation in type annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ Semantic versioning in our case means:
   But, in the future we might change the configuration names / logic,
   change the client facing API, change code conventions signigicantly, etc.
 
+## 0.15.2
+
+### Bugfixes
+
+- Fixes `BitwiseAndBooleanMixupViolation` work with PEP 604 union types #1884
 
 ## 0.15.1
 

--- a/tests/test_visitors/test_ast/test_operators/test_bitwise_boolean_mixup.py
+++ b/tests/test_visitors/test_ast/test_operators/test_bitwise_boolean_mixup.py
@@ -58,3 +58,30 @@ def test_correct_binary(
     visitor.run()
 
     assert_errors(visitor, [])
+
+
+@pytest.mark.parametrize('context', [
+    'foo: {0}',
+    'def fun(foo) -> {0}: ...',
+    'def fun(foo: {0}): ...',
+])
+@pytest.mark.parametrize('expression', [
+    'str | int',
+    'int | None',
+    'First | None',
+    'First | Second',
+])
+def test_union_type(
+    assert_errors,
+    parse_ast_tree,
+    context,
+    expression,
+    default_options,
+):
+    """Testing PEP 604 union types."""
+    tree = parse_ast_tree(context.format(expression))
+
+    visitor = BitwiseOpVisitor(default_options, tree=tree)
+    visitor.run()
+
+    assert_errors(visitor, [])


### PR DESCRIPTION
# I have made things!

## Checklist

- [X] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [X] I have created at least one test case for the changes I have made
- [ ] I have updated the documentation for the changes I have made
- [X] I have added my changes to the `CHANGELOG.md`

## Related issues

Closes #1884 
