### PR TITLE
Replace typing.re import

### DIFF
--- a/wemake_python_styleguide/visitors/ast/builtins.py
+++ b/wemake_python_styleguide/visitors/ast/builtins.py
@@ -73,7 +73,7 @@ class WrongStringVisitor(base.BaseNodeVisitor):
     ))
 
     #: Copied from https://stackoverflow.com/a/30018957/4842742
-    _modulo_string_pattern: ClassVar[Pattern] = re.compile(
+    _modulo_string_pattern: ClassVar[Pattern[str]] = re.compile(
         r"""                             # noqa: WPS323
         (                                # start of capture group 1
             %                            # literal "%"
@@ -142,7 +142,7 @@ class WrongStringVisitor(base.BaseNodeVisitor):
         if parent and strings.is_doc_string(parent):
             return  # we allow `%s` in docstrings: they cannot be formatted.
 
-        if self._modulo_string_pattern.search(text_data):
+        if text_data and self._modulo_string_pattern.search(text_data):
             if not self._is_modulo_pattern_exception(parent):
                 self.add_violation(
                     consistency.ModuloStringFormatViolation(node),

--- a/wemake_python_styleguide/visitors/ast/builtins.py
+++ b/wemake_python_styleguide/visitors/ast/builtins.py
@@ -10,10 +10,10 @@ from typing import (
     FrozenSet,
     List,
     Optional,
+    Pattern,
     Sequence,
     Union,
 )
-from typing.re import Pattern
 
 from typing_extensions import Final, final
 

--- a/wemake_python_styleguide/visitors/tokenize/comments.py
+++ b/wemake_python_styleguide/visitors/tokenize/comments.py
@@ -19,8 +19,7 @@ All comments have the same type.
 import re
 import tokenize
 from token import ENDMARKER
-from typing import ClassVar
-from typing.re import Pattern
+from typing import ClassVar, Pattern
 
 from typing_extensions import Final, final
 

--- a/wemake_python_styleguide/visitors/tokenize/comments.py
+++ b/wemake_python_styleguide/visitors/tokenize/comments.py
@@ -53,8 +53,8 @@ SENTINEL_TOKEN: Final = tokenize.TokenInfo(
 class WrongCommentVisitor(BaseTokenVisitor):
     """Checks comment tokens."""
 
-    _no_cover: ClassVar[Pattern] = re.compile(r'^pragma:\s+no\s+cover')
-    _type_check: ClassVar[Pattern] = re.compile(
+    _no_cover: ClassVar[Pattern[str]] = re.compile(r'^pragma:\s+no\s+cover')
+    _type_check: ClassVar[Pattern[str]] = re.compile(
         r'^type:\s?([\w\d\[\]\'\"\.]+)$',
     )
 
@@ -181,7 +181,7 @@ class ShebangVisitor(BaseTokenVisitor):
     Code is insipired by https://github.com/xuhdev/flake8-executable
     """
 
-    _shebang: ClassVar[Pattern] = re.compile(r'(\s*)#!')
+    _shebang: ClassVar[Pattern[str]] = re.compile(r'(\s*)#!')
     _python_executable: ClassVar[str] = 'python'
 
     def visit_comment(self, token: tokenize.TokenInfo) -> None:
@@ -261,7 +261,9 @@ class ShebangVisitor(BaseTokenVisitor):
 class NoqaVisitor(BaseTokenVisitor):
     """Checks noqa comment tokens."""
 
-    _noqa_check: ClassVar[Pattern] = re.compile(r'^(noqa:?)($|[A-Z\d\,\s]+)')
+    _noqa_check: ClassVar[Pattern[str]] = re.compile(
+        r'^(noqa:?)($|[A-Z\d\,\s]+)',
+    )
 
     def __init__(self, *args, **kwargs) -> None:
         """Initializes a counter."""

--- a/wemake_python_styleguide/visitors/tokenize/primitives.py
+++ b/wemake_python_styleguide/visitors/tokenize/primitives.py
@@ -26,18 +26,18 @@ def _replace_braces(string: str) -> str:
 class WrongNumberTokenVisitor(BaseTokenVisitor):
     """Visits number tokens to find incorrect usages."""
 
-    _bad_number_suffixes: ClassVar[Pattern] = re.compile(
+    _bad_number_suffixes: ClassVar[Pattern[str]] = re.compile(
         r'^[0-9\.]+[BOXE]',
     )
 
-    _leading_zero_pattern: ClassVar[Pattern] = re.compile(
+    _leading_zero_pattern: ClassVar[Pattern[str]] = re.compile(
         r'^[0-9\.]+([box]|e\+?\-?)0.+', re.IGNORECASE | re.ASCII,
     )
-    _leading_zero_float_pattern: ClassVar[Pattern] = re.compile(
+    _leading_zero_float_pattern: ClassVar[Pattern[str]] = re.compile(
         r'^[0-9]*\.[0-9]+0+$',
     )
 
-    _positive_exponent_patterns: ClassVar[Pattern] = re.compile(
+    _positive_exponent_patterns: ClassVar[Pattern[str]] = re.compile(
         r'^[0-9\.]+e\+', re.IGNORECASE | re.ASCII,
     )
 
@@ -47,7 +47,7 @@ class WrongNumberTokenVisitor(BaseTokenVisitor):
 
     _bad_complex_suffix: ClassVar[str] = 'J'
 
-    _float_zero: ClassVar[Pattern] = re.compile(
+    _float_zero: ClassVar[Pattern[str]] = re.compile(
         r'^0\.0$',
     )
 
@@ -144,7 +144,7 @@ class WrongStringTokenVisitor(BaseTokenVisitor):
         'u', 'U', 'N',
     ))
 
-    _implicit_raw_strings: ClassVar[Pattern] = re.compile(r'\\{2}.+')
+    _implicit_raw_strings: ClassVar[Pattern[str]] = re.compile(r'\\{2}.+')
 
     def __init__(self, *args, **kwargs) -> None:
         """Initializes new visitor and saves all docstrings."""

--- a/wemake_python_styleguide/visitors/tokenize/primitives.py
+++ b/wemake_python_styleguide/visitors/tokenize/primitives.py
@@ -1,7 +1,6 @@
 import re
 import tokenize
-from typing import ClassVar, FrozenSet, Optional
-from typing.re import Pattern
+from typing import ClassVar, FrozenSet, Optional, Pattern
 
 from typing_extensions import final
 


### PR DESCRIPTION
`typing.re` has been deprecated since Python 3.8 and will be removed in Python 3.12. But `Pattern` can also be imported directly from `typing`.

## Checklist

- [X] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [ ] I have created at least one test case for the changes I have made
- [ ] I have updated the documentation for the changes I have made
- [ ] I have added my changes to the `CHANGELOG.md`

Should this have a CHANGELOG entry?

## Related issues

python/cpython#92873
