### PR TITLE
1731 Forbid returning too long tuples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,12 @@ Semantic versioning in our case means:
 - Forbids getting first element of list by unpacking
 
 
+## 0.16.0
+
+### Features
+
+- Now `WPS227` forbids returning tuples that are too long
+
 ## 0.15.2
 
 ### Bugfixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ Semantic versioning in our case means:
 - Adds `KwargsUnpackingInClassDefinitionViolation` #1714
 - `DirectMagicAttributeAccessViolation` now only flags instances for which
   a known alternative exists #2268
+- Forbids getting collection element of list by unpacking #1824
+- Now `WPS227` forbids returning tuples that are too long #1731
 
 ### Bugfixes
 
@@ -68,18 +70,6 @@ Semantic versioning in our case means:
 - Adds documentation (and tests) for how to run project on Jupyter Notebooks
 - Updates `mypy` to `0.902` and fixes type issues
 
-## 0.16.0
-
-### Features
-
-- Forbids getting first element of list by unpacking
-
-
-## 0.16.0
-
-### Features
-
-- Now `WPS227` forbids returning tuples that are too long
 
 ## 0.15.2
 

--- a/tests/fixtures/noqa/noqa.py
+++ b/tests/fixtures/noqa/noqa.py
@@ -813,3 +813,6 @@ class TestClass(object, **{}):  # noqa: WPS470
 
 secondary_slice = items[1:][:3]  # noqa: WPS471
 first, *_rest = some_collection  # noqa: WPS472
+
+def foo2_func():
+    return (1, 2, 3, 4, 5, 6)  # noqa: WPS227

--- a/tests/test_checker/test_noqa.py
+++ b/tests/test_checker/test_noqa.py
@@ -102,7 +102,7 @@ SHOULD_BE_RAISED = types.MappingProxyType({
     'WPS224': 0,  # defined in version specific table.
     'WPS225': 1,
     'WPS226': 0,  # defined in ignored violations.
-    'WPS227': 1,
+    'WPS227': 2,
     'WPS228': 1,
     'WPS229': 1,
     'WPS230': 1,

--- a/tests/test_visitors/test_ast/test_complexity/test_counts/test_output_length.py
+++ b/tests/test_visitors/test_ast/test_complexity/test_counts/test_output_length.py
@@ -1,18 +1,21 @@
 import pytest
 
-from wemake_python_styleguide.constants import MAX_LEN_YIELD_TUPLE
+from wemake_python_styleguide.constants import MAX_LEN_TUPLE_OUTPUT
 from wemake_python_styleguide.violations.complexity import (
-    TooLongYieldTupleViolation,
+    TooLongOutputTupleViolation,
 )
 from wemake_python_styleguide.visitors.ast.complexity.counts import (
-    YieldTupleVisitor,
+    ReturnLikeStatementTupleVisitor,
 )
+
+RETURN_LIKE_STATEMENTS = ('return', 'yield')
+
 
 generator = """
 def function_name():
     i = 0
     while True:
-        yield {0}
+        {0} {1}
         i = i + 1
 """
 
@@ -30,17 +33,19 @@ tuple_short = 'i, i + 1, i + 2'
     tuple_empty,
     tuple_fixed_short,
 ])
-def test_yield_length_normal(
+@pytest.mark.parametrize('return_like', RETURN_LIKE_STATEMENTS)
+def test_output_length_normal(
     assert_errors,
     parse_ast_tree,
     tuple_param,
     mode,
     default_options,
+    return_like,
 ):
     """Testing that classes and functions in a module work well."""
-    tree = parse_ast_tree(mode(generator.format(tuple_param)))
+    tree = parse_ast_tree(mode(generator.format(return_like, tuple_param)))
 
-    visitor = YieldTupleVisitor(default_options, tree=tree)
+    visitor = ReturnLikeStatementTupleVisitor(default_options, tree=tree)
     visitor.run()
 
     assert_errors(visitor, [])
@@ -50,19 +55,21 @@ def test_yield_length_normal(
     tuple_long,
     tuple_fixed_long,
 ])
-def test_yield_length_violation(
+@pytest.mark.parametrize('return_like', RETURN_LIKE_STATEMENTS)
+def test_output_length_violation(
     assert_errors,
     assert_error_text,
     parse_ast_tree,
     tuple_param,
     mode,
     default_options,
+    return_like,
 ):
     """Testing that classes and functions in a module work well."""
-    tree = parse_ast_tree(mode(generator.format(tuple_param)))
+    tree = parse_ast_tree(mode(generator.format(return_like, tuple_param)))
 
-    visitor = YieldTupleVisitor(default_options, tree=tree)
+    visitor = ReturnLikeStatementTupleVisitor(default_options, tree=tree)
     visitor.run()
 
-    assert_errors(visitor, [TooLongYieldTupleViolation])
-    assert_error_text(visitor, 6, MAX_LEN_YIELD_TUPLE)
+    assert_errors(visitor, [TooLongOutputTupleViolation])
+    assert_error_text(visitor, 6, MAX_LEN_TUPLE_OUTPUT)

--- a/wemake_python_styleguide/constants.py
+++ b/wemake_python_styleguide/constants.py
@@ -406,8 +406,8 @@ MAGIC_NUMBERS_WHITELIST: Final = frozenset((
 #: Maximum amount of ``pragma`` no-cover comments per module.
 MAX_NO_COVER_COMMENTS: Final = 5
 
-#: Maximum length of ``yield`` ``tuple`` expressions.
-MAX_LEN_YIELD_TUPLE: Final = 5
+#: Maximum length of ``yield`` or ``return`` ``tuple`` expressions.
+MAX_LEN_TUPLE_OUTPUT: Final = 5
 
 #: Maximum number of compare nodes in a single expression.
 MAX_COMPARES: Final = 2

--- a/wemake_python_styleguide/presets/topics/complexity.py
+++ b/wemake_python_styleguide/presets/topics/complexity.py
@@ -31,7 +31,7 @@ PRESET: Final = (
     counts.ConditionsVisitor,
     counts.ElifVisitor,
     counts.TryExceptVisitor,
-    counts.YieldTupleVisitor,
+    counts.ReturnLikeStatementTupleVisitor,
     counts.TupleUnpackVisitor,
 
     classes.ClassComplexityVisitor,

--- a/wemake_python_styleguide/violations/complexity.py
+++ b/wemake_python_styleguide/violations/complexity.py
@@ -47,7 +47,7 @@ Summary
    TooManyForsInComprehensionViolation
    TooManyExceptCasesViolation
    OverusedStringViolation
-   TooLongYieldTupleViolation
+   TooLongOutputTupleViolation
    TooLongCompareViolation
    TooLongTryBodyViolation
    TooManyPublicAttributesViolation
@@ -89,7 +89,7 @@ Structure complexity
 .. autoclass:: TooManyForsInComprehensionViolation
 .. autoclass:: TooManyExceptCasesViolation
 .. autoclass:: OverusedStringViolation
-.. autoclass:: TooLongYieldTupleViolation
+.. autoclass:: TooLongOutputTupleViolation
 .. autoclass:: TooLongCompareViolation
 .. autoclass:: TooLongTryBodyViolation
 .. autoclass:: TooManyPublicAttributesViolation
@@ -884,22 +884,24 @@ class OverusedStringViolation(MaybeASTViolation):
 
 
 @final
-class TooLongYieldTupleViolation(ASTViolation):
+class TooLongOutputTupleViolation(ASTViolation):
     """
-    Forbid yielding tuples that are too long.
+    Forbid returning or yielding tuples that are too long.
 
     Reasoning:
-        Long yield tuples complicate generator usage.
+        Long output tuples complicate function or generator usage.
         This rule helps to reduce complication.
 
     Solution:
         Use lists of similar type or wrapper objects.
 
     .. versionadded:: 0.10.0
+    .. versionchanged:: 0.16.0
+
 
     """
 
-    error_template = 'Found too long yield tuple: {0}'
+    error_template = 'Found too long function output tuple: {0}'
     code = 227
 
 

--- a/wemake_python_styleguide/visitors/ast/complexity/counts.py
+++ b/wemake_python_styleguide/visitors/ast/complexity/counts.py
@@ -16,6 +16,7 @@ from wemake_python_styleguide.visitors.decorators import alias
 # Type aliases:
 _ConditionNodes = Union[ast.If, ast.While, ast.IfExp]
 _ModuleMembers = Union[AnyFunctionDef, ast.ClassDef]
+_ReturnLikeStatement = Union[ast.Return, ast.Yield]
 
 
 @final
@@ -205,22 +206,26 @@ class TryExceptVisitor(BaseNodeVisitor):
 
 
 @final
-class YieldTupleVisitor(BaseNodeVisitor):
-    """Finds too long ``tuples`` in ``yield`` expressions."""
+@alias('visit_return_like', (
+    'visit_Return',
+    'visit_Yield',
+))
+class ReturnLikeStatementTupleVisitor(BaseNodeVisitor):
+    """Finds too long ``tuples`` in ``yield`` and ``return`` expressions."""
 
-    def visit_Yield(self, node: ast.Yield) -> None:
-        """Helper to get all ``yield`` nodes in a function at once."""
-        self._check_yield_values(node)
+    def visit_return_like(self, node: _ReturnLikeStatement) -> None:
+        """Helper to get all ``yield`` and ``return`` nodes in a function."""
+        self._check_return_like_values(node)
         self.generic_visit(node)
 
-    def _check_yield_values(self, node: ast.Yield) -> None:
+    def _check_return_like_values(self, node: _ReturnLikeStatement) -> None:
         if isinstance(node.value, ast.Tuple):
-            if len(node.value.elts) > constants.MAX_LEN_YIELD_TUPLE:
+            if len(node.value.elts) > constants.MAX_LEN_TUPLE_OUTPUT:
                 self.add_violation(
-                    complexity.TooLongYieldTupleViolation(
+                    complexity.TooLongOutputTupleViolation(
                         node,
                         text=str(len(node.value.elts)),
-                        baseline=constants.MAX_LEN_YIELD_TUPLE,
+                        baseline=constants.MAX_LEN_TUPLE_OUTPUT,
                     ),
                 )
 


### PR DESCRIPTION
# I have made things!

This PR extends `TooLongYieldTupleViolation` realization this way:

* Violation is new
* Tests and visitor was extended to cover this violation
* Constant is new (`MAX_LEN_RETURN_TUPLE`). I am not sure how do they work, but doc says they are a public API. So I decided I should not rename constant to cover both cases, to not to break API.

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made
- [x] I have added my changes to the `CHANGELOG.md`

## Related issues

- Closes #1731 

