### PR TITLE
Added `WPS473` rule that disallows usage of `Union` and `Optional`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Semantic versioning in our case means:
   But, in the future we might change the configuration names/logic,
   change the client facing API, change code conventions significantly, etc.
 
-## 0.17.2
+## 0.18.0
 
 ### Features
 - Adds `disallow_union_type` configuration option

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ Semantic versioning in our case means:
   But, in the future we might change the configuration names/logic,
   change the client facing API, change code conventions significantly, etc.
 
+## 0.17.2
+
+### Features
+- Adds `disallow_union_type` configuration option
+
 ## 0.17.1
 
 ### Features
@@ -24,7 +29,7 @@ Semantic versioning in our case means:
 ## 0.16.2
 
 ### Misc
-- Adds full violation codes to docs and `BaseViolation.full_code` #2409 
+- Adds full violation codes to docs and `BaseViolation.full_code` #2409
 
 ## 0.16.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Semantic versioning in our case means:
 ## 0.18.0
 
 ### Features
-- Adds `disallow_union_type` configuration option
+- Adds `WPS473` check for `typing.Union` and `typing.Optional` usages
 
 ## 0.17.1
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,8 +56,8 @@ per-file-ignores =
   wemake_python_styleguide/checker.py: WPS201
   # Exceeded maximum number of imports due to the from __future__ import:
   wemake_python_styleguide/visitors/tokenize/statements.py: WPS201
-  # Allows mypy type hinting, `Ellipsis`` usage, multiple methods:
-  wemake_python_styleguide/types.py: D102, WPS214, WPS220, WPS428
+  # Allows mypy type hinting, `Ellipsis`` usage, multiple methods and noqa:
+  wemake_python_styleguide/types.py: D102, WPS214, WPS220, WPS428, WPS402
   # There are multiple fixtures, `assert`s, and subprocesses in tests:
   tests/test_visitors/test_ast/test_naming/conftest.py: WPS202
   tests/*.py: S101, S105, S404, S603, S607, WPS211, WPS226, WPS323

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,6 +54,8 @@ per-file-ignores =
   wemake_python_styleguide/options/defaults.py: WPS432
   # Checker has a lot of imports:
   wemake_python_styleguide/checker.py: WPS201
+  # Exceeded maximum number of imports due to the from __future__ import:
+  wemake_python_styleguide/visitors/tokenize/statements.py: WPS201
   # Allows mypy type hinting, `Ellipsis`` usage, multiple methods:
   wemake_python_styleguide/types.py: D102, WPS214, WPS220, WPS428
   # There are multiple fixtures, `assert`s, and subprocesses in tests:
@@ -126,6 +128,9 @@ rules =
 
   "sys_version_info < (3, 9)": py-lt-39
   "sys_version_info >= (3, 9)": py-gte-39
+
+  "sys_version_info < (3, 10)": py-lt-310
+  "sys_version_info >= (3, 10)": py-gte-310
 
 
 [mypy]

--- a/tests/fixtures/noqa/noqa.py
+++ b/tests/fixtures/noqa/noqa.py
@@ -814,5 +814,9 @@ class TestClass(object, **{}):  # noqa: WPS470
 secondary_slice = items[1:][:3]  # noqa: WPS471
 first, *_rest = some_collection  # noqa: WPS472
 
+
+def function_with_unions(a: Union[int, str], b: Optional[int]) -> None:  # noqa: WPS473
+    _ = f'{a} {b}'
+
 def foo2_func():
     return (1, 2, 3, 4, 5, 6)  # noqa: WPS227

--- a/tests/fixtures/noqa/noqa.py
+++ b/tests/fixtures/noqa/noqa.py
@@ -350,10 +350,10 @@ my_print(
 
 
 def function(  # noqa: WPS320
-    arg: Optional[  # noqa: WPS320
+    arg: List[  # noqa: WPS320
         str,
     ]
-) -> Optional[
+) -> List[
     str,
 ]:
     some_set = {1
@@ -814,9 +814,6 @@ class TestClass(object, **{}):  # noqa: WPS470
 secondary_slice = items[1:][:3]  # noqa: WPS471
 first, *_rest = some_collection  # noqa: WPS472
 
-
-def function_with_unions(a: Union[int, str], b: Optional[int]) -> None:  # noqa: WPS473
-    _ = f'{a} {b}'
 
 def foo2_func():
     return (1, 2, 3, 4, 5, 6)  # noqa: WPS227

--- a/tests/fixtures/noqa/noqa310.py
+++ b/tests/fixtures/noqa/noqa310.py
@@ -1,0 +1,13 @@
+"""
+Here we list errors that are specific for python3.10 and further versions.
+
+Please, do not add general violations here.
+"""
+
+
+def function_with_unions(
+    arg1: Union[int, str],   # noqa: WPS473
+    arg2: Optional[int],  # noqa: WPS473
+) -> None:
+    """Docstring."""
+

--- a/tests/test_checker/test_noqa.py
+++ b/tests/test_checker/test_noqa.py
@@ -378,7 +378,6 @@ def test_noqa_fixture_disabled(
             '--ignore',
             ','.join(IGNORED_VIOLATIONS),
             '--disable-noqa',
-            '--disallow-union-type',
             '--isolated',
             '--select',
             'WPS',

--- a/tests/test_checker/test_noqa.py
+++ b/tests/test_checker/test_noqa.py
@@ -23,6 +23,7 @@ import pytest
 _PY_OLD = sys.version_info < (3, 8)
 _PY38 = (3, 8) <= sys.version_info < (3, 9)
 _PY39 = (3, 9) <= sys.version_info < (3, 10)
+_PYGTE310 = sys.version_info >= (3, 10)
 
 #: Used to find violations' codes in output.
 ERROR_PATTERN = re.compile(r'(WPS\d{3})')
@@ -41,18 +42,19 @@ IGNORED_VIOLATIONS = (
 
 #: Number and count of violations that would be raised.
 VERSION_SPECIFIC = types.MappingProxyType({
-    'WPS216': int(not _PY39),
-    'WPS224': int(not _PY39),
+    'WPS216': int(not _PY39 and not _PYGTE310),
+    'WPS224': int(not _PY39 and not _PYGTE310),
 
-    'WPS307': int(not _PY39),
+    'WPS307': int(not _PY39 and not _PYGTE310),
     'WPS332': 0,  # TODO: pyflakes fails at `:=` at the moment
 
     'WPS416': int(_PY_OLD),  # only works for `< python3.8`
     'WPS451': int(_PY38),  # only works for `== python3.8`
     'WPS452': int(_PY38),  # only works for `== python3.8`
     'WPS466': int(_PY39),  # only works for `== python3.9`
+    'WPS473': 2 * int(_PYGTE310),  # only works for `>= python3.10`
 
-    'WPS602': 2 * int(not _PY39),
+    'WPS602': 2 * int(not _PY39 and not _PYGTE310),
 })
 
 #: Number and count of violations that would be raised.
@@ -252,6 +254,7 @@ SHOULD_BE_RAISED = types.MappingProxyType({
     'WPS470': 1,
     'WPS471': 1,
     'WPS472': 1,
+    'WPS473': 0,  # defined in version specific table.
 
     'WPS500': 1,
     'WPS501': 1,
@@ -362,6 +365,15 @@ def test_codes(all_violations):
         VERSION_SPECIFIC,
         0,
         marks=pytest.mark.skipif(not _PY39, reason='ast changes on 3.9'),
+    ),
+    pytest.param(
+        'noqa310.py',
+        VERSION_SPECIFIC,
+        0,
+        marks=pytest.mark.skipif(
+            not _PYGTE310,
+            reason='Union symbol `|` enforced in 3.10',
+        ),
     ),
 ])
 def test_noqa_fixture_disabled(

--- a/tests/test_checker/test_noqa.py
+++ b/tests/test_checker/test_noqa.py
@@ -378,6 +378,7 @@ def test_noqa_fixture_disabled(
             '--ignore',
             ','.join(IGNORED_VIOLATIONS),
             '--disable-noqa',
+            '--disallow-union-type',
             '--isolated',
             '--select',
             'WPS',

--- a/tests/test_visitors/conftest.py
+++ b/tests/test_visitors/conftest.py
@@ -12,7 +12,7 @@ from wemake_python_styleguide.violations.base import (
 )
 from wemake_python_styleguide.visitors.base import BaseVisitor
 
-_IgnoredTypes = Union[
+_IgnoredTypes = Union[  # noqa: WPS473
     Type[BaseViolation],
     Tuple[Type[BaseViolation], ...],
     None,

--- a/tests/test_visitors/conftest.py
+++ b/tests/test_visitors/conftest.py
@@ -1,4 +1,6 @@
-from typing import Optional, Sequence, Tuple, Type, Union
+from __future__ import annotations
+
+from typing import Sequence, Tuple, Type, Union
 
 import pytest
 from typing_extensions import Final
@@ -53,7 +55,7 @@ def assert_error_text():
     def factory(
         visitor: BaseVisitor,
         text: str,
-        baseline: Optional[int] = None,
+        baseline: int | None = None,
         *,
         multiple: bool = False,
         ignored_types: _IgnoredTypes = None,

--- a/tests/test_visitors/test_ast/test_annotations/test_multiline_annotations/test_argument_annotations.py
+++ b/tests/test_visitors/test_ast/test_annotations/test_multiline_annotations/test_argument_annotations.py
@@ -20,13 +20,13 @@ def function(arg: int): ...
 """
 
 correct_compound_argument = """
-def function(arg: Optional[int]): ...
+def function(arg: List[int]): ...
 """
 
 correct_multiline_arguments = """
 def function(
     arg1: str,
-    arg2: Union[int, str, None],
+    arg2: Tuple[int, str, None],
 ): ...
 """
 
@@ -34,7 +34,7 @@ def function(
 
 wrong_multiline_arguments = """
 def function(
-    arg: Optional[
+    arg: List[
         int,
     ],
 ): ...

--- a/tests/test_visitors/test_ast/test_annotations/test_multiline_annotations/test_return_annotations.py
+++ b/tests/test_visitors/test_ast/test_annotations/test_multiline_annotations/test_return_annotations.py
@@ -16,13 +16,13 @@ def function() -> int: ...
 """
 
 correct_compound_return = """
-def function() -> Optional[int]: ...
+def function() -> List[int]: ...
 """
 
 correct_multiline_return = """
 def function(
     arg1,
-) -> Union[int, str, None]: ...
+) -> Tuple[int, str, None]: ...
 """
 
 # Wrong:
@@ -30,16 +30,16 @@ def function(
 wrong_multiline_return1 = """
 def function(
     arg
-) -> Optional[
-    Union[int, str]
+) -> List[
+    Tuple[int, str]
 ]: ...
 """
 
 wrong_multiline_return2 = """
 def function(
     arg
-) -> Optional[
-    Union[
+) -> List[
+    Tuple[
         int, str,
     ]
 ]: ...
@@ -48,8 +48,8 @@ def function(
 wrong_multiline_return3 = """
 def function(
     arg
-) -> Optional[
-    Union[
+) -> List[
+    Tuple[
         int,
         str,
     ]

--- a/tests/test_visitors/test_ast/test_annotations/test_union_annotations.py
+++ b/tests/test_visitors/test_ast/test_annotations/test_union_annotations.py
@@ -11,7 +11,7 @@ from wemake_python_styleguide.visitors.ast.annotations import (
 
 
 @pytest.mark.parametrize(
-    'function',
+    'expression',
     [
         'def function(a: Union[int, str]): ...',
         'def function(a: typing.Union[int, str]): ...',
@@ -19,17 +19,20 @@ from wemake_python_styleguide.visitors.ast.annotations import (
         'def function(a: List[Union[int, str]]): ...',
         'def function(a: int) -> Union[int, str]: ...',
         'def function(a: Optional[int]) -> None: ...',
+        'a = Union[int, str]',
+        'a: Optional[str] = None',
+        'a: Optional[Union[int, str]]',
     ],
 )
-def test_wrong_return_annotation(
+def test_wrong_union_func_annotation(
     assert_errors,
     parse_ast_tree,
-    function,
+    expression,
     default_options,
     mode,
 ) -> None:
-    """Ensures that using incorrect return annotations is forbidden."""
-    tree = parse_ast_tree(mode(function))
+    """Ensures that using incorrect union annotations is forbidden."""
+    tree = parse_ast_tree(mode(expression))
 
     visitor = WrongAnnotationVisitor(default_options, tree=tree)
     visitor.run()

--- a/tests/test_visitors/test_ast/test_annotations/test_union_annotations.py
+++ b/tests/test_visitors/test_ast/test_annotations/test_union_annotations.py
@@ -35,6 +35,6 @@ def test_wrong_return_annotation(
     visitor.run()
 
     if sys.version_info < (3, 10):  # pragma: py-lt-310
-        assert_errors(visitor, [DisallowUnionTypeViolation])
+        assert_errors(visitor, [])
     else:  # pragma: py-gte-310
         assert_errors(visitor, [DisallowUnionTypeViolation])

--- a/tests/test_visitors/test_ast/test_annotations/test_union_annotations.py
+++ b/tests/test_visitors/test_ast/test_annotations/test_union_annotations.py
@@ -1,0 +1,37 @@
+import pytest
+
+from wemake_python_styleguide.violations.best_practices import (
+    DisallowUnionTypeViolation,
+)
+from wemake_python_styleguide.visitors.ast.annotations import (
+    WrongAnnotationVisitor,
+)
+
+functions_breaking_rule = [
+    """def function(a: Union[int, str]): ...""",
+    """def function(a: typing.Union[int, str]): ...""",
+    """def function(a: t.Union[int, str]): ...""",
+    """def function(a: List[Union[int, str]]): ...""",
+    """def function(a: int) -> Union[int, str]: ...""",
+    """def function(a: Optional[int]) -> None: ...""",
+]
+
+
+@pytest.mark.parametrize('function', functions_breaking_rule)
+def test_wrong_return_annotation(
+    assert_errors,
+    parse_ast_tree,
+    function,
+    options,
+    mode,
+) -> None:
+    """Ensures that using incorrect return annotations is forbidden."""
+    tree = parse_ast_tree(mode(function))
+
+    visitor = WrongAnnotationVisitor(
+        options(disallow_union_type=True),
+        tree=tree,
+    )
+    visitor.run()
+
+    assert_errors(visitor, [DisallowUnionTypeViolation])

--- a/tests/test_visitors/test_ast/test_annotations/test_union_annotations.py
+++ b/tests/test_visitors/test_ast/test_annotations/test_union_annotations.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 
 from wemake_python_styleguide.violations.best_practices import (
@@ -32,4 +34,7 @@ def test_wrong_return_annotation(
     visitor = WrongAnnotationVisitor(default_options, tree=tree)
     visitor.run()
 
-    assert_errors(visitor, [DisallowUnionTypeViolation])
+    if sys.version_info < (3, 10):  # pragma: py-lt-310
+        assert_errors(visitor, [DisallowUnionTypeViolation])
+    else:  # pragma: py-gte-310
+        assert_errors(visitor, [DisallowUnionTypeViolation])

--- a/tests/test_visitors/test_ast/test_annotations/test_union_annotations.py
+++ b/tests/test_visitors/test_ast/test_annotations/test_union_annotations.py
@@ -7,31 +7,29 @@ from wemake_python_styleguide.visitors.ast.annotations import (
     WrongAnnotationVisitor,
 )
 
-functions_breaking_rule = [
-    """def function(a: Union[int, str]): ...""",
-    """def function(a: typing.Union[int, str]): ...""",
-    """def function(a: t.Union[int, str]): ...""",
-    """def function(a: List[Union[int, str]]): ...""",
-    """def function(a: int) -> Union[int, str]: ...""",
-    """def function(a: Optional[int]) -> None: ...""",
-]
 
-
-@pytest.mark.parametrize('function', functions_breaking_rule)
+@pytest.mark.parametrize(
+    'function',
+    [
+        """def function(a: Union[int, str]): ...""",
+        """def function(a: typing.Union[int, str]): ...""",
+        """def function(a: t.Union[int, str]): ...""",
+        """def function(a: List[Union[int, str]]): ...""",
+        """def function(a: int) -> Union[int, str]: ...""",
+        """def function(a: Optional[int]) -> None: ...""",
+    ],
+)
 def test_wrong_return_annotation(
     assert_errors,
     parse_ast_tree,
     function,
-    options,
+    default_options,
     mode,
 ) -> None:
     """Ensures that using incorrect return annotations is forbidden."""
     tree = parse_ast_tree(mode(function))
 
-    visitor = WrongAnnotationVisitor(
-        options(disallow_union_type=True),
-        tree=tree,
-    )
+    visitor = WrongAnnotationVisitor(default_options, tree=tree)
     visitor.run()
 
     assert_errors(visitor, [DisallowUnionTypeViolation])

--- a/tests/test_visitors/test_ast/test_annotations/test_union_annotations.py
+++ b/tests/test_visitors/test_ast/test_annotations/test_union_annotations.py
@@ -13,12 +13,12 @@ from wemake_python_styleguide.visitors.ast.annotations import (
 @pytest.mark.parametrize(
     'function',
     [
-        """def function(a: Union[int, str]): ...""",
-        """def function(a: typing.Union[int, str]): ...""",
-        """def function(a: t.Union[int, str]): ...""",
-        """def function(a: List[Union[int, str]]): ...""",
-        """def function(a: int) -> Union[int, str]: ...""",
-        """def function(a: Optional[int]) -> None: ...""",
+        'def function(a: Union[int, str]): ...',
+        'def function(a: typing.Union[int, str]): ...',
+        'def function(a: t.Union[int, str]): ...',
+        'def function(a: List[Union[int, str]]): ...',
+        'def function(a: int) -> Union[int, str]: ...',
+        'def function(a: Optional[int]) -> None: ...',
     ],
 )
 def test_wrong_return_annotation(

--- a/wemake_python_styleguide/compat/functions.py
+++ b/wemake_python_styleguide/compat/functions.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import ast
-from typing import List, Union
+from typing import List
 
 from wemake_python_styleguide.compat.nodes import NamedExpr
 from wemake_python_styleguide.compat.types import AnyAssignWithWalrus
@@ -7,7 +9,7 @@ from wemake_python_styleguide.types import AnyFunctionDefAndLambda
 
 
 def get_assign_targets(
-    node: Union[AnyAssignWithWalrus, ast.AugAssign],
+    node: AnyAssignWithWalrus | ast.AugAssign,
 ) -> List[ast.expr]:
     """Returns list of assign targets without knowing the type of assign."""
     if isinstance(node, (ast.AnnAssign, ast.AugAssign, NamedExpr)):

--- a/wemake_python_styleguide/compat/nodes.py
+++ b/wemake_python_styleguide/compat/nodes.py
@@ -5,9 +5,11 @@ Note that we use ``sys.version_info`` directly,
 because that's how ``mypy`` knows about what we are doing.
 """
 
+from __future__ import annotations
+
 import ast
 import sys
-from typing import Any, Optional
+from typing import Any
 
 if sys.version_info >= (3, 8):  # pragma: py-lt-38
     from ast import Constant as Constant  # noqa: WPS433, WPS113
@@ -39,7 +41,7 @@ else:  # pragma: py-gte-38
         """
 
         value: Any  # noqa: WPS110
-        kind: Optional[str]
+        kind: str | None
 
         s: Any  # noqa: WPS111
         n: complex  # noqa: WPS111

--- a/wemake_python_styleguide/compat/types.py
+++ b/wemake_python_styleguide/compat/types.py
@@ -4,4 +4,4 @@ from wemake_python_styleguide.compat.nodes import NamedExpr
 from wemake_python_styleguide.types import AnyAssign
 
 #: When we search for assign elements, we also need typed assign.
-AnyAssignWithWalrus = Union[AnyAssign, NamedExpr]
+AnyAssignWithWalrus = Union[AnyAssign, NamedExpr]  # noqa: WPS473

--- a/wemake_python_styleguide/logic/arguments/function_args.py
+++ b/wemake_python_styleguide/logic/arguments/function_args.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import ast
 from itertools import zip_longest
-from typing import List, Mapping, Optional, Tuple
+from typing import List, Mapping, Tuple
 
 from wemake_python_styleguide import constants, types
 from wemake_python_styleguide.compat.functions import get_posonlyargs
@@ -41,7 +43,7 @@ def _has_same_vararg(
     call: ast.Call,
 ) -> bool:
     """Tells whether ``call`` has the same vararg ``*args`` as ``node``."""
-    vararg_name: Optional[str] = None
+    vararg_name: str | None = None
     for starred_arg in get_starred_args(call):
         # 'args': [<_ast.Starred object at 0x10d77a3c8>]
         if isinstance(starred_arg.value, ast.Name):
@@ -58,7 +60,7 @@ def _has_same_kwarg(
     call: ast.Call,
 ) -> bool:
     """Tells whether ``call`` has the same kwargs as ``node``."""
-    kwarg_name: Optional[str] = None
+    kwarg_name: str | None = None
     null_arg_keywords = filter(lambda key: key.arg is None, call.keywords)
     for keyword in null_arg_keywords:
         # `a=1` vs `**kwargs`:

--- a/wemake_python_styleguide/logic/arguments/super_args.py
+++ b/wemake_python_styleguide/logic/arguments/super_args.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import ast
-from typing import Dict, Optional
+from typing import Dict
 
 
 def is_ordinary_super_call(node: ast.AST, class_name: str) -> bool:
@@ -47,8 +49,8 @@ def _get_keyword_args_by_names(
 def _is_super_called_with(call: ast.Call, type_: str, object_: str) -> bool:
     """Tells whether super ``call`` was done with ``type_`` and ``object_``."""
     if len(call.args) == 2:  # branch for super(Test, self)
-        arg1: Optional[ast.expr] = call.args[0]
-        arg2: Optional[ast.expr] = call.args[1]
+        arg1: ast.expr | None = call.args[0]
+        arg2: ast.expr | None = call.args[1]
     elif len(call.keywords) == 2:  # branch for super(t=Test, obj=self)
         keyword_args = _get_keyword_args_by_names(call, 't', 'obj')
         arg1 = keyword_args.get('t')
@@ -61,7 +63,7 @@ def _is_super_called_with(call: ast.Call, type_: str, object_: str) -> bool:
     return is_expected_type and is_expected_object
 
 
-def _get_super_call(node: ast.AST) -> Optional[ast.Call]:
+def _get_super_call(node: ast.AST) -> ast.Call | None:
     """Returns given ``node`` if it represents ``super`` ``ast.Call``."""
     if not isinstance(node, ast.Call):
         return None

--- a/wemake_python_styleguide/logic/complexity/annotations.py
+++ b/wemake_python_styleguide/logic/complexity/annotations.py
@@ -12,7 +12,7 @@ from typing import Union
 
 from wemake_python_styleguide.compat.functions import get_slice_expr
 
-_Annotation = Union[
+_Annotation = Union[  # noqa: WPS473
     ast.expr,
     ast.Str,
 ]

--- a/wemake_python_styleguide/logic/complexity/overuses.py
+++ b/wemake_python_styleguide/logic/complexity/overuses.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import ast
-from typing import Union
 
 from wemake_python_styleguide.compat.aliases import FunctionNodes
 from wemake_python_styleguide.compat.nodes import Constant
@@ -57,7 +58,7 @@ def is_self(node: ast.AST) -> bool:
     We do not check for attribute access, because ``ast.Attribute`` nodes
     are globally ignored.
     """
-    self_node: Union[ast.Attribute, ast.Subscript, None] = None
+    self_node: ast.Attribute | ast.Subscript | None = None
     if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
         self_node = node.func
     elif isinstance(node, ast.Subscript):

--- a/wemake_python_styleguide/logic/naming/name_nodes.py
+++ b/wemake_python_styleguide/logic/naming/name_nodes.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import ast
 import itertools
-from typing import Iterable, List, Optional
+from typing import Iterable, List
 
 from wemake_python_styleguide.compat.functions import get_assign_targets
 from wemake_python_styleguide.compat.types import AnyAssignWithWalrus
@@ -13,7 +15,7 @@ def is_same_variable(left: ast.AST, right: ast.AST) -> bool:
     return False
 
 
-def get_assigned_name(node: ast.AST) -> Optional[str]:
+def get_assigned_name(node: ast.AST) -> str | None:
     """
     Returns variable names for node that is just assigned.
 
@@ -82,7 +84,7 @@ def get_variables_from_node(node: ast.AST) -> List[str]:
     return names
 
 
-def extract_name(node: ast.AST) -> Optional[str]:
+def extract_name(node: ast.AST) -> str | None:
     """
     Utility to extract names for several types of nodes.
 

--- a/wemake_python_styleguide/logic/nodes.py
+++ b/wemake_python_styleguide/logic/nodes.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import ast
-from typing import Optional, Union
 
 from wemake_python_styleguide.logic.safe_eval import literal_eval_with_names
 from wemake_python_styleguide.types import ContextNodes
@@ -19,17 +20,17 @@ def is_literal(node: ast.AST) -> bool:
     return True
 
 
-def get_parent(node: ast.AST) -> Optional[ast.AST]:
+def get_parent(node: ast.AST) -> ast.AST | None:
     """Returns the parent node or ``None`` if node has no parent."""
     return getattr(node, 'wps_parent', None)
 
 
-def get_context(node: ast.AST) -> Optional[ContextNodes]:
+def get_context(node: ast.AST) -> ContextNodes | None:
     """Returns the context or ``None`` if node has no context."""
     return getattr(node, 'wps_context', None)
 
 
-def evaluate_node(node: ast.AST) -> Optional[Union[int, float, str, bytes]]:
+def evaluate_node(node: ast.AST) -> int | float | str | bytes | None:
     """Returns the value of a node or its evaluation."""
     if isinstance(node, ast.Name):
         return None

--- a/wemake_python_styleguide/logic/safe_eval.py
+++ b/wemake_python_styleguide/logic/safe_eval.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
+
 import ast
-from typing import Any, Optional, Union
+from typing import Any
 
 from wemake_python_styleguide.compat.nodes import Constant
 
 
-def _convert_num(node: Optional[ast.AST]):
+def _convert_num(node: ast.AST | None):
     if isinstance(node, Constant):  # pragma: py-lt-38
         if isinstance(node.value, (int, float, complex)):
             return node.value
@@ -17,7 +19,7 @@ def _convert_num(node: Optional[ast.AST]):
     raise ValueError('malformed node or string: {0!r}'.format(node))
 
 
-def _convert_signed_num(node: Optional[ast.AST]):
+def _convert_signed_num(node: ast.AST | None):
     unary_operators = (ast.UAdd, ast.USub)
     if isinstance(node, ast.UnaryOp) and isinstance(node.op, unary_operators):
         operand = _convert_num(node.operand)
@@ -25,7 +27,7 @@ def _convert_signed_num(node: Optional[ast.AST]):
     return _convert_num(node)
 
 
-def _convert_complex(node: ast.BinOp) -> Optional[complex]:
+def _convert_complex(node: ast.BinOp) -> complex | None:
     left = _convert_signed_num(node.left)
     right = _convert_num(node.right)
     if isinstance(left, (int, float)) and isinstance(right, complex):
@@ -35,7 +37,7 @@ def _convert_complex(node: ast.BinOp) -> Optional[complex]:
     return None
 
 
-def _convert_iterable(node: Union[ast.Tuple, ast.List, ast.Set, ast.Dict]):
+def _convert_iterable(node: ast.Tuple | ast.List | ast.Set | ast.Dict):
     if isinstance(node, ast.Tuple):
         return tuple(map(literal_eval_with_names, node.elts))
     elif isinstance(node, ast.List):
@@ -49,7 +51,7 @@ def _convert_iterable(node: Union[ast.Tuple, ast.List, ast.Set, ast.Dict]):
 
 
 def literal_eval_with_names(  # noqa: WPS231
-    node: Optional[ast.AST],
+    node: ast.AST | None,
 ) -> Any:
     """
     Safely evaluate constants and ``ast.Name`` nodes.

--- a/wemake_python_styleguide/logic/tokens/comprehensions.py
+++ b/wemake_python_styleguide/logic/tokens/comprehensions.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import tokenize
-from typing import List, Optional
+from typing import List
 
 import attr
 from typing_extensions import final
@@ -17,7 +19,7 @@ class Compehension(object):
     """
 
     left_bracket: tokenize.TokenInfo
-    expr: Optional[tokenize.TokenInfo] = None
+    expr: tokenize.TokenInfo | None = None
 
     # `for` keywords
     fors: List[tokenize.TokenInfo] = attr.ib(factory=list)

--- a/wemake_python_styleguide/logic/tree/attributes.py
+++ b/wemake_python_styleguide/logic/tree/attributes.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
+
 import ast
-from typing import Iterable, Optional
+from typing import Iterable
 
 from wemake_python_styleguide.types import AnyChainable
 
 
-def _chained_item(iterator: ast.AST) -> Optional[ast.AST]:
+def _chained_item(iterator: ast.AST) -> ast.AST | None:
     if isinstance(iterator, (ast.Attribute, ast.Subscript)):
         return iterator.value
     elif isinstance(iterator, ast.Call):

--- a/wemake_python_styleguide/logic/tree/calls.py
+++ b/wemake_python_styleguide/logic/tree/calls.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import ast
-from typing import Iterable, Optional
+from typing import Iterable
 
 
-def _chained_item(iterator: ast.AST) -> Optional[ast.Call]:
+def _chained_item(iterator: ast.AST) -> ast.Call | None:
     children = list(ast.iter_child_nodes(iterator))
     if isinstance(children[0], ast.Call):
         return children[0]

--- a/wemake_python_styleguide/logic/tree/classes.py
+++ b/wemake_python_styleguide/logic/tree/classes.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import ast
-from typing import List, Optional, Tuple
+from typing import List, Tuple
 
 from wemake_python_styleguide.compat.aliases import AssignNodes
 from wemake_python_styleguide.constants import ALLOWED_BUILTIN_CLASSES
@@ -11,7 +13,7 @@ from wemake_python_styleguide.types import AnyAssign
 _AllAttributes = Tuple[List[AnyAssign], List[ast.Attribute]]
 
 
-def is_forbidden_super_class(class_name: Optional[str]) -> bool:
+def is_forbidden_super_class(class_name: str | None) -> bool:
     """
     Tells whether or not the base class is forbidden to be subclassed.
 
@@ -81,7 +83,7 @@ def get_attributes(
     return class_attributes, instance_attributes
 
 
-def _get_instance_attribute(node: ast.AST) -> Optional[ast.Attribute]:
+def _get_instance_attribute(node: ast.AST) -> ast.Attribute | None:
     return node if (
         isinstance(node, ast.Attribute) and
         isinstance(node.ctx, ast.Store) and
@@ -93,7 +95,7 @@ def _get_instance_attribute(node: ast.AST) -> Optional[ast.Attribute]:
 def _get_class_attribute(
     node: ast.ClassDef,
     subnode: ast.AST,
-) -> Optional[AnyAssign]:
+) -> AnyAssign | None:
     return subnode if (
         nodes.get_context(subnode) is node and
         getattr(subnode, 'value', None) and
@@ -104,7 +106,7 @@ def _get_class_attribute(
 def _get_annotated_class_attribute(
     node: ast.ClassDef,
     subnode: ast.AST,
-) -> Optional[AnyAssign]:
+) -> AnyAssign | None:
     return subnode if (
         nodes.get_context(subnode) is node and
         (

--- a/wemake_python_styleguide/logic/tree/collections.py
+++ b/wemake_python_styleguide/logic/tree/collections.py
@@ -1,14 +1,14 @@
+from __future__ import annotations
+
 import ast
 from functools import partial
 from typing import (  # noqa: WPS235
     Iterable,
     List,
-    Optional,
     Sequence,
     Tuple,
     Type,
     TypeVar,
-    Union,
     cast,
 )
 
@@ -70,7 +70,7 @@ def sequence_of_node(
 
 def first(
     sequence: Iterable[_NodeType],
-    default: Optional[_DefaultType] = None,
-) -> Union[_NodeType, _DefaultType, None]:
+    default: _DefaultType | None = None,
+) -> _NodeType | _DefaultType | None:
     """Get first variable from sequence or default."""
     return next(iter(sequence), default)

--- a/wemake_python_styleguide/logic/tree/compares.py
+++ b/wemake_python_styleguide/logic/tree/compares.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import ast
 import types
 from collections import defaultdict
-from typing import DefaultDict, Mapping, Set, Tuple, Type, Union
+from typing import DefaultDict, Mapping, Set, Tuple, Type
 
 import attr
 from typing_extensions import Final, final
@@ -40,7 +42,7 @@ SIMILAR_OPERATORS: Final[_ComparesMapping] = types.MappingProxyType({
 
 def get_similar_operators(
     operator: ast.cmpop,
-) -> Union[Type[ast.cmpop], _MultipleCompareOperators]:
+) -> Type[ast.cmpop] | _MultipleCompareOperators:
     """Returns similar operators types for the given operator."""
     operator_type = operator.__class__
     return SIMILAR_OPERATORS.get(operator_type, operator_type)

--- a/wemake_python_styleguide/logic/tree/exceptions.py
+++ b/wemake_python_styleguide/logic/tree/exceptions.py
@@ -1,13 +1,15 @@
+from __future__ import annotations
+
 import ast
 from inspect import getmro
-from typing import List, Mapping, Optional, Tuple
+from typing import List, Mapping, Tuple
 
 from wemake_python_styleguide.logic import source
 from wemake_python_styleguide.logic.walk import is_contained
 from wemake_python_styleguide.types import AnyNodes
 
 
-def get_exception_name(node: ast.Raise) -> Optional[str]:
+def get_exception_name(node: ast.Raise) -> str | None:
     """Returns the exception name or ``None`` if node has not it."""
     exception = node.exc
     if exception is None:
@@ -20,7 +22,7 @@ def get_exception_name(node: ast.Raise) -> Optional[str]:
     return getattr(exception, 'id', None)
 
 
-def get_cause_name(node: ast.Raise) -> Optional[str]:
+def get_cause_name(node: ast.Raise) -> str | None:
     """Returns the cause name or ``None`` if node has not it."""
     return getattr(node.cause, 'id', None)
 

--- a/wemake_python_styleguide/logic/tree/functions.py
+++ b/wemake_python_styleguide/logic/tree/functions.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from ast import Call, Return, Yield, YieldFrom, arg, walk
-from typing import Container, Iterable, List, Optional, Union
+from typing import Container, Iterable, List, Union
 
 from typing_extensions import Final
 
@@ -12,7 +14,7 @@ from wemake_python_styleguide.types import (
 )
 
 #: Expressions that causes control transfer from a routine
-_AnyControlTransfers = Union[
+_AnyControlTransfers = Union[  # noqa: WPS473
     Return,
     Yield,
     YieldFrom,
@@ -49,7 +51,7 @@ def given_function_called(
     return ''
 
 
-def is_method(function_type: Optional[str]) -> bool:
+def is_method(function_type: str | None) -> bool:
     """
     Returns whether a given function type belongs to a class.
 

--- a/wemake_python_styleguide/logic/tree/ifs.py
+++ b/wemake_python_styleguide/logic/tree/ifs.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 import ast
-from typing import Iterable, List, Optional, Union
+from typing import Iterable, List, Union
 
 from wemake_python_styleguide.types import AnyNodes
 
-_IfAndElifASTNode = Union[ast.If, List[ast.stmt]]
+_IfAndElifASTNode = Union[ast.If, List[ast.stmt]]  # noqa: WPS473
 
 
 def is_elif(node: ast.If) -> bool:
@@ -30,7 +32,7 @@ def has_else(node: ast.If) -> bool:
     return bool(last_elem)
 
 
-def root_if(node: ast.If) -> Optional[ast.If]:
+def root_if(node: ast.If) -> ast.If | None:
     """Returns the previous ``if`` node in the chain if it exists."""
     return getattr(node, 'wps_if_chained', None)
 

--- a/wemake_python_styleguide/logic/tree/keywords.py
+++ b/wemake_python_styleguide/logic/tree/keywords.py
@@ -1,14 +1,16 @@
+from __future__ import annotations
+
 import ast
 from typing import List, Sequence, Tuple, Type, Union
 
 from wemake_python_styleguide.logic.nodes import get_context
 
-_ReturningNodes = List[Union[ast.Return, ast.Yield]]
+_ReturningNodes = List[Union[ast.Return, ast.Yield]]  # noqa: WPS473
 
 
 def returning_nodes(
     node: ast.AST,
-    returning_type: Union[Type[ast.Return], Type[ast.Yield]],
+    returning_type: Type[ast.Return] | Type[ast.Yield],
 ) -> Tuple[_ReturningNodes, bool]:
     """Returns ``return`` or ``yield`` nodes with values."""
     returns: _ReturningNodes = []

--- a/wemake_python_styleguide/logic/tree/loops.py
+++ b/wemake_python_styleguide/logic/tree/loops.py
@@ -1,12 +1,13 @@
+from __future__ import annotations
+
 import ast
-from typing import Optional
 
 from wemake_python_styleguide.compat.aliases import ForNodes
 from wemake_python_styleguide.types import AnyLoop, AnyNodes
 
 
 def _does_loop_contain_node(
-    loop: Optional[AnyLoop],
+    loop: AnyLoop | None,
     to_check: ast.AST,
 ) -> bool:
     """

--- a/wemake_python_styleguide/logic/tree/operators.py
+++ b/wemake_python_styleguide/logic/tree/operators.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import ast
-from typing import Optional, Type
+from typing import Type
 
 from wemake_python_styleguide.logic.nodes import get_parent
 
@@ -24,7 +26,7 @@ def unwrap_starred_node(node: ast.AST) -> ast.AST:
     return node
 
 
-def get_parent_ignoring_unary(node: ast.AST) -> Optional[ast.AST]:
+def get_parent_ignoring_unary(node: ast.AST) -> ast.AST | None:
     """
     Returns real parent ignoring proxy unary parent level.
 

--- a/wemake_python_styleguide/logic/tree/variables.py
+++ b/wemake_python_styleguide/logic/tree/variables.py
@@ -4,8 +4,8 @@ from typing import List, Union
 from wemake_python_styleguide.logic import nodes
 from wemake_python_styleguide.logic.naming import access
 
-_VarDefinition = Union[ast.AST, ast.expr]
-_LocalVariable = Union[ast.Name, ast.ExceptHandler]
+_VarDefinition = Union[ast.AST, ast.expr]  # noqa: WPS473
+_LocalVariable = Union[ast.Name, ast.ExceptHandler]  # noqa: WPS473
 
 
 def get_variable_name(node: _LocalVariable) -> str:

--- a/wemake_python_styleguide/logic/walk.py
+++ b/wemake_python_styleguide/logic/walk.py
@@ -1,11 +1,13 @@
+from __future__ import annotations
+
 import ast
-from typing import Iterator, Optional, Type, TypeVar, Union
+from typing import Iterator, Type, TypeVar
 
 from wemake_python_styleguide.logic.nodes import get_parent
 from wemake_python_styleguide.types import AnyNodes
 
 _SubnodeType = TypeVar('_SubnodeType', bound=ast.AST)
-_IsInstanceContainer = Union[AnyNodes, type]
+_IsInstanceContainer = AnyNodes | type
 
 
 def is_contained(
@@ -26,7 +28,7 @@ def is_contained(
 def get_closest_parent(
     node: ast.AST,
     parents: _IsInstanceContainer,
-) -> Optional[ast.AST]:
+) -> ast.AST | None:
     """Returns the closes parent of a node of requested types."""
     parent = get_parent(node)
     while True:

--- a/wemake_python_styleguide/logic/walk.py
+++ b/wemake_python_styleguide/logic/walk.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 import ast
-from typing import Iterator, Type, TypeVar
+from typing import Iterator, Type, TypeVar, Union
 
 from wemake_python_styleguide.logic.nodes import get_parent
 from wemake_python_styleguide.types import AnyNodes
 
 _SubnodeType = TypeVar('_SubnodeType', bound=ast.AST)
-_IsInstanceContainer = AnyNodes | type
+_IsInstanceContainer = Union[AnyNodes, type]  # noqa: WPS473
 
 
 def is_contained(

--- a/wemake_python_styleguide/options/config.py
+++ b/wemake_python_styleguide/options/config.py
@@ -269,17 +269,6 @@ class Configuration(object):
             type='string',
             comma_separated_list=True,
         ),
-        _Option(
-            '--disallow-union-type',
-            defaults.DISALLOW_UNION_TYPE,
-            (
-                'Should the `typing.Union` and `typing.Optional` ' +
-                'usage be prohibited.'
-            ),
-            action='store_true',
-            type=None,
-            dest='disallow_union_type',
-        ),
 
         # Complexity:
 

--- a/wemake_python_styleguide/options/config.py
+++ b/wemake_python_styleguide/options/config.py
@@ -59,6 +59,8 @@ You can also show all options that ``flake8`` supports by running:
 - ``forbidden-inline-ignore`` - list of codes of violations or
     class of violations that are forbidden to ignore inline, defaults to
     :str:`wemake_python_styleguide.options.defaults.FORBIDDEN_INLINE_IGNORE`
+- ``disallow-union-type`` - controls whether `typing.Union` usage should be
+    prohibited in favor of the new `|` syntax, defaults to False
 
 
 .. rubric:: Complexity options
@@ -266,6 +268,17 @@ class Configuration(object):
             'Codes of violations or class of violations forbidden to ignore.',
             type='string',
             comma_separated_list=True,
+        ),
+        _Option(
+            '--disallow-union-type',
+            defaults.DISALLOW_UNION_TYPE,
+            (
+                'Should the `typing.Union` and `typing.Optional` ' +
+                'usage be prohibited.'
+            ),
+            action='store_true',
+            type=None,
+            dest='disallow_union_type',
         ),
 
         # Complexity:

--- a/wemake_python_styleguide/options/config.py
+++ b/wemake_python_styleguide/options/config.py
@@ -59,8 +59,6 @@ You can also show all options that ``flake8`` supports by running:
 - ``forbidden-inline-ignore`` - list of codes of violations or
     class of violations that are forbidden to ignore inline, defaults to
     :str:`wemake_python_styleguide.options.defaults.FORBIDDEN_INLINE_IGNORE`
-- ``disallow-union-type`` - controls whether `typing.Union` usage should be
-    prohibited in favor of the new `|` syntax, defaults to False
 
 
 .. rubric:: Complexity options
@@ -154,7 +152,9 @@ You can also show all options that ``flake8`` supports by running:
     :str:`wemake_python_styleguide.options.defaults.SHOW_VIOLATION_LINKS`
 """
 
-from typing import ClassVar, Mapping, Optional, Sequence, Union
+from __future__ import annotations
+
+from typing import ClassVar, Mapping, Sequence, Union
 
 import attr
 from flake8.options.manager import OptionManager
@@ -162,7 +162,7 @@ from typing_extensions import final
 
 from wemake_python_styleguide.options import defaults
 
-ConfigValuesTypes = Union[str, int, bool, Sequence[str]]
+ConfigValuesTypes = Union[str, int, bool, Sequence[str]]  # noqa: WPS473
 string = 'string'
 
 
@@ -174,11 +174,11 @@ class _Option(object):
     long_option_name: str
     default: ConfigValuesTypes
     help: str  # noqa: WPS125
-    type: Optional[str] = 'int'  # noqa: WPS125
+    type: str | None = 'int'  # noqa: WPS125
     parse_from_config: bool = True
     action: str = 'store'
     comma_separated_list: bool = False
-    dest: Optional[str] = None
+    dest: str | None = None
 
     def __attrs_post_init__(self):
         """Is called after regular init is done."""

--- a/wemake_python_styleguide/options/defaults.py
+++ b/wemake_python_styleguide/options/defaults.py
@@ -46,9 +46,6 @@ FORBIDDEN_DOMAIN_NAMES: Final = ()
 #: Violation codes that are forbidden to use.
 FORBIDDEN_INLINE_IGNORE: Final = ()
 
-#: Whether usage of ``typing.Union`` is allowed.
-DISALLOW_UNION_TYPE: Final = False
-
 # ===========
 # Complexity:
 # ===========

--- a/wemake_python_styleguide/options/defaults.py
+++ b/wemake_python_styleguide/options/defaults.py
@@ -46,6 +46,9 @@ FORBIDDEN_DOMAIN_NAMES: Final = ()
 #: Violation codes that are forbidden to use.
 FORBIDDEN_INLINE_IGNORE: Final = ()
 
+#: Whether usage of ``typing.Union`` is allowed.
+DISALLOW_UNION_TYPE: Final = False
+
 # ===========
 # Complexity:
 # ===========

--- a/wemake_python_styleguide/options/validation.py
+++ b/wemake_python_styleguide/options/validation.py
@@ -1,4 +1,6 @@
-from typing import Optional, Tuple
+from __future__ import annotations
+
+from typing import Tuple
 
 import attr
 from typing_extensions import final
@@ -8,8 +10,8 @@ from wemake_python_styleguide.types import ConfigurationOptions
 
 
 def _min_max(
-    min: Optional[int] = None,  # noqa: WPS125
-    max: Optional[int] = None,  # noqa: WPS125
+    min: int | None = None,  # noqa: WPS125
+    max: int | None = None,  # noqa: WPS125
 ):
     """Validator to check that value is in bounds."""
     def factory(instance, attribute, field_value):

--- a/wemake_python_styleguide/options/validation.py
+++ b/wemake_python_styleguide/options/validation.py
@@ -68,6 +68,7 @@ class _ValidatedOptions(object):
     allowed_domain_names: Tuple[str, ...] = attr.ib(converter=tuple)
     forbidden_domain_names: Tuple[str, ...] = attr.ib(converter=tuple)
     forbidden_inline_ignore: Tuple[str, ...] = attr.ib(converter=tuple)
+    disallow_union_type: bool
 
     # Complexity:
     max_arguments: int = attr.ib(validator=[_min_max(min=1)])

--- a/wemake_python_styleguide/options/validation.py
+++ b/wemake_python_styleguide/options/validation.py
@@ -68,7 +68,6 @@ class _ValidatedOptions(object):
     allowed_domain_names: Tuple[str, ...] = attr.ib(converter=tuple)
     forbidden_domain_names: Tuple[str, ...] = attr.ib(converter=tuple)
     forbidden_inline_ignore: Tuple[str, ...] = attr.ib(converter=tuple)
-    disallow_union_type: bool
 
     # Complexity:
     max_arguments: int = attr.ib(validator=[_min_max(min=1)])

--- a/wemake_python_styleguide/transformations/ast/enhancements.py
+++ b/wemake_python_styleguide/transformations/ast/enhancements.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import ast
 import operator
 from contextlib import suppress
 from types import MappingProxyType
-from typing import Optional, Tuple, Type, Union
+from typing import Tuple, Type
 
 from typing_extensions import Final
 
@@ -119,7 +121,7 @@ def set_constant_evaluations(tree: ast.AST) -> ast.AST:
 def _find_context(
     node: ast.AST,
     contexts: Tuple[Type[ast.AST], ...],
-) -> Optional[ast.AST]:
+) -> ast.AST | None:
     """
     We changed how we find and assign contexts in 0.8.1 version.
 
@@ -145,7 +147,7 @@ def _apply_if_statement(statement: ast.If) -> None:
 
 def evaluate_operation(
     statement: ast.BinOp,
-) -> Optional[Union[int, float, str, bytes]]:
+) -> int | float | str | bytes | None:
     """Tries to evaluate all math operations inside the statement."""
     if isinstance(statement.left, ast.BinOp):
         left = evaluate_operation(statement.left)

--- a/wemake_python_styleguide/types.py
+++ b/wemake_python_styleguide/types.py
@@ -273,3 +273,7 @@ class ConfigurationOptions(Protocol):
     @property
     def show_violation_links(self) -> bool:
         ...
+
+    @property
+    def disallow_union_type(self) -> bool:
+        ...

--- a/wemake_python_styleguide/types.py
+++ b/wemake_python_styleguide/types.py
@@ -273,7 +273,3 @@ class ConfigurationOptions(Protocol):
     @property
     def show_violation_links(self) -> bool:
         ...
-
-    @property
-    def disallow_union_type(self) -> bool:
-        ...

--- a/wemake_python_styleguide/types.py
+++ b/wemake_python_styleguide/types.py
@@ -41,31 +41,35 @@ from typing import Tuple, Type, Union
 from typing_extensions import Protocol, final
 
 #: We use this type to represent all string-like nodes.
-AnyText = Union[ast.Str, ast.Bytes]
+AnyText = Union[ast.Str, ast.Bytes]  # noqa: WPS473
 
 #: In cases we need to work with both import types.
-AnyImport = Union[ast.Import, ast.ImportFrom]
+AnyImport = Union[ast.Import, ast.ImportFrom]  # noqa: WPS473
 
 #: In cases we need to work with both function definitions.
-AnyFunctionDef = Union[ast.FunctionDef, ast.AsyncFunctionDef]
+AnyFunctionDef = Union[ast.FunctionDef, ast.AsyncFunctionDef]  # noqa: WPS473
 
 #: In cases we need to work with all function definitions (including lambdas).
-AnyFunctionDefAndLambda = Union[AnyFunctionDef, ast.Lambda]
+AnyFunctionDefAndLambda = Union[AnyFunctionDef, ast.Lambda]  # noqa: WPS473
 
 #: In cases we need to work with both forms of if functions.
-AnyIf = Union[ast.If, ast.IfExp]
+AnyIf = Union[ast.If, ast.IfExp]  # noqa: WPS473
 
 #: In cases we need to work with both sync and async loops.
-AnyFor = Union[ast.For, ast.AsyncFor]
+AnyFor = Union[ast.For, ast.AsyncFor]  # noqa: WPS473
 
 #: In case we need to work with any loop: sync, async, and while.
-AnyLoop = Union[AnyFor, ast.While]
+AnyLoop = Union[AnyFor, ast.While]  # noqa: WPS473
 
 #: This is how you can define a variable in Python.
-AnyVariableDef = Union[ast.Name, ast.Attribute, ast.ExceptHandler]
+AnyVariableDef = Union[  # noqa: WPS473
+    ast.Name,
+    ast.Attribute,
+    ast.ExceptHandler,
+]
 
 #: All different comprehension types in one place.
-AnyComprehension = Union[
+AnyComprehension = Union[  # noqa: WPS473
     ast.ListComp,
     ast.DictComp,
     ast.SetComp,
@@ -73,19 +77,19 @@ AnyComprehension = Union[
 ]
 
 #: In cases we need to work with both sync and async context managers.
-AnyWith = Union[ast.With, ast.AsyncWith]
+AnyWith = Union[ast.With, ast.AsyncWith]  # noqa: WPS473
 
 #: When we search for assign elements, we also need typed assign.
-AnyAssign = Union[ast.Assign, ast.AnnAssign]
+AnyAssign = Union[ast.Assign, ast.AnnAssign]  # noqa: WPS473
 
 #: In cases we need to work with both access types.
-AnyAccess = Union[
+AnyAccess = Union[  # noqa: WPS473
     ast.Attribute,
     ast.Subscript,
 ]
 
 #: In case we need to handle types that can be chained.
-AnyChainable = Union[
+AnyChainable = Union[  # noqa: WPS473
     ast.Attribute,
     ast.Subscript,
     ast.Call,
@@ -95,10 +99,10 @@ AnyChainable = Union[
 AnyNodes = Tuple[Type[ast.AST], ...]
 
 #: We use this type to work with any text-like values. Related to `AnyText`.
-AnyTextPrimitive = Union[str, bytes]
+AnyTextPrimitive = Union[str, bytes]  # noqa: WPS473
 
 #: That's how we define context of operations.
-ContextNodes = Union[
+ContextNodes = Union[  # noqa: WPS473
     ast.Module,
     ast.ClassDef,
     AnyFunctionDef,

--- a/wemake_python_styleguide/violations/base.py
+++ b/wemake_python_styleguide/violations/base.py
@@ -49,16 +49,18 @@ Reference
 
 """
 
+from __future__ import annotations
+
 import abc
 import ast
 import enum
 import tokenize
-from typing import Callable, ClassVar, Optional, Set, Tuple, Union
+from typing import Callable, ClassVar, Set, Tuple, Union
 
 from typing_extensions import final
 
 #: General type for all possible nodes where error happens.
-ErrorNode = Union[
+ErrorNode = Union[  # noqa: WPS473
     ast.AST,
     tokenize.TokenInfo,
     None,
@@ -131,8 +133,8 @@ class BaseViolation(object, metaclass=abc.ABCMeta):  # noqa: WPS338
     def __init__(
         self,
         node: ErrorNode,
-        text: Optional[str] = None,
-        baseline: Optional[int] = None,
+        text: str | None = None,
+        baseline: int | None = None,
     ) -> None:
         """
         Creates a new instance of an abstract violation.
@@ -195,7 +197,7 @@ class BaseViolation(object, metaclass=abc.ABCMeta):  # noqa: WPS338
 class _BaseASTViolation(BaseViolation, metaclass=abc.ABCMeta):
     """Used as a based type for all ``ast`` violations."""
 
-    _node: Optional[ast.AST]
+    _node: ast.AST | None
 
     @final
     def _location(self) -> Tuple[int, int]:
@@ -220,9 +222,9 @@ class MaybeASTViolation(_BaseASTViolation, metaclass=abc.ABCMeta):
 
     def __init__(
         self,
-        node: Optional[ast.AST] = None,
-        text: Optional[str] = None,
-        baseline: Optional[int] = None,
+        node: ast.AST | None = None,
+        text: str | None = None,
+        baseline: int | None = None,
     ) -> None:
         """Creates new instance of module violation without explicit node."""
         super().__init__(node, text=text, baseline=baseline)
@@ -246,8 +248,8 @@ class SimpleViolation(BaseViolation, metaclass=abc.ABCMeta):
     def __init__(
         self,
         node=None,
-        text: Optional[str] = None,
-        baseline: Optional[int] = None,
+        text: str | None = None,
+        baseline: int | None = None,
     ) -> None:
         """Creates new instance of simple style violation."""
         super().__init__(node, text=text, baseline=baseline)

--- a/wemake_python_styleguide/violations/best_practices.py
+++ b/wemake_python_styleguide/violations/best_practices.py
@@ -89,6 +89,7 @@ Summary
    KwargsUnpackingInClassDefinitionViolation
    ConsecutiveSlicesViolation
    GettingElementByUnpackingViolation
+   DisallowUnionTypeViolation
 
 Best practices
 --------------
@@ -166,6 +167,7 @@ Best practices
 .. autoclass:: KwargsUnpackingInClassDefinitionViolation
 .. autoclass:: ConsecutiveSlicesViolation
 .. autoclass:: GettingElementByUnpackingViolation
+.. autoclass:: DisallowUnionTypeViolation
 
 """
 
@@ -2770,3 +2772,40 @@ class GettingElementByUnpackingViolation(ASTViolation):
         'Found unpacking used to get a single element from a collection'
     )
     code = 472
+
+
+@final
+class DisallowUnionTypeViolation(ASTViolation):
+    """
+    Forbid usage of the `typing.Union` and `typing.Optional` when denoting type.
+
+    Reasoning:
+        Python 3.10 introduced a new union type syntax in form of `|` syntax.
+
+    Solution:
+        Write union types using the new syntax.
+
+    Example::
+
+        # Correct:
+        def func(arg: X | Y) -> None: ...
+        def func(arg: X | None) -> None: ...
+
+        # Wrong:
+        def func(arg: Union[X, Y]) -> None: ...
+        def func(arg: Optional[X]) -> None: ...
+
+    Configuration:
+        This rule is configurable with ``--disallow-union-type`` option.
+        Default:
+        :str:`wemake_python_styleguide.options.defaults.DISALLOW_UNION_TYPE`
+
+    .. versionadded:: 0.17.2
+
+    """
+
+    error_template = (
+        'Found usage of the `typing.Union` or `typing.Optional` when ' +
+        'denoting union type'
+    )
+    code = 473

--- a/wemake_python_styleguide/violations/best_practices.py
+++ b/wemake_python_styleguide/violations/best_practices.py
@@ -2777,8 +2777,9 @@ class GettingElementByUnpackingViolation(ASTViolation):
 @final
 class DisallowUnionTypeViolation(ASTViolation):
     """
-    Forbid usage of the `typing.Union` and `typing.Optional` when denoting type
-    while using Python 3.10+.
+    Forbid usage of the `typing.Union` and `typing.Optional` when denoting type.
+
+    This check is active only while using Python 3.10+.
 
     Reasoning:
         Python 3.10 introduced a new union type syntax in form of `|` syntax.

--- a/wemake_python_styleguide/violations/best_practices.py
+++ b/wemake_python_styleguide/violations/best_practices.py
@@ -2777,7 +2777,8 @@ class GettingElementByUnpackingViolation(ASTViolation):
 @final
 class DisallowUnionTypeViolation(ASTViolation):
     """
-    Forbid usage of the `typing.Union` and `typing.Optional` when denoting type.
+    Forbid usage of the `typing.Union` and `typing.Optional` when denoting type
+    while using Python 3.10+.
 
     Reasoning:
         Python 3.10 introduced a new union type syntax in form of `|` syntax.
@@ -2795,12 +2796,7 @@ class DisallowUnionTypeViolation(ASTViolation):
         def func(arg: Union[X, Y]) -> None: ...
         def func(arg: Optional[X]) -> None: ...
 
-    Configuration:
-        This rule is configurable with ``--disallow-union-type`` option.
-        Default:
-        :str:`wemake_python_styleguide.options.defaults.DISALLOW_UNION_TYPE`
-
-    .. versionadded:: 0.17.2
+    .. versionadded:: 0.18.0
 
     """
 

--- a/wemake_python_styleguide/visitors/ast/annotations.py
+++ b/wemake_python_styleguide/visitors/ast/annotations.py
@@ -42,10 +42,12 @@ class WrongAnnotationVisitor(BaseNodeVisitor):  # noqa: WPS214
     def visit_Assign(self, node: ast.Assign) -> None:
         """Checks assignment annotations."""
         self._check_prohibited_union_annotation(node, node.value)
+        self.generic_visit(node)
 
     def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
         """Checks variable type annotations."""
         self._check_prohibited_union_annotation(node, node.annotation)
+        self.generic_visit(node)
 
     def _check_return_annotation(self, node: AnyFunctionDef) -> None:
         if not node.returns:

--- a/wemake_python_styleguide/visitors/ast/annotations.py
+++ b/wemake_python_styleguide/visitors/ast/annotations.py
@@ -84,7 +84,7 @@ class WrongAnnotationVisitor(BaseNodeVisitor):  # noqa: WPS214
 
     def _has_union_annotation_been_used(
         self,
-        node: AnyFunctionDef | ast.arg,
+        node: AnyFunctionDef | ast.arg | ast.Assign | ast.AnnAssign,
         annotation_node: ast.expr | None,
     ) -> bool:
         if not isinstance(annotation_node, ast.Subscript):

--- a/wemake_python_styleguide/visitors/ast/annotations.py
+++ b/wemake_python_styleguide/visitors/ast/annotations.py
@@ -69,44 +69,41 @@ class WrongAnnotationVisitor(BaseNodeVisitor):  # noqa: WPS214
     def _check_prohibited_union_annotation(
         self,
         node: AnyFunctionDef | ast.arg | ast.Assign | ast.AnnAssign,
-        annotation_node: ast.expr | None,
+        annotate_node: ast.expr | None,
     ) -> None:
         should_skip_check = (
             sys.version_info < (3, 10) or
-            annotation_node is None
+            annotate_node is None
         )
         if should_skip_check:
             return
 
-        is_check_violated = (
-            self._has_union_annotation_been_used(node, annotation_node)
-        )
-        if is_check_violated:  # pragma: py-lt-310
+        if self._has_union_been_used(node, annotate_node):  # pragma: py-lt-310
             self.add_violation(DisallowUnionTypeViolation(node))
 
-    def _has_union_annotation_been_used(
+    def _has_union_been_used(
         self,
         node: AnyFunctionDef | ast.arg | ast.Assign | ast.AnnAssign,
-        annotation_node: ast.expr | None,
-    ) -> bool:
-        if not isinstance(annotation_node, ast.Subscript):
+        annotate_node: ast.expr | None,
+    ) -> bool:  # pragma: py-lt-310
+        if not isinstance(annotate_node, ast.Subscript):
             return False
 
         union_used_in_node_name = (
-            isinstance(annotation_node.value, ast.Name) and
-            annotation_node.value.id in self._union_names
+            isinstance(annotate_node.value, ast.Name) and
+            annotate_node.value.id in self._union_names
         )
         if union_used_in_node_name:
             return True
 
         union_used_in_node_attr = (
-            isinstance(annotation_node.value, ast.Attribute) and
-            annotation_node.value.attr in self._union_names
+            isinstance(annotate_node.value, ast.Attribute) and
+            annotate_node.value.attr in self._union_names
         )
         if union_used_in_node_attr:
             return True
 
-        return self._has_union_annotation_been_used(
+        return self._has_union_been_used(
             node,
-            get_slice_expr(annotation_node),
+            get_slice_expr(annotate_node),
         )

--- a/wemake_python_styleguide/visitors/ast/annotations.py
+++ b/wemake_python_styleguide/visitors/ast/annotations.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 import ast
 import sys
-from typing import Optional, Union
 
 from typing_extensions import final
 
@@ -23,6 +24,7 @@ from wemake_python_styleguide.visitors.decorators import alias
 ))
 class WrongAnnotationVisitor(BaseNodeVisitor):
     """Ensures that annotations are used correctly."""
+
     _union_names = ('Union', 'Optional')
 
     def visit_any_function(self, node: AnyFunctionDef) -> None:
@@ -56,8 +58,8 @@ class WrongAnnotationVisitor(BaseNodeVisitor):
 
     def _check_prohibited_union_annotation(
         self,
-        node: Union[AnyFunctionDef, ast.arg],
-        annotation_node: Optional[ast.expr],
+        node: AnyFunctionDef | ast.arg,
+        annotation_node: ast.expr | None,
     ) -> None:
         should_skip_check = (
             sys.version_info < (3, 10) or
@@ -66,14 +68,16 @@ class WrongAnnotationVisitor(BaseNodeVisitor):
         if should_skip_check:
             return
 
-        is_check_violated = self._has_union_annotation_been_used(node, annotation_node)
+        is_check_violated = (
+            self._has_union_annotation_been_used(node, annotation_node)
+        )
         if is_check_violated:  # pragma: py-lt-310
             self.add_violation(DisallowUnionTypeViolation(node))
 
     def _has_union_annotation_been_used(
         self,
-        node: Union[AnyFunctionDef, ast.arg],
-        annotation_node: Optional[ast.expr],
+        node: AnyFunctionDef | ast.arg,
+        annotation_node: ast.expr | None,
     ) -> bool:
         if not isinstance(annotation_node, ast.Subscript):
             return False

--- a/wemake_python_styleguide/visitors/ast/annotations.py
+++ b/wemake_python_styleguide/visitors/ast/annotations.py
@@ -22,7 +22,7 @@ from wemake_python_styleguide.visitors.decorators import alias
     'visit_FunctionDef',
     'visit_AsyncFunctionDef',
 ))
-class WrongAnnotationVisitor(BaseNodeVisitor):
+class WrongAnnotationVisitor(BaseNodeVisitor):  # noqa: WPS214
     """Ensures that annotations are used correctly."""
 
     _union_names = ('Union', 'Optional')
@@ -38,6 +38,14 @@ class WrongAnnotationVisitor(BaseNodeVisitor):
         self._check_arg_annotation(node)
         self._check_prohibited_union_annotation(node, node.annotation)
         self.generic_visit(node)
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        """Checks assignment annotations."""
+        self._check_prohibited_union_annotation(node, node.value)
+
+    def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
+        """Checks variable type annotations."""
+        self._check_prohibited_union_annotation(node, node.annotation)
 
     def _check_return_annotation(self, node: AnyFunctionDef) -> None:
         if not node.returns:
@@ -58,7 +66,7 @@ class WrongAnnotationVisitor(BaseNodeVisitor):
 
     def _check_prohibited_union_annotation(
         self,
-        node: AnyFunctionDef | ast.arg,
+        node: AnyFunctionDef | ast.arg | ast.Assign | ast.AnnAssign,
         annotation_node: ast.expr | None,
     ) -> None:
         should_skip_check = (

--- a/wemake_python_styleguide/visitors/ast/blocks.py
+++ b/wemake_python_styleguide/visitors/ast/blocks.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import ast
 from collections import defaultdict
-from typing import Callable, DefaultDict, List, Set, Tuple, Union, cast
+from typing import Callable, DefaultDict, List, Set, Tuple, cast
 
 from typing_extensions import final
 
@@ -85,7 +87,7 @@ class BlockVariableVisitor(base.BaseNodeVisitor):
 
     def visit_named_nodes(
         self,
-        node: Union[AnyFunctionDef, ast.ClassDef, ast.ExceptHandler],
+        node: AnyFunctionDef | ast.ClassDef | ast.ExceptHandler,
     ) -> None:
         """Visits block nodes that have ``.name`` property."""
         names = {node.name} if node.name else set()
@@ -119,7 +121,7 @@ class BlockVariableVisitor(base.BaseNodeVisitor):
 
     # Locals:
 
-    def visit_locals(self, node: Union[AnyAssignWithWalrus, ast.arg]) -> None:
+    def visit_locals(self, node: AnyAssignWithWalrus | ast.arg) -> None:
         """Visits local variable definitions and function arguments."""
         if isinstance(node, ast.arg):
             names = {node.arg}

--- a/wemake_python_styleguide/visitors/ast/builtins.py
+++ b/wemake_python_styleguide/visitors/ast/builtins.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import ast
 import re
 import string
@@ -12,7 +14,6 @@ from typing import (
     Optional,
     Pattern,
     Sequence,
-    Union,
 )
 
 from typing_extensions import Final, final
@@ -47,7 +48,7 @@ from wemake_python_styleguide.violations import (
 from wemake_python_styleguide.visitors import base, decorators
 
 #: Items that can be inside a hash.
-_HashItems = Sequence[Optional[ast.AST]]
+_HashItems = Sequence[Optional[ast.AST]]  # noqa: WPS473
 
 
 @final
@@ -108,7 +109,7 @@ class WrongStringVisitor(base.BaseNodeVisitor):
     def _check_is_alphabet(
         self,
         node: AnyText,
-        text_data: Optional[str],
+        text_data: str | None,
     ) -> None:
         if text_data in self._string_constants:
             self.add_violation(
@@ -117,7 +118,7 @@ class WrongStringVisitor(base.BaseNodeVisitor):
                 ),
             )
 
-    def _is_modulo_pattern_exception(self, parent: Optional[ast.AST]) -> bool:
+    def _is_modulo_pattern_exception(self, parent: ast.AST | None) -> bool:
         """
         Check if string with modulo pattern is in an exceptional situation.
 
@@ -136,7 +137,7 @@ class WrongStringVisitor(base.BaseNodeVisitor):
     def _check_modulo_patterns(
         self,
         node: AnyText,
-        text_data: Optional[str],
+        text_data: str | None,
     ) -> None:
         parent = nodes.get_parent(node)
         if parent and strings.is_doc_string(parent):
@@ -391,7 +392,7 @@ class WrongAssignmentVisitor(base.BaseNodeVisitor):
                     best_practices.WrongUnpackingViolation(node),
                 )
 
-    def _check_unpacking_target_types(self, node: Optional[ast.AST]) -> None:
+    def _check_unpacking_target_types(self, node: ast.AST | None) -> None:
         if not node:
             return
         for subnode in walk.get_subnodes_by_type(node, ast.List):
@@ -480,7 +481,7 @@ class WrongCollectionVisitor(base.BaseNodeVisitor):
 
     def _check_set_elements(
         self,
-        node: Union[ast.Set, ast.Dict],
+        node: ast.Set | ast.Dict,
         keys_or_elts: _HashItems,
     ) -> None:
         elements: List[str] = []
@@ -513,7 +514,7 @@ class WrongCollectionVisitor(base.BaseNodeVisitor):
 
     def _report_set_elements(
         self,
-        node: Union[ast.Set, ast.Dict],
+        node: ast.Set | ast.Dict,
         elements: List[str],
         element_values,
     ) -> None:

--- a/wemake_python_styleguide/visitors/ast/classes.py
+++ b/wemake_python_styleguide/visitors/ast/classes.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import ast
 from collections import defaultdict
-from typing import ClassVar, DefaultDict, FrozenSet, List, Optional
+from typing import ClassVar, DefaultDict, FrozenSet, List
 
 from typing_extensions import final
 
@@ -206,7 +208,7 @@ class WrongMethodVisitor(base.BaseNodeVisitor):
     def _get_call_stmt_of_useless_method(
         self,
         node: types.AnyFunctionDef,
-    ) -> Optional[ast.Call]:
+    ) -> ast.Call | None:
         """
         Fetches ``super`` call statement from function definition.
 
@@ -327,7 +329,7 @@ class WrongSlotsVisitor(base.BaseNodeVisitor):
         if isinstance(node.value, ast.Tuple):
             self._count_slots_items(node, node.value)
 
-    def _slot_item_name(self, node: ast.AST) -> Optional[str]:
+    def _slot_item_name(self, node: ast.AST) -> str | None:
         if isinstance(node, ast.Str):
             return node.s
         if isinstance(node, ast.Starred):

--- a/wemake_python_styleguide/visitors/ast/compares.py
+++ b/wemake_python_styleguide/visitors/ast/compares.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import ast
-from typing import ClassVar, List, Optional, Sequence
+from typing import ClassVar, List, Sequence
 
 from typing_extensions import final
 
@@ -343,7 +345,7 @@ class WrongConditionalVisitor(BaseNodeVisitor):
     def _is_simplifiable_assign(
         self,
         node_body: List[ast.stmt],
-    ) -> Optional[str]:
+    ) -> str | None:
         wrong_length = len(node_body) != 1
         if wrong_length or not isinstance(node_body[0], AssignNodes):
             return None

--- a/wemake_python_styleguide/visitors/ast/complexity/counts.py
+++ b/wemake_python_styleguide/visitors/ast/complexity/counts.py
@@ -14,9 +14,9 @@ from wemake_python_styleguide.visitors.base import BaseNodeVisitor
 from wemake_python_styleguide.visitors.decorators import alias
 
 # Type aliases:
-_ConditionNodes = Union[ast.If, ast.While, ast.IfExp]
-_ModuleMembers = Union[AnyFunctionDef, ast.ClassDef]
-_ReturnLikeStatement = Union[ast.Return, ast.Yield]
+_ConditionNodes = Union[ast.If, ast.While, ast.IfExp]  # noqa: WPS473
+_ModuleMembers = Union[AnyFunctionDef, ast.ClassDef]  # noqa: WPS473
+_ReturnLikeStatement = Union[ast.Return, ast.Yield]  # noqa: WPS473
 
 
 @final

--- a/wemake_python_styleguide/visitors/ast/complexity/function.py
+++ b/wemake_python_styleguide/visitors/ast/complexity/function.py
@@ -25,7 +25,10 @@ from wemake_python_styleguide.visitors.decorators import alias
 
 # Type aliases:
 
-_AnyFunctionCounter = Union[FunctionCounter, FunctionCounterWithLambda]
+_AnyFunctionCounter = Union[  # noqa: WPS473
+    FunctionCounter,
+    FunctionCounterWithLambda,
+]
 _CheckRule = Tuple[_AnyFunctionCounter, int, Type[BaseViolation]]
 _NodeTypeHandler = Mapping[
     Union[type, Tuple[type, ...]],

--- a/wemake_python_styleguide/visitors/ast/complexity/overuses.py
+++ b/wemake_python_styleguide/visitors/ast/complexity/overuses.py
@@ -23,7 +23,7 @@ from wemake_python_styleguide.visitors import base, decorators
 #: We use these types to store the number of nodes usage in different contexts.
 _Expressions = DefaultDict[str, List[ast.AST]]
 _FunctionExpressions = DefaultDict[ast.AST, _Expressions]
-_StringConstants = FrozenSet[Union[str, bytes]]
+_StringConstants = FrozenSet[Union[str, bytes]]  # noqa: WPS473
 
 
 @final

--- a/wemake_python_styleguide/visitors/ast/functions.py
+++ b/wemake_python_styleguide/visitors/ast/functions.py
@@ -51,7 +51,7 @@ from wemake_python_styleguide.violations.refactoring import (
 from wemake_python_styleguide.visitors import base, decorators
 
 #: Things we treat as local variables.
-_LocalVariable = Union[ast.Name, ast.ExceptHandler]
+_LocalVariable = Union[ast.Name, ast.ExceptHandler]  # noqa: WPS473
 
 #: Function definitions with name and arity:
 _Defs = Mapping[str, int]

--- a/wemake_python_styleguide/visitors/ast/keywords.py
+++ b/wemake_python_styleguide/visitors/ast/keywords.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import ast
-from typing import ClassVar, Dict, FrozenSet, List, Optional, Type, Union, cast
+from typing import ClassVar, Dict, FrozenSet, List, Type, Union, cast
 
 from typing_extensions import final
 
@@ -41,7 +43,7 @@ from wemake_python_styleguide.visitors.base import BaseNodeVisitor
 from wemake_python_styleguide.visitors.decorators import alias
 
 #: Utility type to work with violations easier.
-_ReturningViolations = Union[
+_ReturningViolations = Union[  # noqa: WPS473
     Type[InconsistentReturnViolation],
     Type[InconsistentYieldViolation],
 ]
@@ -135,7 +137,7 @@ class ConsistentReturningVisitor(BaseNodeVisitor):
     def _iterate_returning_values(
         self,
         node: AnyFunctionDef,
-        returning_type: Union[Type[ast.Return], Type[ast.Yield]],
+        returning_type: Type[ast.Return] | Type[ast.Yield],
         violation: _ReturningViolations,
     ):
         return_nodes, has_values = keywords.returning_nodes(
@@ -278,8 +280,8 @@ class GeneratorKeywordsVisitor(BaseNodeVisitor):
                 self.add_violation(IncorrectYieldFromTargetViolation(node))
 
     def _post_visit(self) -> None:
-        previous_line: Optional[int] = None
-        previous_parent: Optional[ast.AST] = None
+        previous_line: int | None = None
+        previous_parent: ast.AST | None = None
 
         for line, node in self._yield_locations.items():
             parent = get_parent(node)
@@ -322,7 +324,7 @@ class ConsistentReturningVariableVisitor(BaseNodeVisitor):
             all(isinstance(elem, ast.Name) for elem in node.value.elts)
         )
 
-    def _get_previous_stmt(self, node: ast.Return) -> Optional[ast.stmt]:
+    def _get_previous_stmt(self, node: ast.Return) -> ast.stmt | None:
         """
         This method gets the previous node in a block.
 

--- a/wemake_python_styleguide/visitors/ast/loops.py
+++ b/wemake_python_styleguide/visitors/ast/loops.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import ast
 from collections import defaultdict
 from contextlib import suppress
-from typing import ClassVar, DefaultDict, List, Mapping, Sequence, Type, Union
+from typing import ClassVar, DefaultDict, List, Mapping, Sequence, Type
 
 from typing_extensions import final
 
@@ -150,7 +152,7 @@ class WrongLoopVisitor(base.BaseNodeVisitor):
 
     def _check_lambda_inside_loop(
         self,
-        node: Union[AnyLoop, AnyComprehension],
+        node: AnyLoop | AnyComprehension,
     ) -> None:
         for lambda_node in walk.get_subnodes_by_type(node, ast.Lambda):
             arg_nodes = walk.get_subnodes_by_type(lambda_node, ast.arg)
@@ -240,7 +242,7 @@ class WrongLoopDefinitionVisitor(base.BaseNodeVisitor):
 
     def _check_explicit_iter_type(
         self,
-        node: Union[AnyFor, ast.comprehension],
+        node: AnyFor | ast.comprehension,
     ) -> None:
         node_iter = operators.unwrap_unary_node(node.iter)
         is_wrong = isinstance(node_iter, self._forbidden_for_iters)

--- a/wemake_python_styleguide/visitors/ast/naming/validation.py
+++ b/wemake_python_styleguide/visitors/ast/naming/validation.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import ast
-from typing import Callable, ClassVar, Iterable, Optional, Type
+from typing import Callable, ClassVar, Iterable, Type
 
 import attr
 from typing_extensions import final
@@ -43,7 +45,7 @@ class _NamingPredicate(object):
     is_correct: _PredicateLogicalCallback
     violation: Type[base.BaseViolation]
 
-    _is_applicable: Optional[_PredicateApplicableCallback] = None
+    _is_applicable: _PredicateApplicableCallback | None = None
 
     def is_applicable(self, node: ast.AST) -> bool:
         """Usability function over real applicable predicate."""

--- a/wemake_python_styleguide/visitors/ast/operators.py
+++ b/wemake_python_styleguide/visitors/ast/operators.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import ast
-from typing import ClassVar, Mapping, Optional, Tuple, Type, Union
+from typing import ClassVar, Mapping, Tuple, Type, Union
 
 from typing_extensions import final
 
@@ -21,7 +23,7 @@ from wemake_python_styleguide.visitors import base, decorators
 
 _MeaninglessOperators = Mapping[complex, Tuple[Type[ast.operator], ...]]
 _OperatorLimits = Mapping[Type[ast.unaryop], int]
-_NumbersAndConstants = Union[ast.Num, ast.NameConstant]
+_NumbersAndConstants = Union[ast.Num, ast.NameConstant]  # noqa: WPS473
 
 
 @final
@@ -114,8 +116,8 @@ class UselessOperatorsVisitor(base.BaseNodeVisitor):
     def _check_useless_math_operator(
         self,
         op: ast.operator,
-        left: Optional[ast.AST],
-        right: Optional[ast.AST] = None,
+        left: ast.AST | None,
+        right: ast.AST | None = None,
     ) -> None:
         if isinstance(left, ast.Num) and left.n in self._left_special_cases:
             if right and isinstance(op, self._left_special_cases[left.n]):
@@ -132,8 +134,8 @@ class UselessOperatorsVisitor(base.BaseNodeVisitor):
 
     def _get_non_negative_nodes(
         self,
-        left: Optional[ast.AST],
-        right: Optional[ast.AST] = None,
+        left: ast.AST | None,
+        right: ast.AST | None = None,
     ):
         non_negative_numbers = []
         for node in filter(None, (left, right)):
@@ -198,7 +200,7 @@ class WrongMathOperatorVisitor(base.BaseNodeVisitor):
         self,
         left: ast.AST,
         op: ast.operator,
-        right: Optional[ast.AST] = None,
+        right: ast.AST | None = None,
     ) -> None:
         if not isinstance(op, ast.Add):
             return

--- a/wemake_python_styleguide/visitors/ast/redundancy.py
+++ b/wemake_python_styleguide/visitors/ast/redundancy.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import ast
-from typing import Union
 
 from typing_extensions import final
 
@@ -36,7 +37,7 @@ class RedundantEnumerateVisitor(BaseNodeVisitor):
         self._check_for_redundant_enumerate(node)
         self.generic_visit(node)
 
-    def _check_for_redundant_enumerate(self, node: Union[AnyFor, ast.comprehension]) -> None:  # noqa: E501
+    def _check_for_redundant_enumerate(self, node: AnyFor | ast.comprehension) -> None:  # noqa: E501
         if not isinstance(node.iter, ast.Call):
             return
 

--- a/wemake_python_styleguide/visitors/ast/statements.py
+++ b/wemake_python_styleguide/visitors/ast/statements.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import ast
-from typing import ClassVar, Mapping, Optional, Sequence, Set, Union
+from typing import ClassVar, Mapping, Sequence, Set, Union
 
 from typing_extensions import final
 
@@ -44,7 +46,7 @@ from wemake_python_styleguide.visitors.base import BaseNodeVisitor
 from wemake_python_styleguide.visitors.decorators import alias
 
 #: Statements that do have `.body` attribute.
-_StatementWithBody = Union[
+_StatementWithBody = Union[  # noqa: WPS473
     ast.If,
     AnyFor,
     ast.While,
@@ -57,7 +59,7 @@ _StatementWithBody = Union[
 ]
 
 #: Simple collections.
-_AnyCollection = Union[
+_AnyCollection = Union[  # noqa: WPS473
     ast.List,
     ast.Set,
     ast.Dict,
@@ -172,7 +174,7 @@ class StatementsWithBodiesVisitor(BaseNodeVisitor):
             self._almost_swapped(assigns)
 
     def _almost_swapped(self, assigns: Sequence[ast.Assign]) -> None:
-        previous_var: Set[Optional[str]] = set()
+        previous_var: Set[str | None] = set()
 
         for assign in assigns:
             current_var = {
@@ -297,7 +299,7 @@ class WrongParametersIndentationVisitor(BaseNodeVisitor):
         node: ast.AST,
         statement: ast.AST,
         extra_lines: int,
-    ) -> Optional[bool]:
+    ) -> bool | None:
         if statement.lineno == node.lineno and not extra_lines:
             return False
         return None
@@ -307,8 +309,8 @@ class WrongParametersIndentationVisitor(BaseNodeVisitor):
         node: ast.AST,
         statement: ast.AST,
         previous_line: int,
-        multi_line_mode: Optional[bool],
-    ) -> Optional[bool]:
+        multi_line_mode: bool | None,
+    ) -> bool | None:
         previous_has_break = previous_line != statement.lineno
         if not previous_has_break and multi_line_mode:
             self.add_violation(ParametersIndentationViolation(node))
@@ -324,7 +326,7 @@ class WrongParametersIndentationVisitor(BaseNodeVisitor):
         elements: Sequence[ast.AST],
         extra_lines: int = 0,  # we need it due to wrong lineno in collections
     ) -> None:
-        multi_line_mode: Optional[bool] = None
+        multi_line_mode: bool | None = None
         for index, statement in enumerate(elements):
             if index == 0:
                 # We treat first element differently,

--- a/wemake_python_styleguide/visitors/tokenize/primitives.py
+++ b/wemake_python_styleguide/visitors/tokenize/primitives.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import re
 import tokenize
-from typing import ClassVar, FrozenSet, Optional, Pattern
+from typing import ClassVar, FrozenSet, Pattern
 
 from typing_extensions import final
 
@@ -247,7 +249,7 @@ class WrongStringConcatenationVisitor(BaseTokenVisitor):
     def __init__(self, *args, **kwargs) -> None:
         """Adds extra ``_previous_token`` property."""
         super().__init__(*args, **kwargs)
-        self._previous_token: Optional[tokenize.TokenInfo] = None
+        self._previous_token: tokenize.TokenInfo | None = None
 
     def visit(self, token: tokenize.TokenInfo) -> None:
         """Ensures that all string are concatenated as we allow."""

--- a/wemake_python_styleguide/visitors/tokenize/statements.py
+++ b/wemake_python_styleguide/visitors/tokenize/statements.py
@@ -1,16 +1,9 @@
+from __future__ import annotations
+
 import tokenize
 from collections import defaultdict
 from operator import attrgetter
-from typing import (
-    ClassVar,
-    DefaultDict,
-    Dict,
-    List,
-    Mapping,
-    Optional,
-    Sequence,
-    Tuple,
-)
+from typing import ClassVar, DefaultDict, Dict, List, Mapping, Sequence, Tuple
 
 from typing_extensions import final
 
@@ -204,8 +197,8 @@ class MultilineStringVisitor(BaseTokenVisitor):
         self,
         index: int,
         tokens: List[tokenize.TokenInfo],
-        previous_token: Optional[tokenize.TokenInfo],
-        next_token: Optional[tokenize.TokenInfo],
+        previous_token: tokenize.TokenInfo | None,
+        next_token: tokenize.TokenInfo | None,
     ) -> None:
         if index != 0:
             previous_token = tokens[index - 1]
@@ -220,8 +213,8 @@ class MultilineStringVisitor(BaseTokenVisitor):
     def _check_individual_line(
         self,
         tokens: List[tokenize.TokenInfo],
-        previous_token: Optional[tokenize.TokenInfo],
-        next_token: Optional[tokenize.TokenInfo],
+        previous_token: tokenize.TokenInfo | None,
+        next_token: tokenize.TokenInfo | None,
     ) -> None:
         for index, token in enumerate(tokens):
             if token.exact_type != tokenize.STRING or token in self._docstrings:
@@ -282,7 +275,7 @@ class InconsistentComprehensionVisitor(BaseTokenVisitor):
         """
         super().__init__(*args, **kwargs)
         self._bracket_stack: List[Compehension] = []
-        self._current_ctx: Optional[Compehension] = None
+        self._current_ctx: Compehension | None = None
 
     def visit_any_left_bracket(self, token: tokenize.TokenInfo) -> None:
         """Sets self._inside_brackets to True if left bracket found."""


### PR DESCRIPTION
# I have made things!

I have added a rule that disallows union types using the old `typing.Union` and/or `typing.Optional` notation when using Python 3.10 or newer.
This PR changed the scope of the issue - instead of introducing configuration option, the new rule has been created.

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [ ] I have updated the documentation for the changes I have made
- [x] I have added my changes to the `CHANGELOG.md`

## Related issues

- Closes #2421