### PR TITLE
Fix docmentation mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,18 +16,20 @@ Semantic versioning in our case means:
   But, in the future we might change the configuration names/logic,
   change the client facing API, change code conventions significantly, etc.
 
-## 0.17.1
+
+## WIP
 
 ### Features
-- Adds `__init_subclass__` in the beginning of accepted methods order as per WPS338
+
+- Adds `__init_subclass__` in the beginning of accepted methods 
+  order as per WPS338 #2411
 
 ### Misc
-- Fix documentation mismatch between default setting for `max-string-usages` and enforced rule
 
-## 0.16.2
-
-### Misc
 - Adds full violation codes to docs and `BaseViolation.full_code` #2409
+- Fix documentation mismatch between default setting
+  for `max-string-usages` and enforced rule  #2456
+
 
 ## 0.16.1
 

--- a/wemake_python_styleguide/options/config.py
+++ b/wemake_python_styleguide/options/config.py
@@ -101,7 +101,7 @@ You can also show all options that ``flake8`` supports by running:
     :str:`wemake_python_styleguide.options.defaults.MAX_DECORATORS`
 - ``max-string-usages`` - maximum number of repeated string constants
     in your modules, defaults to
-    :str:`wemake_python_styleguide.options.defaults.MAX_DECORATORS`
+    :str:`wemake_python_styleguide.options.defaults.MAX_STRING_USAGES`
 - ``max-awaits`` - maximum allowed number of ``await``
     expressions in one function, defaults to
     :str:`wemake_python_styleguide.options.defaults.MAX_AWAITS`


### PR DESCRIPTION
default for max-string-usages should be MAX_STRING_USAGES

# I have made things!

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [ ] I have created at least one test case for the changes I have made
- [ ] I have updated the documentation for the changes I have made
- [x] I have added my changes to the `CHANGELOG.md`

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #2392 

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->
Refs #2392 

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
