### PR TITLE
Add __init_subclass__ to the methods order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Semantic versioning in our case means:
   But, in the future we might change the configuration names/logic,
   change the client facing API, change code conventions significantly, etc.
 
+## 0.16.2
+
+### Features
+- Adds `__init_subclass__` in the beginning of accepted methods order as per WPS338
 
 ## 0.16.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Semantic versioning in our case means:
   But, in the future we might change the configuration names/logic,
   change the client facing API, change code conventions significantly, etc.
 
-## 0.16.2
+## 0.17.1
 
 ### Features
 - Adds `__init_subclass__` in the beginning of accepted methods order as per WPS338

--- a/tests/test_visitors/test_ast/test_classes/test_method_order.py
+++ b/tests/test_visitors/test_ast/test_classes/test_method_order.py
@@ -9,6 +9,9 @@ from wemake_python_styleguide.visitors.ast.classes import (
 
 correct_method_order = """
 class Test(object):
+    def __init_subclass__(cls):
+        ...
+
     def __new__(self):
         ...
 
@@ -82,21 +85,25 @@ def test_correct_method_order(
 
 
 @pytest.mark.parametrize(('first', 'second'), [
+    ('__new__', '__init_subclass__'),
     ('__init__', '__new__'),
     ('__call__', '__init__'),
     ('__call__', '__new__'),
     ('__await__', '__call__'),
 
+    ('public', '__init_subclass__'),
     ('public', '__new__'),
     ('public', '__init__'),
     ('public', '__call__'),
     ('public', '__await__'),
 
+    ('__magic__', '__init_subclass__'),
     ('__magic__', '__new__'),
     ('__magic__', '__init__'),
     ('__magic__', '__call__'),
     ('__magic__', '__await__'),
 
+    ('_protected', '__init_subclass__'),
     ('_protected', '__new__'),
     ('_protected', '__init__'),
     ('_protected', '__call__'),
@@ -104,6 +111,7 @@ def test_correct_method_order(
     ('_protected', 'public'),
     ('_protected', '__magic__'),
 
+    ('__private', '__init_subclass__'),
     ('__private', '__new__'),
     ('__private', '__init__'),
     ('__private', '__call__'),

--- a/wemake_python_styleguide/violations/consistency.py
+++ b/wemake_python_styleguide/violations/consistency.py
@@ -1564,6 +1564,7 @@ class WrongMethodOrderViolation(ASTViolation):
 
     We follow the same ordering:
 
+    - ``__init_subclass__``
     - ``__new__``
     - ``__init__``
     - ``__call__``

--- a/wemake_python_styleguide/visitors/ast/classes.py
+++ b/wemake_python_styleguide/visitors/ast/classes.py
@@ -395,7 +395,8 @@ class ClassMethodOrderVisitor(base.BaseNodeVisitor):
 
     def _ideal_order(self, first: str) -> int:
         base_methods_order = {
-            '__new__': 6,  # highest priority
+            '__init_subclass__': 7,  # highest priority
+            '__new__': 6,
             '__init__': 5,
             '__call__': 4,
             '__await__': 3,


### PR DESCRIPTION
Add `__init_subclass__`  to `WPS338` order.

New allowed methods order:
- `__init_subclass__`
- `__new__`
- `__init__`
- `__call__`
- `__await__`
- 
## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made
- [x] I have added my changes to the `CHANGELOG.md`

## Related issues
Closes #2410

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->

🙏 Please, if you or your company is finding wemake-python-styleguide valuable, help us sustain the project by sponsoring it transparently on https://opencollective.com/wemake-python-styleguide. As a thank you, your profile/company logo will be added to our main README which receives hundreds of unique visitors per day.
