### PR TITLE
Do not raise reassignment violation over unary operation on the same variable

### DIFF
--- a/tests/test_visitors/test_ast/test_naming/test_variable_self_reassignment.py
+++ b/tests/test_visitors/test_ast/test_naming/test_variable_self_reassignment.py
@@ -86,6 +86,8 @@ right_swap4 = 'dx, dy = +dy, -dx'
 right_swap5 = 'dx, dy = dy, dx'
 right_swap6 = 'dy, dx = dx, dy'
 
+right_unary1 = 'a = not a'
+right_unary2 = 'a = -a'
 
 # Wrong:
 
@@ -267,6 +269,8 @@ def test_self_variable_reassignment_triple(
     right_swap4,
     right_swap5,
     right_swap6,
+    right_unary1,
+    right_unary2,
 ])
 def test_correct_variable_reassignment(
     assert_errors,

--- a/wemake_python_styleguide/violations/best_practices.py
+++ b/wemake_python_styleguide/violations/best_practices.py
@@ -1424,13 +1424,14 @@ class ReassigningVariableToItselfViolation(ASTViolation):
         # Correct:
         some = some + 1
         x_coord, y_coord = y_coord, x_coord
+        flag = not flag
 
         # Wrong:
         some = some
         x_coord, y_coord = x_coord, y_coord
 
     .. versionadded:: 0.3.0
-    .. versionchanged:: 0.11.0
+    .. versionchanged:: 0.15.3
 
     """
 

--- a/wemake_python_styleguide/violations/best_practices.py
+++ b/wemake_python_styleguide/violations/best_practices.py
@@ -1431,7 +1431,7 @@ class ReassigningVariableToItselfViolation(ASTViolation):
         x_coord, y_coord = x_coord, y_coord
 
     .. versionadded:: 0.3.0
-    .. versionchanged:: 0.15.3
+    .. versionchanged:: 0.16.0
 
     """
 


### PR DESCRIPTION
This is done so we do not generate false positives on the common pattern of flipping boolean
flags using `not` operator.

Closes #2189

# I have made things!

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Checklist

<!-- Please check everything that applies: -->

- [X] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [X] I have created at least one test case for the changes I have made
- [X] I have updated the documentation for the changes I have made
- [X] I have added my changes to the `CHANGELOG.md`

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->

🙏 Please, if you or your company is finding wemake-python-styleguide valuable, help us sustain the project by sponsoring it transparently on https://opencollective.com/wemake-python-styleguide. As a thank you, your profile/company logo will be added to our main README which receives hundreds of unique visitors per day.
