### PR TITLE
Add full violations codes to docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ Semantic versioning in our case means:
   change the client facing API, change code conventions significantly, etc.
 
 
+## 0.16.2
+
+### Misc
+- Adds full violation codes to docs and `BaseViolation.full_code` #2409 
+
 ## 0.16.1
 
 ### Bugfixes

--- a/tests/test_violations/test_docs.py
+++ b/tests/test_violations/test_docs.py
@@ -60,3 +60,9 @@ def test_configuration(all_violations):
 
     for option_item, is_listed in option_listed.items():
         assert is_listed, option_item
+
+
+def test_all_violations_doc_start_with_full_code(all_violations):
+    """Ensures that all violations have `versionadded` tag."""
+    for violation in all_violations:
+        assert violation.__doc__.lstrip().startswith(violation.full_code)

--- a/tests/test_violations/test_implementation.py
+++ b/tests/test_violations/test_implementation.py
@@ -1,4 +1,7 @@
 import ast
+import re
+
+import pytest
 
 from wemake_python_styleguide.violations.base import ASTViolation
 
@@ -21,3 +24,18 @@ def test_visitor_returns_location():
 
     visitor = NewViolation(node=ast.parse(''), text='violation')
     assert visitor.node_items() == (0, 0, 'WPS001 violation')
+
+
+def test_violation_must_have_docstring():
+    """Ensures that `BaseNodeVisitor` return correct violation message."""
+    with pytest.raises(
+        TypeError,
+        match=re.escape(
+            'Please include a docstring documenting ' +
+            "<class 'test_implementation.test_violation_must_have_docstring." +
+            "<locals>.IShallNotPass'>",
+        ),
+    ):
+
+        class IShallNotPass(ASTViolation):  # noqa: WPS431
+            code = 123

--- a/tests/test_violations/test_implementation.py
+++ b/tests/test_violations/test_implementation.py
@@ -3,9 +3,21 @@ import ast
 from wemake_python_styleguide.violations.base import ASTViolation
 
 
+class NewViolation(ASTViolation):
+    """
+    Yells at cloud.
+    
+    Yay, I'm a docstring!
+    """
+
+    code = 1
+    error_template = '{0}'
+
+
 def test_visitor_returns_location():
     """Ensures that `BaseNodeVisitor` return correct violation message."""
-    visitor = ASTViolation(node=ast.parse(''), text='violation')
-    visitor.error_template = '{0}'
-    visitor.code = 1
+    assert NewViolation.full_code == 'WPS001'
+    assert NewViolation.summary == 'Yells at cloud.'
+
+    visitor = NewViolation(node=ast.parse(''), text='violation')
     assert visitor.node_items() == (0, 0, 'WPS001 violation')

--- a/tests/test_violations/test_implementation.py
+++ b/tests/test_violations/test_implementation.py
@@ -6,7 +6,7 @@ from wemake_python_styleguide.violations.base import ASTViolation
 class NewViolation(ASTViolation):
     """
     Yells at cloud.
-    
+
     Yay, I'm a docstring!
     """
 

--- a/wemake_python_styleguide/violations/base.py
+++ b/wemake_python_styleguide/violations/base.py
@@ -103,7 +103,7 @@ class BaseViolation(object, metaclass=abc.ABCMeta):
     code: ClassVar[int]
     previous_codes: ClassVar[Set[int]]
     deprecated: ClassVar[bool] = False
-    
+
     # assigned in __init_subclass__
     full_code: ClassVar[str]
     summary: ClassVar[str]
@@ -116,7 +116,7 @@ class BaseViolation(object, metaclass=abc.ABCMeta):
     def __init_subclass__(cls) -> None:
         """Sets additional values for subclasses."""
         violation_code = getattr(cls, 'code', None)
-        if violation_code is not None:
+        if violation_code is not None and cls.__doc__:
             # this is mostly done for docs to display the full code,
             # allowing its indexing in search engines and better discoverability
             cls.full_code = cls._full_code()

--- a/wemake_python_styleguide/violations/base.py
+++ b/wemake_python_styleguide/violations/base.py
@@ -122,7 +122,9 @@ class BaseViolation(object, metaclass=abc.ABCMeta):
             cls.full_code = cls._full_code()
             cls.summary = cls.__doc__.lstrip().split('\n', maxsplit=1)[0]
             # this hack adds full code to summary table in the docs
-            cls.__doc__ = _prepend_skipping_whitespaces(f'{cls.full_code} — ', cls.__doc__)
+            cls.__doc__ = _prepend_skipping_whitespaces(
+                '{0} — '.format(cls.full_code), cls.__doc__,
+            )
 
     def __init__(
         self,

--- a/wemake_python_styleguide/violations/base.py
+++ b/wemake_python_styleguide/violations/base.py
@@ -67,6 +67,7 @@ ErrorNode = Union[
 #: We use this type to define helper classes with callbacks to add violations.
 ErrorCallback = Callable[['BaseViolation'], None]
 
+
 @enum.unique
 class ViolationPostfixes(enum.Enum):
     """String values of postfixes used for violation baselines."""
@@ -110,15 +111,20 @@ class BaseViolation(object, metaclass=abc.ABCMeta):
     def __init_subclass__(cls) -> None:
         """Sets additional values for subclasses."""
         violation_code = getattr(cls, 'code', None)
-        if violation_code is not None and cls.__doc__:
-            # this is mostly done for docs to display the full code,
-            # allowing its indexing in search engines and better discoverability
-            cls.full_code = cls._full_code()
-            cls.summary = cls.__doc__.lstrip().split('\n', maxsplit=1)[0]
-            # this hack adds full code to summary table in the docs
-            cls.__doc__ = _prepend_skipping_whitespaces(
-                '{0} — '.format(cls.full_code), cls.__doc__,
+        if violation_code is None:
+            return
+        if cls.__doc__ is None:
+            raise TypeError(
+                'Please include a docstring documenting {0}'.format(cls),
             )
+        # this is mostly done for docs to display the full code,
+        # allowing its indexing in search engines and better discoverability
+        cls.full_code = cls._full_code()
+        cls.summary = cls.__doc__.lstrip().split('\n', maxsplit=1)[0]
+        # this hack adds full code to summary table in the docs
+        cls.__doc__ = _prepend_skipping_whitespaces(
+            '{0} — '.format(cls.full_code), cls.__doc__,
+        )
 
     def __init__(
         self,

--- a/wemake_python_styleguide/violations/base.py
+++ b/wemake_python_styleguide/violations/base.py
@@ -76,7 +76,8 @@ class ViolationPostfixes(enum.Enum):
     less_than = ' < {0}'
 
 
-class BaseViolation(object, metaclass=abc.ABCMeta):
+# TODO: remove `noqa` after a new release:
+class BaseViolation(object, metaclass=abc.ABCMeta):  # noqa: WPS338
     """
     Abstract base class for all style violations.
 
@@ -108,8 +109,7 @@ class BaseViolation(object, metaclass=abc.ABCMeta):
         ViolationPostfixes.bigger_than
     )
 
-    # TODO: remove `noqa` after a new release: 
-    def __init_subclass__(cls, **kwargs) -> None:  # noqa: WPS338
+    def __init_subclass__(cls, **kwargs) -> None:
         """Sets additional values for subclasses."""
         super().__init_subclass__(**kwargs)
         violation_code = getattr(cls, 'code', None)

--- a/wemake_python_styleguide/violations/base.py
+++ b/wemake_python_styleguide/violations/base.py
@@ -108,8 +108,9 @@ class BaseViolation(object, metaclass=abc.ABCMeta):
         ViolationPostfixes.bigger_than
     )
 
-    def __init_subclass__(cls) -> None:
+    def __init_subclass__(cls, **kwargs) -> None:
         """Sets additional values for subclasses."""
+        super().__init_subclass__(**kwargs)
         violation_code = getattr(cls, 'code', None)
         if violation_code is None:
             return

--- a/wemake_python_styleguide/violations/base.py
+++ b/wemake_python_styleguide/violations/base.py
@@ -108,7 +108,8 @@ class BaseViolation(object, metaclass=abc.ABCMeta):
         ViolationPostfixes.bigger_than
     )
 
-    def __init_subclass__(cls, **kwargs) -> None:
+    # TODO: remove `noqa` after a new release: 
+    def __init_subclass__(cls, **kwargs) -> None:  # noqa: WPS338
         """Sets additional values for subclasses."""
         super().__init_subclass__(**kwargs)
         violation_code = getattr(cls, 'code', None)

--- a/wemake_python_styleguide/violations/base.py
+++ b/wemake_python_styleguide/violations/base.py
@@ -115,8 +115,6 @@ class BaseViolation(object, metaclass=abc.ABCMeta):
 
     def __init_subclass__(cls) -> None:
         """Sets additional values for subclasses."""
-        Derives and sets additional values for subclasses
-        """
         violation_code = getattr(cls, 'code', None)
         if violation_code is not None:
             # this is mostly done for docs to display the full code,

--- a/wemake_python_styleguide/violations/base.py
+++ b/wemake_python_styleguide/violations/base.py
@@ -117,7 +117,8 @@ class BaseViolation(object, metaclass=abc.ABCMeta):
         """Sets additional values for subclasses."""
         Derives and sets additional values for subclasses
         """
-        if hasattr(cls, 'code'):
+        violation_code = getattr(cls, 'code', None)
+        if violation_code is not None:
             # this is mostly done for docs to display the full code,
             # allowing its indexing in search engines and better discoverability
             cls.full_code = cls._full_code()

--- a/wemake_python_styleguide/violations/base.py
+++ b/wemake_python_styleguide/violations/base.py
@@ -67,12 +67,6 @@ ErrorNode = Union[
 #: We use this type to define helper classes with callbacks to add violations.
 ErrorCallback = Callable[['BaseViolation'], None]
 
-def _prepend_skipping_whitespaces(prefix: str, text: str) -> str:
-    lstripped_text = text.lstrip()
-    leading_whitespaces = text[:len(text) - len(lstripped_text)]
-    return leading_whitespaces + prefix + lstripped_text
-
-
 @enum.unique
 class ViolationPostfixes(enum.Enum):
     """String values of postfixes used for violation baselines."""
@@ -259,3 +253,9 @@ class SimpleViolation(BaseViolation, metaclass=abc.ABCMeta):
         Cannot be ignored by inline ``noqa`` comments.
         """
         return 0, 0
+
+
+def _prepend_skipping_whitespaces(prefix: str, text: str) -> str:
+    lstripped_text = text.lstrip()
+    leading_whitespaces = text[:len(text) - len(lstripped_text)]
+    return leading_whitespaces + prefix + lstripped_text

--- a/wemake_python_styleguide/violations/base.py
+++ b/wemake_python_styleguide/violations/base.py
@@ -70,7 +70,7 @@ ErrorCallback = Callable[['BaseViolation'], None]
 def _prepend_skipping_whitespaces(prefix: str, text: str) -> str:
     lstripped_text = text.lstrip()
     leading_whitespaces = text[:len(text) - len(lstripped_text)]
-    return f'{leading_whitespaces}{prefix}{lstripped_text}'
+    return leading_whitespaces + prefix + lstripped_text
 
 
 @enum.unique

--- a/wemake_python_styleguide/violations/base.py
+++ b/wemake_python_styleguide/violations/base.py
@@ -114,7 +114,7 @@ class BaseViolation(object, metaclass=abc.ABCMeta):
     )
 
     def __init_subclass__(cls) -> None:
-        """
+        """Sets additional values for subclasses."""
         Derives and sets additional values for subclasses
         """
         if hasattr(cls, 'code'):


### PR DESCRIPTION
# I made full violations codes indexable

Finally, people searching for `WPS527 Sovereign Starter Motor` will see that WPS truly means!
<img width="430" alt="image" src="https://user-images.githubusercontent.com/36469655/165780205-28ace86a-c42b-4e4f-9ef4-affcf4e2cdce.png">

## Changes
- Full code is now prepended to `BaseViolation.__doc__`
- Full code is added to `BaseViolation.full_code` class var
- Summary is added to `BaseViolation.summary` class car
- `BaseViolation._full_name` is now a `classmethod`

## How it looks in docs
<img align="right" width="380" alt="image" src="https://user-images.githubusercontent.com/36469655/165781957-f24a6bab-8096-47fe-8a37-2aa413033b1d.png">
<img align="left"width="380" alt="image" src="https://user-images.githubusercontent.com/36469655/165782116-2d78bb81-aed2-488b-bb9d-90181d6e7f33.png">


## Checklist
- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made
- [x] I have added my changes to the `CHANGELOG.md`

## Related issues
Closes #2288
Closes #1145

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->

🙏 Please, if you or your company is finding wemake-python-styleguide valuable, help us sustain the project by sponsoring it transparently on https://opencollective.com/wemake-python-styleguide. As a thank you, your profile/company logo will be added to our main README which receives hundreds of unique visitors per day.
