### PR TITLE
Add an option to show violation shortlinks in the formatter output

### DIFF
--- a/docs/pages/usage/formatter.rst
+++ b/docs/pages/usage/formatter.rst
@@ -54,7 +54,7 @@ and will show the exact problem with your code:
 
     E231  120:32   missing whitespace after ':'
     def show_source(self, error:Violation) -> str:
-                              ^
+                               ^
 
 It helps to visually identify the problems in your code and fix it faster.
 We include ``show-source = True`` into our default configuration.
@@ -75,13 +75,13 @@ do you have and where you have them:
 
     E231  136:32   missing whitespace after ':'
     def show_source(self, error:Violation) -> str:
-                              ^
+                               ^
 
   ./wemake_python_styleguide/types.py
 
     E231  52:47    missing whitespace after ','
     AnyFunctionDefAndLambda = Union[AnyFunctionDef,ast.Lambda]
-                                                 ^
+                                                  ^
 
   E231: missing whitespace after ':'
     1     ./wemake_python_styleguide/formatter.py
@@ -106,8 +106,10 @@ You can also show links to the documentation pages of violations:
 
   ./wemake_python_styleguide/formatter.py
 
-    E231  120:32   missing whitespace after ':' (https://pyflak.es/E231)
+    E231  120:32   missing whitespace after ':'
     def show_source(self, error:Violation) -> str:
+                               ^
+    -> https://pyflak.es/E231
 
 In modern terminals, you can click them to open the respective docs page.
 

--- a/docs/pages/usage/formatter.rst
+++ b/docs/pages/usage/formatter.rst
@@ -94,3 +94,21 @@ do you have and where you have them:
 We do not include ``show-statistic`` in our default configuration.
 It should be only called when user needs to find how many violations
 there are and what files do contain them.
+
+
+.. rubric:: Showing links to documentation
+
+You can also show links to the documentation pages of violations:
+
+.. code::
+
+  » flake8 . --format=wemake --show-source --show-violation-links
+
+  ./wemake_python_styleguide/formatter.py
+
+    E231  120:32   missing whitespace after ':' (https://pyflak.es/E231)
+    def show_source(self, error:Violation) -> str:
+
+In modern terminals, you can click them to open the respective docs page.
+
+We do not include ``show-violation-links`` in our default configuration.

--- a/docs/pages/usage/formatter.rst
+++ b/docs/pages/usage/formatter.rst
@@ -52,7 +52,7 @@ and will show the exact problem with your code:
 
   ./wemake_python_styleguide/formatter.py
 
-    E231  120:32   missing whitespace after ':'
+    107:32   E231  missing whitespace after ':'
     def show_source(self, error:Violation) -> str:
                                ^
 
@@ -73,13 +73,13 @@ do you have and where you have them:
 
   ./wemake_python_styleguide/formatter.py
 
-    E231  136:32   missing whitespace after ':'
+    107:32   E231  missing whitespace after ':'
     def show_source(self, error:Violation) -> str:
                                ^
 
   ./wemake_python_styleguide/types.py
 
-    E231  52:47    missing whitespace after ','
+    53:47    E231  missing whitespace after ','
     AnyFunctionDefAndLambda = Union[AnyFunctionDef,ast.Lambda]
                                                   ^
 
@@ -106,10 +106,10 @@ You can also show links to the documentation pages of violations:
 
   ./wemake_python_styleguide/formatter.py
 
-    E231  120:32   missing whitespace after ':'
+    107:32   E231  missing whitespace after ':'
+             -> https://pyflak.es/E231
     def show_source(self, error:Violation) -> str:
                                ^
-    -> https://pyflak.es/E231
 
 In modern terminals, you can click them to open the respective docs page.
 

--- a/tests/test_formatter/snapshots/snap_test_formatter_output.py
+++ b/tests/test_formatter/snapshots/snap_test_formatter_output.py
@@ -109,148 +109,24 @@ https://wemake-python-stylegui.de/en/xx.xx/pages/usage/violations/
 
 snapshots['test_formatter[cli_options3-with_links] formatter_with_links'] = '''
 \x1b[4m\x1b[1m./tests/fixtures/formatter/formatter1.py\x1b[0m\x1b[0m
-  1:1      WPS111 Found too short name: s < 2 (https://pyflak.es/WPS111)
-  1:7      WPS110 Found wrong variable name: handle (https://pyflak.es/WPS110)
-  2:21     WPS432 Found magic number: 200 (https://pyflak.es/WPS432)
-  2:21     WPS303 Found underscored number: 2_00 (https://pyflak.es/WPS303)
-
-\x1b[4m\x1b[1m./tests/fixtures/formatter/formatter2.py\x1b[0m\x1b[0m
-  1:1      WPS110 Found wrong variable name: data (https://pyflak.es/WPS110)
-  1:10     WPS110 Found wrong variable name: param (https://pyflak.es/WPS110)
-  2:12     WPS437 Found protected attribute usage: _protected (https://pyflak.es/WPS437)
-  2:31     WPS303 Found underscored number: 10_00 (https://pyflak.es/WPS303)
-
-Full list of violations and explanations:
-https://wemake-python-stylegui.de/en/xx.xx/pages/usage/violations/
-'''
-
-snapshots['test_formatter[cli_options3-with_source_statistic] formatter_with_source_statistic'] = '''
-\x1b[4m\x1b[1m./tests/fixtures/formatter/formatter1.py\x1b[0m\x1b[0m
-
   1:1      WPS111 Found too short name: s < 2
-  \x1b[34mdef\x1b[39;49;00m \x1b[32ms\x1b[39;49;00m(handle: \x1b[36mint\x1b[39;49;00m) -> \x1b[36mint\x1b[39;49;00m:
-  ^
-
+           -> https://pyflak.es/WPS111
   1:7      WPS110 Found wrong variable name: handle
-  \x1b[34mdef\x1b[39;49;00m \x1b[32ms\x1b[39;49;00m(handle: \x1b[36mint\x1b[39;49;00m) -> \x1b[36mint\x1b[39;49;00m:
-        ^
-
+           -> https://pyflak.es/WPS110
   2:21     WPS432 Found magic number: 200
-  \x1b[34mreturn\x1b[39;49;00m handle + \x1b[34m2_00\x1b[39;49;00m
-                  ^
-
+           -> https://pyflak.es/WPS432
   2:21     WPS303 Found underscored number: 2_00
-  \x1b[34mreturn\x1b[39;49;00m handle + \x1b[34m2_00\x1b[39;49;00m
-                  ^
+           -> https://pyflak.es/WPS303
 
 \x1b[4m\x1b[1m./tests/fixtures/formatter/formatter2.py\x1b[0m\x1b[0m
-
   1:1      WPS110 Found wrong variable name: data
-  \x1b[34mdef\x1b[39;49;00m \x1b[32mdata\x1b[39;49;00m(param) -> \x1b[36mint\x1b[39;49;00m:
-  ^
-
+           -> https://pyflak.es/WPS110
   1:10     WPS110 Found wrong variable name: param
-  \x1b[34mdef\x1b[39;49;00m \x1b[32mdata\x1b[39;49;00m(param) -> \x1b[36mint\x1b[39;49;00m:
-           ^
-
+           -> https://pyflak.es/WPS110
   2:12     WPS437 Found protected attribute usage: _protected
-  \x1b[34mreturn\x1b[39;49;00m param._protected + \x1b[34m10_00\x1b[39;49;00m
-         ^
-
+           -> https://pyflak.es/WPS437
   2:31     WPS303 Found underscored number: 10_00
-  \x1b[34mreturn\x1b[39;49;00m param._protected + \x1b[34m10_00\x1b[39;49;00m
-                            ^
-
-\x1b[1mWPS110\x1b[0m: Found wrong variable name: handle
-  1     ./tests/fixtures/formatter/formatter1.py
-  2     ./tests/fixtures/formatter/formatter2.py
-\x1b[4mTotal: 3\x1b[0m
-
-\x1b[1mWPS111\x1b[0m: Found too short name: s < 2
-  1     ./tests/fixtures/formatter/formatter1.py
-\x1b[4mTotal: 1\x1b[0m
-
-\x1b[1mWPS303\x1b[0m: Found underscored number: 2_00
-  1     ./tests/fixtures/formatter/formatter1.py
-  1     ./tests/fixtures/formatter/formatter2.py
-\x1b[4mTotal: 2\x1b[0m
-
-\x1b[1mWPS432\x1b[0m: Found magic number: 200
-  1     ./tests/fixtures/formatter/formatter1.py
-\x1b[4mTotal: 1\x1b[0m
-
-\x1b[1mWPS437\x1b[0m: Found protected attribute usage: _protected
-  1     ./tests/fixtures/formatter/formatter2.py
-\x1b[4mTotal: 1\x1b[0m
-
-
-\x1b[4m\x1b[1mAll errors: 8\x1b[0m\x1b[0m
-
-Full list of violations and explanations:
-https://wemake-python-stylegui.de/en/xx.xx/pages/usage/violations/
-'''
-
-snapshots['test_formatter[cli_options4-statistic_with_source] formatter_statistic_with_source'] = '''
-\x1b[4m\x1b[1m./tests/fixtures/formatter/formatter1.py\x1b[0m\x1b[0m
-
-  1:1      WPS111 Found too short name: s < 2
-  \x1b[34mdef\x1b[39;49;00m \x1b[32ms\x1b[39;49;00m(handle: \x1b[36mint\x1b[39;49;00m) -> \x1b[36mint\x1b[39;49;00m:
-  ^
-
-  1:7      WPS110 Found wrong variable name: handle
-  \x1b[34mdef\x1b[39;49;00m \x1b[32ms\x1b[39;49;00m(handle: \x1b[36mint\x1b[39;49;00m) -> \x1b[36mint\x1b[39;49;00m:
-        ^
-
-  2:21     WPS432 Found magic number: 200
-  \x1b[34mreturn\x1b[39;49;00m handle + \x1b[34m2_00\x1b[39;49;00m
-                  ^
-
-  2:21     WPS303 Found underscored number: 2_00
-  \x1b[34mreturn\x1b[39;49;00m handle + \x1b[34m2_00\x1b[39;49;00m
-                  ^
-
-\x1b[4m\x1b[1m./tests/fixtures/formatter/formatter2.py\x1b[0m\x1b[0m
-
-  1:1      WPS110 Found wrong variable name: data
-  \x1b[34mdef\x1b[39;49;00m \x1b[32mdata\x1b[39;49;00m(param) -> \x1b[36mint\x1b[39;49;00m:
-  ^
-
-  1:10     WPS110 Found wrong variable name: param
-  \x1b[34mdef\x1b[39;49;00m \x1b[32mdata\x1b[39;49;00m(param) -> \x1b[36mint\x1b[39;49;00m:
-           ^
-
-  2:12     WPS437 Found protected attribute usage: _protected
-  \x1b[34mreturn\x1b[39;49;00m param._protected + \x1b[34m10_00\x1b[39;49;00m
-         ^
-
-  2:31     WPS303 Found underscored number: 10_00
-  \x1b[34mreturn\x1b[39;49;00m param._protected + \x1b[34m10_00\x1b[39;49;00m
-                            ^
-
-\x1b[1mWPS110\x1b[0m: Found wrong variable name: handle
-  1     ./tests/fixtures/formatter/formatter1.py
-  2     ./tests/fixtures/formatter/formatter2.py
-\x1b[4mTotal: 3\x1b[0m
-
-\x1b[1mWPS111\x1b[0m: Found too short name: s < 2
-  1     ./tests/fixtures/formatter/formatter1.py
-\x1b[4mTotal: 1\x1b[0m
-
-\x1b[1mWPS303\x1b[0m: Found underscored number: 2_00
-  1     ./tests/fixtures/formatter/formatter1.py
-  1     ./tests/fixtures/formatter/formatter2.py
-\x1b[4mTotal: 2\x1b[0m
-
-\x1b[1mWPS432\x1b[0m: Found magic number: 200
-  1     ./tests/fixtures/formatter/formatter1.py
-\x1b[4mTotal: 1\x1b[0m
-
-\x1b[1mWPS437\x1b[0m: Found protected attribute usage: _protected
-  1     ./tests/fixtures/formatter/formatter2.py
-\x1b[4mTotal: 1\x1b[0m
-
-
-\x1b[4m\x1b[1mAll errors: 8\x1b[0m\x1b[0m
+           -> https://pyflak.es/WPS303
 
 Full list of violations and explanations:
 https://wemake-python-stylegui.de/en/xx.xx/pages/usage/violations/
@@ -325,39 +201,47 @@ https://wemake-python-stylegui.de/en/xx.xx/pages/usage/violations/
 snapshots['test_formatter[cli_options5-with_source_links] formatter_with_source_links'] = '''
 \x1b[4m\x1b[1m./tests/fixtures/formatter/formatter1.py\x1b[0m\x1b[0m
 
-  1:1      WPS111 Found too short name: s < 2 (https://pyflak.es/WPS111)
+  1:1      WPS111 Found too short name: s < 2
   \x1b[34mdef\x1b[39;49;00m \x1b[32ms\x1b[39;49;00m(handle: \x1b[36mint\x1b[39;49;00m) -> \x1b[36mint\x1b[39;49;00m:
   ^
+  -> https://pyflak.es/WPS111
 
-  1:7      WPS110 Found wrong variable name: handle (https://pyflak.es/WPS110)
+  1:7      WPS110 Found wrong variable name: handle
   \x1b[34mdef\x1b[39;49;00m \x1b[32ms\x1b[39;49;00m(handle: \x1b[36mint\x1b[39;49;00m) -> \x1b[36mint\x1b[39;49;00m:
         ^
+  -> https://pyflak.es/WPS110
 
-  2:21     WPS432 Found magic number: 200 (https://pyflak.es/WPS432)
+  2:21     WPS432 Found magic number: 200
   \x1b[34mreturn\x1b[39;49;00m handle + \x1b[34m2_00\x1b[39;49;00m
                   ^
+  -> https://pyflak.es/WPS432
 
-  2:21     WPS303 Found underscored number: 2_00 (https://pyflak.es/WPS303)
+  2:21     WPS303 Found underscored number: 2_00
   \x1b[34mreturn\x1b[39;49;00m handle + \x1b[34m2_00\x1b[39;49;00m
                   ^
+  -> https://pyflak.es/WPS303
 
 \x1b[4m\x1b[1m./tests/fixtures/formatter/formatter2.py\x1b[0m\x1b[0m
 
-  1:1      WPS110 Found wrong variable name: data (https://pyflak.es/WPS110)
+  1:1      WPS110 Found wrong variable name: data
   \x1b[34mdef\x1b[39;49;00m \x1b[32mdata\x1b[39;49;00m(param) -> \x1b[36mint\x1b[39;49;00m:
   ^
+  -> https://pyflak.es/WPS110
 
-  1:10     WPS110 Found wrong variable name: param (https://pyflak.es/WPS110)
+  1:10     WPS110 Found wrong variable name: param
   \x1b[34mdef\x1b[39;49;00m \x1b[32mdata\x1b[39;49;00m(param) -> \x1b[36mint\x1b[39;49;00m:
            ^
+  -> https://pyflak.es/WPS110
 
-  2:12     WPS437 Found protected attribute usage: _protected (https://pyflak.es/WPS437)
+  2:12     WPS437 Found protected attribute usage: _protected
   \x1b[34mreturn\x1b[39;49;00m param._protected + \x1b[34m10_00\x1b[39;49;00m
          ^
+  -> https://pyflak.es/WPS437
 
-  2:31     WPS303 Found underscored number: 10_00 (https://pyflak.es/WPS303)
+  2:31     WPS303 Found underscored number: 10_00
   \x1b[34mreturn\x1b[39;49;00m param._protected + \x1b[34m10_00\x1b[39;49;00m
                             ^
+  -> https://pyflak.es/WPS303
 
 Full list of violations and explanations:
 https://wemake-python-stylegui.de/en/xx.xx/pages/usage/violations/
@@ -438,12 +322,16 @@ snapshots['test_formatter_correct[cli_options1-regular_statistic] formatter_corr
 
 snapshots['test_formatter_correct[cli_options2-with_source] formatter_correct_with_source'] = ''
 
-snapshots['test_formatter_correct[cli_options3-with_source_statistic] formatter_correct_with_source_statistic'] = '''
+snapshots['test_formatter_correct[cli_options3-with_links] formatter_correct_with_links'] = ''
+
+snapshots['test_formatter_correct[cli_options4-with_source_statistic] formatter_correct_with_source_statistic'] = '''
 
 \x1b[4m\x1b[1mAll errors: 0\x1b[0m\x1b[0m
 '''
 
-snapshots['test_formatter_correct[cli_options4-statistic_with_source] formatter_correct_statistic_with_source'] = '''
+snapshots['test_formatter_correct[cli_options5-with_source_links] formatter_correct_with_source_links'] = ''
+
+snapshots['test_formatter_correct[cli_options6-statistic_with_source] formatter_correct_statistic_with_source'] = '''
 
 \x1b[4m\x1b[1mAll errors: 0\x1b[0m\x1b[0m
 '''

--- a/tests/test_formatter/snapshots/snap_test_formatter_output.py
+++ b/tests/test_formatter/snapshots/snap_test_formatter_output.py
@@ -202,46 +202,46 @@ snapshots['test_formatter[cli_options5-with_source_links] formatter_with_source_
 \x1b[4m\x1b[1m./tests/fixtures/formatter/formatter1.py\x1b[0m\x1b[0m
 
   1:1      WPS111 Found too short name: s < 2
+           -> https://pyflak.es/WPS111
   \x1b[34mdef\x1b[39;49;00m \x1b[32ms\x1b[39;49;00m(handle: \x1b[36mint\x1b[39;49;00m) -> \x1b[36mint\x1b[39;49;00m:
   ^
-  -> https://pyflak.es/WPS111
 
   1:7      WPS110 Found wrong variable name: handle
+           -> https://pyflak.es/WPS110
   \x1b[34mdef\x1b[39;49;00m \x1b[32ms\x1b[39;49;00m(handle: \x1b[36mint\x1b[39;49;00m) -> \x1b[36mint\x1b[39;49;00m:
         ^
-  -> https://pyflak.es/WPS110
 
   2:21     WPS432 Found magic number: 200
+           -> https://pyflak.es/WPS432
   \x1b[34mreturn\x1b[39;49;00m handle + \x1b[34m2_00\x1b[39;49;00m
                   ^
-  -> https://pyflak.es/WPS432
 
   2:21     WPS303 Found underscored number: 2_00
+           -> https://pyflak.es/WPS303
   \x1b[34mreturn\x1b[39;49;00m handle + \x1b[34m2_00\x1b[39;49;00m
                   ^
-  -> https://pyflak.es/WPS303
 
 \x1b[4m\x1b[1m./tests/fixtures/formatter/formatter2.py\x1b[0m\x1b[0m
 
   1:1      WPS110 Found wrong variable name: data
+           -> https://pyflak.es/WPS110
   \x1b[34mdef\x1b[39;49;00m \x1b[32mdata\x1b[39;49;00m(param) -> \x1b[36mint\x1b[39;49;00m:
   ^
-  -> https://pyflak.es/WPS110
 
   1:10     WPS110 Found wrong variable name: param
+           -> https://pyflak.es/WPS110
   \x1b[34mdef\x1b[39;49;00m \x1b[32mdata\x1b[39;49;00m(param) -> \x1b[36mint\x1b[39;49;00m:
            ^
-  -> https://pyflak.es/WPS110
 
   2:12     WPS437 Found protected attribute usage: _protected
+           -> https://pyflak.es/WPS437
   \x1b[34mreturn\x1b[39;49;00m param._protected + \x1b[34m10_00\x1b[39;49;00m
          ^
-  -> https://pyflak.es/WPS437
 
   2:31     WPS303 Found underscored number: 10_00
+           -> https://pyflak.es/WPS303
   \x1b[34mreturn\x1b[39;49;00m param._protected + \x1b[34m10_00\x1b[39;49;00m
                             ^
-  -> https://pyflak.es/WPS303
 
 Full list of violations and explanations:
 https://wemake-python-stylegui.de/en/xx.xx/pages/usage/violations/

--- a/tests/test_formatter/snapshots/snap_test_formatter_output.py
+++ b/tests/test_formatter/snapshots/snap_test_formatter_output.py
@@ -107,6 +107,23 @@ Full list of violations and explanations:
 https://wemake-python-stylegui.de/en/xx.xx/pages/usage/violations/
 '''
 
+snapshots['test_formatter[cli_options3-with_links] formatter_with_links'] = '''
+\x1b[4m\x1b[1m./tests/fixtures/formatter/formatter1.py\x1b[0m\x1b[0m
+  1:1      WPS111 Found too short name: s < 2 (https://pyflak.es/WPS111)
+  1:7      WPS110 Found wrong variable name: handle (https://pyflak.es/WPS110)
+  2:21     WPS432 Found magic number: 200 (https://pyflak.es/WPS432)
+  2:21     WPS303 Found underscored number: 2_00 (https://pyflak.es/WPS303)
+
+\x1b[4m\x1b[1m./tests/fixtures/formatter/formatter2.py\x1b[0m\x1b[0m
+  1:1      WPS110 Found wrong variable name: data (https://pyflak.es/WPS110)
+  1:10     WPS110 Found wrong variable name: param (https://pyflak.es/WPS110)
+  2:12     WPS437 Found protected attribute usage: _protected (https://pyflak.es/WPS437)
+  2:31     WPS303 Found underscored number: 10_00 (https://pyflak.es/WPS303)
+
+Full list of violations and explanations:
+https://wemake-python-stylegui.de/en/xx.xx/pages/usage/violations/
+'''
+
 snapshots['test_formatter[cli_options3-with_source_statistic] formatter_with_source_statistic'] = '''
 \x1b[4m\x1b[1m./tests/fixtures/formatter/formatter1.py\x1b[0m\x1b[0m
 
@@ -174,6 +191,179 @@ https://wemake-python-stylegui.de/en/xx.xx/pages/usage/violations/
 '''
 
 snapshots['test_formatter[cli_options4-statistic_with_source] formatter_statistic_with_source'] = '''
+\x1b[4m\x1b[1m./tests/fixtures/formatter/formatter1.py\x1b[0m\x1b[0m
+
+  1:1      WPS111 Found too short name: s < 2
+  \x1b[34mdef\x1b[39;49;00m \x1b[32ms\x1b[39;49;00m(handle: \x1b[36mint\x1b[39;49;00m) -> \x1b[36mint\x1b[39;49;00m:
+  ^
+
+  1:7      WPS110 Found wrong variable name: handle
+  \x1b[34mdef\x1b[39;49;00m \x1b[32ms\x1b[39;49;00m(handle: \x1b[36mint\x1b[39;49;00m) -> \x1b[36mint\x1b[39;49;00m:
+        ^
+
+  2:21     WPS432 Found magic number: 200
+  \x1b[34mreturn\x1b[39;49;00m handle + \x1b[34m2_00\x1b[39;49;00m
+                  ^
+
+  2:21     WPS303 Found underscored number: 2_00
+  \x1b[34mreturn\x1b[39;49;00m handle + \x1b[34m2_00\x1b[39;49;00m
+                  ^
+
+\x1b[4m\x1b[1m./tests/fixtures/formatter/formatter2.py\x1b[0m\x1b[0m
+
+  1:1      WPS110 Found wrong variable name: data
+  \x1b[34mdef\x1b[39;49;00m \x1b[32mdata\x1b[39;49;00m(param) -> \x1b[36mint\x1b[39;49;00m:
+  ^
+
+  1:10     WPS110 Found wrong variable name: param
+  \x1b[34mdef\x1b[39;49;00m \x1b[32mdata\x1b[39;49;00m(param) -> \x1b[36mint\x1b[39;49;00m:
+           ^
+
+  2:12     WPS437 Found protected attribute usage: _protected
+  \x1b[34mreturn\x1b[39;49;00m param._protected + \x1b[34m10_00\x1b[39;49;00m
+         ^
+
+  2:31     WPS303 Found underscored number: 10_00
+  \x1b[34mreturn\x1b[39;49;00m param._protected + \x1b[34m10_00\x1b[39;49;00m
+                            ^
+
+\x1b[1mWPS110\x1b[0m: Found wrong variable name: handle
+  1     ./tests/fixtures/formatter/formatter1.py
+  2     ./tests/fixtures/formatter/formatter2.py
+\x1b[4mTotal: 3\x1b[0m
+
+\x1b[1mWPS111\x1b[0m: Found too short name: s < 2
+  1     ./tests/fixtures/formatter/formatter1.py
+\x1b[4mTotal: 1\x1b[0m
+
+\x1b[1mWPS303\x1b[0m: Found underscored number: 2_00
+  1     ./tests/fixtures/formatter/formatter1.py
+  1     ./tests/fixtures/formatter/formatter2.py
+\x1b[4mTotal: 2\x1b[0m
+
+\x1b[1mWPS432\x1b[0m: Found magic number: 200
+  1     ./tests/fixtures/formatter/formatter1.py
+\x1b[4mTotal: 1\x1b[0m
+
+\x1b[1mWPS437\x1b[0m: Found protected attribute usage: _protected
+  1     ./tests/fixtures/formatter/formatter2.py
+\x1b[4mTotal: 1\x1b[0m
+
+
+\x1b[4m\x1b[1mAll errors: 8\x1b[0m\x1b[0m
+
+Full list of violations and explanations:
+https://wemake-python-stylegui.de/en/xx.xx/pages/usage/violations/
+'''
+
+snapshots['test_formatter[cli_options4-with_source_statistic] formatter_with_source_statistic'] = '''
+\x1b[4m\x1b[1m./tests/fixtures/formatter/formatter1.py\x1b[0m\x1b[0m
+
+  1:1      WPS111 Found too short name: s < 2
+  \x1b[34mdef\x1b[39;49;00m \x1b[32ms\x1b[39;49;00m(handle: \x1b[36mint\x1b[39;49;00m) -> \x1b[36mint\x1b[39;49;00m:
+  ^
+
+  1:7      WPS110 Found wrong variable name: handle
+  \x1b[34mdef\x1b[39;49;00m \x1b[32ms\x1b[39;49;00m(handle: \x1b[36mint\x1b[39;49;00m) -> \x1b[36mint\x1b[39;49;00m:
+        ^
+
+  2:21     WPS432 Found magic number: 200
+  \x1b[34mreturn\x1b[39;49;00m handle + \x1b[34m2_00\x1b[39;49;00m
+                  ^
+
+  2:21     WPS303 Found underscored number: 2_00
+  \x1b[34mreturn\x1b[39;49;00m handle + \x1b[34m2_00\x1b[39;49;00m
+                  ^
+
+\x1b[4m\x1b[1m./tests/fixtures/formatter/formatter2.py\x1b[0m\x1b[0m
+
+  1:1      WPS110 Found wrong variable name: data
+  \x1b[34mdef\x1b[39;49;00m \x1b[32mdata\x1b[39;49;00m(param) -> \x1b[36mint\x1b[39;49;00m:
+  ^
+
+  1:10     WPS110 Found wrong variable name: param
+  \x1b[34mdef\x1b[39;49;00m \x1b[32mdata\x1b[39;49;00m(param) -> \x1b[36mint\x1b[39;49;00m:
+           ^
+
+  2:12     WPS437 Found protected attribute usage: _protected
+  \x1b[34mreturn\x1b[39;49;00m param._protected + \x1b[34m10_00\x1b[39;49;00m
+         ^
+
+  2:31     WPS303 Found underscored number: 10_00
+  \x1b[34mreturn\x1b[39;49;00m param._protected + \x1b[34m10_00\x1b[39;49;00m
+                            ^
+
+\x1b[1mWPS110\x1b[0m: Found wrong variable name: handle
+  1     ./tests/fixtures/formatter/formatter1.py
+  2     ./tests/fixtures/formatter/formatter2.py
+\x1b[4mTotal: 3\x1b[0m
+
+\x1b[1mWPS111\x1b[0m: Found too short name: s < 2
+  1     ./tests/fixtures/formatter/formatter1.py
+\x1b[4mTotal: 1\x1b[0m
+
+\x1b[1mWPS303\x1b[0m: Found underscored number: 2_00
+  1     ./tests/fixtures/formatter/formatter1.py
+  1     ./tests/fixtures/formatter/formatter2.py
+\x1b[4mTotal: 2\x1b[0m
+
+\x1b[1mWPS432\x1b[0m: Found magic number: 200
+  1     ./tests/fixtures/formatter/formatter1.py
+\x1b[4mTotal: 1\x1b[0m
+
+\x1b[1mWPS437\x1b[0m: Found protected attribute usage: _protected
+  1     ./tests/fixtures/formatter/formatter2.py
+\x1b[4mTotal: 1\x1b[0m
+
+
+\x1b[4m\x1b[1mAll errors: 8\x1b[0m\x1b[0m
+
+Full list of violations and explanations:
+https://wemake-python-stylegui.de/en/xx.xx/pages/usage/violations/
+'''
+
+snapshots['test_formatter[cli_options5-with_source_links] formatter_with_source_links'] = '''
+\x1b[4m\x1b[1m./tests/fixtures/formatter/formatter1.py\x1b[0m\x1b[0m
+
+  1:1      WPS111 Found too short name: s < 2 (https://pyflak.es/WPS111)
+  \x1b[34mdef\x1b[39;49;00m \x1b[32ms\x1b[39;49;00m(handle: \x1b[36mint\x1b[39;49;00m) -> \x1b[36mint\x1b[39;49;00m:
+  ^
+
+  1:7      WPS110 Found wrong variable name: handle (https://pyflak.es/WPS110)
+  \x1b[34mdef\x1b[39;49;00m \x1b[32ms\x1b[39;49;00m(handle: \x1b[36mint\x1b[39;49;00m) -> \x1b[36mint\x1b[39;49;00m:
+        ^
+
+  2:21     WPS432 Found magic number: 200 (https://pyflak.es/WPS432)
+  \x1b[34mreturn\x1b[39;49;00m handle + \x1b[34m2_00\x1b[39;49;00m
+                  ^
+
+  2:21     WPS303 Found underscored number: 2_00 (https://pyflak.es/WPS303)
+  \x1b[34mreturn\x1b[39;49;00m handle + \x1b[34m2_00\x1b[39;49;00m
+                  ^
+
+\x1b[4m\x1b[1m./tests/fixtures/formatter/formatter2.py\x1b[0m\x1b[0m
+
+  1:1      WPS110 Found wrong variable name: data (https://pyflak.es/WPS110)
+  \x1b[34mdef\x1b[39;49;00m \x1b[32mdata\x1b[39;49;00m(param) -> \x1b[36mint\x1b[39;49;00m:
+  ^
+
+  1:10     WPS110 Found wrong variable name: param (https://pyflak.es/WPS110)
+  \x1b[34mdef\x1b[39;49;00m \x1b[32mdata\x1b[39;49;00m(param) -> \x1b[36mint\x1b[39;49;00m:
+           ^
+
+  2:12     WPS437 Found protected attribute usage: _protected (https://pyflak.es/WPS437)
+  \x1b[34mreturn\x1b[39;49;00m param._protected + \x1b[34m10_00\x1b[39;49;00m
+         ^
+
+  2:31     WPS303 Found underscored number: 10_00 (https://pyflak.es/WPS303)
+  \x1b[34mreturn\x1b[39;49;00m param._protected + \x1b[34m10_00\x1b[39;49;00m
+                            ^
+
+Full list of violations and explanations:
+https://wemake-python-stylegui.de/en/xx.xx/pages/usage/violations/
+'''
+
+snapshots['test_formatter[cli_options6-statistic_with_source] formatter_statistic_with_source'] = '''
 \x1b[4m\x1b[1m./tests/fixtures/formatter/formatter1.py\x1b[0m\x1b[0m
 
   1:1      WPS111 Found too short name: s < 2

--- a/tests/test_formatter/test_formatter_output.py
+++ b/tests/test_formatter/test_formatter_output.py
@@ -46,7 +46,9 @@ def _safe_output(output: str) -> str:
     ([], 'regular'),
     (['--statistic'], 'regular_statistic'),
     (['--show-source'], 'with_source'),
+    (['--show-violation-links'], 'with_links'),
     (['--show-source', '--statistic'], 'with_source_statistic'),
+    (['--show-source', '--show-violation-links'], 'with_source_links'),
     (['--statistic', '--show-source'], 'statistic_with_source'),
 ])
 def test_formatter(snapshot, cli_options, output):

--- a/tests/test_formatter/test_formatter_output.py
+++ b/tests/test_formatter/test_formatter_output.py
@@ -91,7 +91,9 @@ def test_formatter(snapshot, cli_options, output):
     ([], 'regular'),
     (['--statistic'], 'regular_statistic'),
     (['--show-source'], 'with_source'),
+    (['--show-violation-links'], 'with_links'),
     (['--show-source', '--statistic'], 'with_source_statistic'),
+    (['--show-source', '--show-violation-links'], 'with_source_links'),
     (['--statistic', '--show-source'], 'statistic_with_source'),
 ])
 def test_formatter_correct(snapshot, cli_options, output):

--- a/tests/test_violations/test_docs.py
+++ b/tests/test_violations/test_docs.py
@@ -1,5 +1,9 @@
 from wemake_python_styleguide.options.config import Configuration
 
+FORMATTING_OPTIONS = frozenset((
+    '--show-violation-links',
+))
+
 
 def test_all_violations_are_documented(all_module_violations):
     """Ensures that all violations are documented."""
@@ -43,6 +47,7 @@ def test_configuration(all_violations):
     option_listed = {
         option.long_option_name: False
         for option in Configuration._options  # noqa: WPS437
+        if option.long_option_name not in FORMATTING_OPTIONS
     }
 
     for violation in all_violations:

--- a/wemake_python_styleguide/formatter.py
+++ b/wemake_python_styleguide/formatter.py
@@ -83,9 +83,16 @@ class WemakeFormatter(BaseFormatter):  # noqa: WPS214
             self._print_header(error.filename)
             self._processed_filenames.append(error.filename)
 
-        super().handle(error)
+        line = self.format(error)
+        source = self.show_source(error)
         link = self._show_link(error)
-        self.write(link, None)
+
+        if line:
+            self._write(line)
+        if link:
+            self._write(link)
+        if source:
+            self._write(source)
 
         self._error_count += 1
 
@@ -153,7 +160,7 @@ class WemakeFormatter(BaseFormatter):  # noqa: WPS214
             return ''
 
         return '  {spacing}-> {link}'.format(
-            spacing='' if self._should_show_source(error) else ' ' * 9,
+            spacing=' ' * 9,
             link=SHORTLINK_TEMPLATE.format(error.code),
         )
 

--- a/wemake_python_styleguide/formatter.py
+++ b/wemake_python_styleguide/formatter.py
@@ -87,8 +87,7 @@ class WemakeFormatter(BaseFormatter):  # noqa: WPS214
         source = self.show_source(error)
         link = self._show_link(error)
 
-        if line:
-            self._write(line)
+        self._write(line)
         if link:
             self._write(link)
         if source:

--- a/wemake_python_styleguide/formatter.py
+++ b/wemake_python_styleguide/formatter.py
@@ -43,6 +43,11 @@ DOCS_URL_TEMPLATE: Final = (
     'https://wemake-python-stylegui.de/en/{0}/pages/usage/violations/'
 )
 
+#: This url points to the specific violation page.
+SHORTLINK_TEMPLATE: Final = (
+    'https://pyflak.es/{0}'
+)
+
 
 class WemakeFormatter(BaseFormatter):  # noqa: WPS214
     """
@@ -79,19 +84,18 @@ class WemakeFormatter(BaseFormatter):  # noqa: WPS214
             self._processed_filenames.append(error.filename)
 
         super().handle(error)
+        link = self.show_link(error)
+        self.write(link, None)
+
         self._error_count += 1
 
     def format(self, error: Violation) -> str:  # noqa: WPS125
         """Called to format each individual :term:`violation`."""
-        return '{newline}  {row_col:<8} {code:<5} {text}{link}'.format(
+        return '{newline}  {row_col:<8} {code:<5} {text}'.format(
             newline=self.newline if self._should_show_source(error) else '',
             code=error.code,
             text=error.text,
             row_col='{0}:{1}'.format(error.line_number, error.column_number),
-            link=(
-                ' (https://pyflak.es/{0})'.format(error.code)
-                if self.options.show_violation_links else ''
-            ),
         )
 
     def show_source(self, error: Violation) -> str:
@@ -111,6 +115,16 @@ class WemakeFormatter(BaseFormatter):  # noqa: WPS214
         return '  {code}  {spacing}^'.format(
             code=code,
             spacing=' ' * (error.column_number - 1 - adjust),
+        )
+
+    def show_link(self, error: Violation) -> str:
+        """Called when ``--show-violation-links`` option is provided."""
+        if not self.options.show_violation_links:
+            return ''
+
+        return '  {spacing}-> {link}'.format(
+            spacing='' if self._should_show_source(error) else ' ' * 9,
+            link=SHORTLINK_TEMPLATE.format(error.code),
         )
 
     def show_statistics(self, statistics: Statistics) -> None:  # noqa: WPS210

--- a/wemake_python_styleguide/formatter.py
+++ b/wemake_python_styleguide/formatter.py
@@ -84,7 +84,7 @@ class WemakeFormatter(BaseFormatter):  # noqa: WPS214
             self._processed_filenames.append(error.filename)
 
         super().handle(error)
-        link = self.show_link(error)
+        link = self._show_link(error)
         self.write(link, None)
 
         self._error_count += 1
@@ -117,16 +117,6 @@ class WemakeFormatter(BaseFormatter):  # noqa: WPS214
             spacing=' ' * (error.column_number - 1 - adjust),
         )
 
-    def show_link(self, error: Violation) -> str:
-        """Called when ``--show-violation-links`` option is provided."""
-        if not self.options.show_violation_links:
-            return ''
-
-        return '  {spacing}-> {link}'.format(
-            spacing='' if self._should_show_source(error) else ' ' * 9,
-            link=SHORTLINK_TEMPLATE.format(error.code),
-        )
-
     def show_statistics(self, statistics: Statistics) -> None:  # noqa: WPS210
         """Called when ``--statistic`` option is passed."""
         all_errors = 0
@@ -156,6 +146,16 @@ class WemakeFormatter(BaseFormatter):  # noqa: WPS214
             self._write(message.format(self.newline, self._doc_url))
 
     # Our own methods:
+
+    def _show_link(self, error: Violation) -> str:
+        """Called when ``--show-violation-links`` option is provided."""
+        if not self.options.show_violation_links:
+            return ''
+
+        return '  {spacing}-> {link}'.format(
+            spacing='' if self._should_show_source(error) else ' ' * 9,
+            link=SHORTLINK_TEMPLATE.format(error.code),
+        )
 
     def _print_header(self, filename: str) -> None:
         self._write(

--- a/wemake_python_styleguide/formatter.py
+++ b/wemake_python_styleguide/formatter.py
@@ -83,11 +83,15 @@ class WemakeFormatter(BaseFormatter):  # noqa: WPS214
 
     def format(self, error: Violation) -> str:  # noqa: WPS125
         """Called to format each individual :term:`violation`."""
-        return '{newline}  {row_col:<8} {code:<5} {text}'.format(
+        return '{newline}  {row_col:<8} {code:<5} {text}{link}'.format(
             newline=self.newline if self._should_show_source(error) else '',
             code=error.code,
             text=error.text,
             row_col='{0}:{1}'.format(error.line_number, error.column_number),
+            link=(
+                ' (https://pyflak.es/{0})'.format(error.code)
+                if self.options.show_violation_links else ''
+            ),
         )
 
     def show_source(self, error: Violation) -> str:

--- a/wemake_python_styleguide/options/config.py
+++ b/wemake_python_styleguide/options/config.py
@@ -144,6 +144,12 @@ You can also show all options that ``flake8`` supports by running:
 - ``max-tuple-unpack-length`` - maximum number of variables in tuple unpacking,
     defaults to
     :str:`wemake_python_styleguide.options.defaults.MAX_TUPLE_UNPACK_LENGTH`
+
+.. rubric:: Formatter options
+
+- ``show-violation-links`` - whether to show violation shortlinks in the
+    formatter output
+    :str:`wemake_python_styleguide.options.defaults.SHOW_VIOLATION_LINKS`
 """
 
 from typing import ClassVar, Mapping, Optional, Sequence, Union
@@ -421,6 +427,17 @@ class Configuration(object):
             '--max-tuple-unpack-length',
             defaults.MAX_TUPLE_UNPACK_LENGTH,
             'Maximum number of variables in a tuple unpacking.',
+        ),
+
+        # Formatter:
+
+        _Option(
+            '--show-violation-links',
+            defaults.SHOW_VIOLATION_LINKS,
+            'Whether to show violation shortlinks in the formatter output.',
+            action='store_true',
+            type=None,
+            dest='show_violation_links',
         ),
     ]
 

--- a/wemake_python_styleguide/options/defaults.py
+++ b/wemake_python_styleguide/options/defaults.py
@@ -130,3 +130,10 @@ MAX_IMPORT_FROM_MEMBERS: Final = 8  # guessed
 
 #: Maximum number of variables in a ``tuple`` unpacking statement.
 MAX_TUPLE_UNPACK_LENGTH: Final = 4  # guessed
+
+# ==========
+# Formatter:
+# ==========
+
+#: Whether to show violation shortlinks in the formatter output.
+SHOW_VIOLATION_LINKS: Final = False

--- a/wemake_python_styleguide/options/validation.py
+++ b/wemake_python_styleguide/options/validation.py
@@ -97,6 +97,7 @@ class _ValidatedOptions(object):
     max_annotation_complexity: int = attr.ib(validator=[_min_max(min=2)])
     max_import_from_members: int = attr.ib(validator=[_min_max(min=1)])
     max_tuple_unpack_length: int = attr.ib(validator=[_min_max(min=1)])
+    show_violation_links: bool
 
 
 def validate_options(options: ConfigurationOptions) -> _ValidatedOptions:

--- a/wemake_python_styleguide/types.py
+++ b/wemake_python_styleguide/types.py
@@ -269,3 +269,7 @@ class ConfigurationOptions(Protocol):
     @property
     def max_tuple_unpack_length(self) -> int:
         ...
+
+    @property
+    def show_violation_links(self) -> bool:
+        ...


### PR DESCRIPTION
## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made
- [ ] I have added my changes to the `CHANGELOG.md`

## Related issues

Closes #2374
