### PR TITLE
Fixes `Hashable` import for `Python 3.10`

### DIFF
--- a/wemake_python_styleguide/visitors/ast/builtins.py
+++ b/wemake_python_styleguide/visitors/ast/builtins.py
@@ -1,7 +1,8 @@
 import ast
 import re
 import string
-from collections import Counter, Hashable, defaultdict
+from collections import Counter, defaultdict
+from collections.abc import Hashable
 from contextlib import suppress
 from typing import (
     ClassVar,


### PR DESCRIPTION
# Fixes `Hashable` import for `Python 3.10`

## Checklist

- [X] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)

## Related issues

Closes #2053
