### PR TITLE
docs: Fix a few typos

### DIFF
--- a/tests/test_visitors/test_ast/test_complexity/test_counts/test_tuple_unpack_length.py
+++ b/tests/test_visitors/test_ast/test_complexity/test_counts/test_tuple_unpack_length.py
@@ -38,7 +38,7 @@ def test_unpack_length_normal(
     unpack_expression,
     options,
 ):
-    """Test that correct usage of unpack expression don't raise excptions."""
+    """Test that correct usage of unpack expression don't raise exceptions."""
     tree = parse_ast_tree(unpack_expression)
 
     option_values = options(max_tuple_unpack_length=4)

--- a/tests/test_visitors/test_ast/test_conditions/test_negated_conditions.py
+++ b/tests/test_visitors/test_ast/test_conditions/test_negated_conditions.py
@@ -100,7 +100,7 @@ def test_wrong_negated_complex_conditions(
     parse_ast_tree,
     default_options,
 ):
-    """Testing complex conditions with nagated ``if`` condition."""
+    """Testing complex conditions with negated ``if`` condition."""
     tree = parse_ast_tree(template.format(code))
 
     visitor = IfStatementVisitor(default_options, tree=tree)

--- a/tests/test_visitors/test_ast/test_keywords/test_keyword_condition.py
+++ b/tests/test_visitors/test_ast/test_keywords/test_keyword_condition.py
@@ -63,7 +63,7 @@ def test_false_condition_keywords(
     condition,
     default_options,
 ):
-    """Testing that false coniditions in keywords are restricted."""
+    """Testing that false conditions in keywords are restricted."""
     tree = parse_ast_tree(code.format(condition))
 
     visitor = ConstantKeywordVisitor(default_options, tree=tree)
@@ -86,7 +86,7 @@ def test_false_assert_condition_keywords(
     condition,
     default_options,
 ):
-    """Testing that false coniditions in keywords are restricted."""
+    """Testing that false conditions in keywords are restricted."""
     tree = parse_ast_tree(code.format(condition))
 
     visitor = ConstantKeywordVisitor(default_options, tree=tree)
@@ -126,7 +126,7 @@ def test_true_condition_keywords_while(
     condition,
     default_options,
 ):
-    """Testing that true coniditions in keywords are allowed."""
+    """Testing that true conditions in keywords are allowed."""
     tree = parse_ast_tree(code.format(condition))
 
     visitor = ConstantKeywordVisitor(default_options, tree=tree)
@@ -147,7 +147,7 @@ def test_true_condition_keywords_assert(
     condition,
     default_options,
 ):
-    """Testing that true coniditions in keywords are allowed."""
+    """Testing that true conditions in keywords are allowed."""
     tree = parse_ast_tree(code.format(condition))
 
     visitor = ConstantKeywordVisitor(default_options, tree=tree)
@@ -169,7 +169,7 @@ def test_true_while_condition_keywords(
     condition,
     default_options,
 ):
-    """Testing that true coniditions in keywords are allowed."""
+    """Testing that true conditions in keywords are allowed."""
     tree = parse_ast_tree(code.format(condition))
 
     visitor = ConstantKeywordVisitor(default_options, tree=tree)

--- a/wemake_python_styleguide/violations/best_practices.py
+++ b/wemake_python_styleguide/violations/best_practices.py
@@ -2691,7 +2691,7 @@ class KwargsUnpackingInClassDefinitionViolation(ASTViolation):
         It also limits the typechecking capabilities.
 
     Solution:
-        Use keyword arguments noramlly without unpacking them.
+        Use keyword arguments normally without unpacking them.
 
     Example::
 

--- a/wemake_python_styleguide/violations/naming.py
+++ b/wemake_python_styleguide/violations/naming.py
@@ -727,7 +727,7 @@ class UnusedVariableIsDefinedViolation(ASTViolation):
     Reasoning:
         While it is ok to define unused variables when you have to,
         like when unpacking a tuple, it is totally not ok to define explicit
-        unusued variables in cases like assignment, function return,
+        unused variables in cases like assignment, function return,
         exception handling, or context managers.
         Why do you need this explicitly unused variables?
 

--- a/wemake_python_styleguide/visitors/ast/complexity/jones.py
+++ b/wemake_python_styleguide/visitors/ast/complexity/jones.py
@@ -67,7 +67,7 @@ class JonesComplexityVisitor(BaseNodeVisitor):
         """
         Triggers after the whole module was processed.
 
-        Checks each line for its complexity, compares it to the tresshold.
+        Checks each line for its complexity, compares it to the threshold.
         We also calculate the final Jones score for the whole module.
         """
         for line_nodes in self._lines.values():

--- a/wemake_python_styleguide/visitors/tokenize/comments.py
+++ b/wemake_python_styleguide/visitors/tokenize/comments.py
@@ -178,7 +178,7 @@ class ShebangVisitor(BaseTokenVisitor):
     """
     Checks the first shebang in the file.
 
-    Code is insipired by https://github.com/xuhdev/flake8-executable
+    Code is inspired by https://github.com/xuhdev/flake8-executable
     """
 
     _shebang: ClassVar[Pattern[str]] = re.compile(r'(\s*)#!')


### PR DESCRIPTION
There are small typos in:
- tests/test_visitors/test_ast/test_complexity/test_counts/test_tuple_unpack_length.py
- tests/test_visitors/test_ast/test_conditions/test_negated_conditions.py
- tests/test_visitors/test_ast/test_keywords/test_keyword_condition.py
- wemake_python_styleguide/violations/best_practices.py
- wemake_python_styleguide/violations/naming.py
- wemake_python_styleguide/visitors/ast/complexity/jones.py
- wemake_python_styleguide/visitors/tokenize/comments.py

Fixes:
- Should read `conditions` rather than `coniditions`.
- Should read `unused` rather than `unusued`.
- Should read `threshold` rather than `tresshold`.
- Should read `normally` rather than `noramlly`.
- Should read `negated` rather than `nagated`.
- Should read `inspired` rather than `insipired`.
- Should read `exceptions` rather than `excptions`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md