### PR TITLE
Issue 1958 - Else block detected as useless incase of loop breaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ Semantic versioning in our case means:
   There are no major releases right now: we are still at `0.x.y` version.
   But, in the future we might change the configuration names / logic,
   change the client facing API, change code conventions signigicantly, etc.
+  
+  
+## 0.15.3 WIP
+
+### Bugfixes
+
+- Fixes `UselessReturningElseViolation` to not report `else` with `break` #1958
 
 
 ## 0.15.2

--- a/tests/test_visitors/test_ast/test_conditions/test_useless_else/test_useless_loop_else.py
+++ b/tests/test_visitors/test_ast/test_conditions/test_useless_else/test_useless_loop_else.py
@@ -148,7 +148,7 @@ def test_else_that_can_be_removed(
     tree = parse_ast_tree(mode(template.format(code1, code2)))
     visitor = UselessElseVisitor(default_options, tree=tree)
     visitor.run()
-    overrides = ['break']
+    overrides = ['break']  # regression1958
     if code1 in overrides:
         # We might want to have an else statement
         # if the loop contains a break statement

--- a/tests/test_visitors/test_ast/test_conditions/test_useless_else/test_useless_loop_else.py
+++ b/tests/test_visitors/test_ast/test_conditions/test_useless_else/test_useless_loop_else.py
@@ -146,11 +146,15 @@ def test_else_that_can_be_removed(
 ):
     """Testing that extra ``else`` blocks can be removed."""
     tree = parse_ast_tree(mode(template.format(code1, code2)))
-
     visitor = UselessElseVisitor(default_options, tree=tree)
     visitor.run()
-
-    assert_errors(visitor, [UselessReturningElseViolation])
+    overrides = ['break']
+    if code1 in overrides:
+        # We might want to have an else statement
+        # if the loop contains a break statement
+        assert_errors(visitor, [])
+    else:
+        assert_errors(visitor, [UselessReturningElseViolation])
 
 
 @pytest.mark.parametrize('template', [

--- a/wemake_python_styleguide/visitors/ast/conditions.py
+++ b/wemake_python_styleguide/visitors/ast/conditions.py
@@ -200,9 +200,11 @@ class UselessElseVisitor(BaseNodeVisitor):
     def _check_useless_loop_else(self, node: AnyLoop) -> None:
         if not node.orelse:
             return
-
+        # An else statement makes sense if we
+        # want to execute something after breaking
+        # out of the loop without writing more code
         body_returning = any(
-            walk.is_contained(sub, self._returning_nodes)
+            walk.is_contained(sub, self._returning_nodes[1:])
             for sub in node.body
         )
         else_returning = any(


### PR DESCRIPTION
After merging this PR, we expect the  `else` block in `while..else` and `for..else` statements to be considered as correct instead of being marked as useless if the loop has a `break` statement

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made
- [] I have added my changes to the `CHANGELOG.md`

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->
Closes #1958 
<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->

🙏 Please, if you or your company is finding wemake-python-styleguide valuable, help us sustain the project by sponsoring it transparently on https://opencollective.com/wemake-python-styleguide. As a thank you, your profile/company logo will be added to our main README which receives hundreds of unique visitors per day.
