### PR TITLE
Git ignore asdf .tool-versions file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,9 @@ target/
 # pyenv
 .python-version
 
+# asdf
+.tool-versions
+
 # celery beat schedule file
 celerybeat-schedule
 


### PR DESCRIPTION
Asdf is a version manager that can be used for python and other programming
languages and tools. It is similar to pyenv in that regard. It uses a
`.tool-versions` file to specify versions of tools used in a project. Since
pyenv's equivalent, `.python-version`, is ignored, `.tool-versions` should be
ignored as well.