### PR TITLE
issue-1880: fixes that ConstantConditionViolation was not reported for a BoolOp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Semantic versioning in our case means:
 - Fixes `BitwiseAndBooleanMixupViolation` work with PEP 604 union types #1884
 - Fixes `CognitiveModuleComplexityViolation` to not trigger
   for a single-item modules
+- Fixes that `ConstantConditionViolation` was not reported for a BoolOp
 
 
 ## 0.15.1

--- a/tests/test_visitors/test_ast/test_compares/test_conditionals.py
+++ b/tests/test_visitors/test_ast/test_compares/test_conditionals.py
@@ -60,7 +60,7 @@ def container():
     'variable is False',
     '[1, 2, 3].size > 3',
     'variable is None',
-    'variable is int or not None',
+    'variable is int or not some()',
     pytest.param(
         '(unique := some()) is True',
         marks=pytest.mark.skipif(not PY38, reason='walrus appeared in 3.8'),
@@ -107,6 +107,10 @@ def test_valid_conditional(
     '{"set"}',
     '("tuple",)',
     '["list"]',
+    'variable or False',
+    'variable and False',
+    'variable or True',
+    'variable and True',
     pytest.param(
         '(unique := True)',
         marks=pytest.mark.skipif(not PY38, reason='walrus appeared in 3.8'),

--- a/wemake_python_styleguide/visitors/ast/compares.py
+++ b/wemake_python_styleguide/visitors/ast/compares.py
@@ -333,9 +333,13 @@ class WrongConditionalVisitor(BaseNodeVisitor):
         self.generic_visit(node)
 
     def _check_constant_condition(self, node: ast.AST) -> None:
-        real_node = operators.unwrap_unary_node(get_assigned_expr(node))
-        if isinstance(real_node, self._forbidden_nodes):
-            self.add_violation(ConstantConditionViolation(node))
+        if isinstance(node, ast.BoolOp):
+            for condition in node.values:
+                self._check_constant_condition(condition)
+        else:
+            real_node = operators.unwrap_unary_node(get_assigned_expr(node))
+            if isinstance(real_node, self._forbidden_nodes):
+                self.add_violation(ConstantConditionViolation(node))
 
     def _check_simplifiable_if(self, node: ast.If) -> None:
         if not ifs.is_elif(node) and not ifs.root_if(node):


### PR DESCRIPTION
# I have made things!

## Checklist

- [X] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [X] I have created at least one test case for the changes I have made
- [ ] I have updated the documentation for the changes I have made
- [X] I have added my changes to the `CHANGELOG.md`

## Related issues
- Closes #1880

Waiting for your feedback.
Is it OK to check for BoolOp or i should do it with `visit_BoolOp` and check for a parent?

🙏 Please, if you or your company is finding wemake-python-styleguide valuable, help us sustain the project by sponsoring it transparently on https://opencollective.com/wemake-python-styleguide. As a thank you, your profile/company logo will be added to our main README which receives hundreds of unique visitors per day.
