### PR TITLE
Bump pep8-naming up to 0.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ flake8-eradicate = "^1.0"
 flake8-bandit = ">=2.1,<4"
 flake8-broken-line = ">=0.3,<0.5"
 flake8-rst-docstrings = "^0.2"
-pep8-naming = ">=0.11,<0.13"
+pep8-naming = ">=0.11,<0.14"
 darglint = "^1.2"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
# I have made things!

Here is  [the pep8-naming 0.13.0 changelog](https://github.com/PyCQA/pep8-naming/blob/0.13.0/CHANGELOG.rst#0130---2022-06-22):

> - Python 3.7 or later is now required.
> - setUpModule and tearDownModule are now exempted by default.


## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [ ] I have created at least one test case for the changes I have made
- [ ] I have updated the documentation for the changes I have made
- [ ] I have added my changes to the `CHANGELOG.md`

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->

🙏 Please, if you or your company is finding wemake-python-styleguide valuable, help us sustain the project by sponsoring it transparently on https://opencollective.com/wemake-python-styleguide. As a thank you, your profile/company logo will be added to our main README which receives hundreds of unique visitors per day.
