### PR TITLE
Ignore WPS114 in notebook test

### DIFF
--- a/docs/pages/usage/integrations/jupyter_notebooks.rst
+++ b/docs/pages/usage/integrations/jupyter_notebooks.rst
@@ -13,7 +13,7 @@ for example by running:
 
 .. code:: bash
 
-    $ nbqa flake8 notebook.ipynb --extend-ignore=NIP102,D100,E302,E305,E703
+    $ nbqa flake8 notebook.ipynb --extend-ignore=NIP102,D100,E302,E305,E703,WPS102,WPS114
 
 For example, if we have a file ``notebook.ipynb``
 

--- a/tests/test_formatter/test_formatter_output.py
+++ b/tests/test_formatter/test_formatter_output.py
@@ -124,7 +124,7 @@ def test_ipynb(snapshot):
     """All correct code should not raise any violations and no output."""
     filename = './tests/fixtures/notebook.ipynb'
     # Ignore error codes which don't apply to Jupyter Notebooks
-    cli_options = ['--extend-ignore', 'NIP102,D100,WPS102']
+    cli_options = ['--extend-ignore', 'NIP102,D100,WPS102,WPS114']
 
     process = subprocess.Popen(
         [


### PR DESCRIPTION
This should avoid the sporadic CI failure observed in #1995 - I ran the test several times on my machine and it always passes now