### PR TITLE
pydantic Config class added NESTED_CLASSES_WHITELIST

### DIFF
--- a/wemake_python_styleguide/options/defaults.py
+++ b/wemake_python_styleguide/options/defaults.py
@@ -34,6 +34,7 @@ MAX_NOQA_COMMENTS: Final = 10  # guessed
 NESTED_CLASSES_WHITELIST: Final = (
     'Meta',  # django forms, models, drf, etc
     'Params',  # factoryboy specific
+    'Config',  # pydantic spesific
 )
 
 #: Domain names that are removed from variable names' blacklist.


### PR DESCRIPTION
Pydantic is a popular data validation library.

So I added Pydantic Config class to NESTED_CLASSES_WHITELIST.

More information: [https://pydantic-docs.helpmanual.io/usage/model_config/](https://pydantic-docs.helpmanual.io/usage/model_config/)


## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [ ] I have created at least one test case for the changes I have made
- [ ] I have updated the documentation for the changes I have made
- [ ] I have added my changes to the `CHANGELOG.md`
