### PR TITLE
Add exception for ImplicitEnumerateViolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Semantic versioning in our case means:
 ### Bugfixes
 
 - Fixes `BitwiseAndBooleanMixupViolation` work with PEP 604 union types #1884
+- Fixes `ImplicitEnumerateViolation` raised outside of for loops
 
 ## 0.15.1
 

--- a/tests/test_visitors/test_ast/test_functions/test_call_context/test_range_len.py
+++ b/tests/test_visitors/test_ast/test_functions/test_call_context/test_range_len.py
@@ -19,6 +19,9 @@ from wemake_python_styleguide.visitors.ast.functions import (
     'len(range(10))',
     'range(0, len(some), 2)',
     'range(0, len(some), -2)',
+    'combinations(range(len(foo)), 2)',
+    'itertools.combinations(range(len(foo)), 2)',
+    'range(len(bar))',
 ])
 def test_correct_range_len(
     assert_errors,
@@ -26,7 +29,7 @@ def test_correct_range_len(
     code,
     default_options,
 ):
-    """Testing that ``range()`` can be used."""
+    """Testing that ``range(len(...))`` can be used outside loops."""
     tree = parse_ast_tree(code)
 
     visitor = WrongFunctionCallContextVisitor(default_options, tree=tree)
@@ -49,8 +52,9 @@ def test_range_len(
     code,
     default_options,
 ):
-    """Testing that ``range(len(...))`` cannot be used."""
-    tree = parse_ast_tree(code)
+    """Testing that ``range(len(...))`` cannot be used inside loops."""
+    context = 'for foo in {0}: foo'
+    tree = parse_ast_tree(context.format(code))
 
     visitor = WrongFunctionCallContextVisitor(default_options, tree=tree)
     visitor.run()

--- a/wemake_python_styleguide/visitors/ast/functions.py
+++ b/wemake_python_styleguide/visitors/ast/functions.py
@@ -243,6 +243,9 @@ class WrongFunctionCallContextVisitor(base.BaseNodeVisitor):
         if not functions.given_function_called(node, {'range'}):
             return
 
+        if self._is_outside_of_loop(node):
+            return
+
         args_len = len(node.args)
 
         is_one_arg_range = (
@@ -265,6 +268,11 @@ class WrongFunctionCallContextVisitor(base.BaseNodeVisitor):
         )
         if any([is_one_arg_range, is_two_args_range, is_three_args_range]):
             self.add_violation(ImplicitEnumerateViolation(node))
+
+    # checks if `range(len(...))` is used outside of a for loop
+    def _is_outside_of_loop(self, node: ast.Call) -> bool:
+        parent_node = nodes.get_parent(node)
+        return not isinstance(parent_node, ast.For)
 
     def _is_multiple_args_range_with_len(self, node: ast.Call) -> bool:
         return bool(


### PR DESCRIPTION
Allow using `range(len(...))` as first argument of `itertools.combinations`.

## Checklist

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [ ] I have updated the documentation for the changes I have made
- [x] I have added my changes to the `CHANGELOG.md`

## Related issues

Closes #1883
