### PR TITLE
Do not check | in type hints in WPS226

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ Semantic versioning in our case means:
 - Domain name was changed from `wemake-python-stylegui.de`
   to `wemake-python-styleguide.rtfd.io`
 
+### Bugfixes
+
+- Fixes `WPS226` false positives on `|` use in `SomeType | AnotherType` type hints syntax
+
 
 ## 0.16.1
 

--- a/tests/test_visitors/test_ast/test_complexity/test_overuses/test_overused_string.py
+++ b/tests/test_visitors/test_ast/test_complexity/test_overuses/test_overused_string.py
@@ -177,6 +177,8 @@ def test_string_overuse(
     '"GenericType[int, str]"',
     '"int"',
     'List["int"]',
+    'list[int]',
+    'int | None',
 ])
 def test_string_type_annotations(
     assert_errors,
@@ -202,6 +204,7 @@ def test_string_type_annotations(
     '""',
     '","',
     '"."',
+    '"|"',
 ])
 @pytest.mark.parametrize('prefix', [
     'b',

--- a/tests/test_visitors/test_ast/test_complexity/test_overuses/test_overused_string.py
+++ b/tests/test_visitors/test_ast/test_complexity/test_overuses/test_overused_string.py
@@ -204,7 +204,6 @@ def test_string_type_annotations(
     '""',
     '","',
     '"."',
-    '"|"',
 ])
 @pytest.mark.parametrize('prefix', [
     'b',

--- a/wemake_python_styleguide/visitors/ast/complexity/overuses.py
+++ b/wemake_python_styleguide/visitors/ast/complexity/overuses.py
@@ -48,6 +48,7 @@ class StringOveruseVisitor(base.BaseNodeVisitor):
         '\n',
         '\r\n',
         '\t',
+        '|',
         b' ',
         b'.',
         b',',
@@ -55,6 +56,7 @@ class StringOveruseVisitor(base.BaseNodeVisitor):
         b'\n',
         b'\r\n',
         b'\t',
+        b'|',
     ))
 
     def __init__(self, *args, **kwargs) -> None:

--- a/wemake_python_styleguide/visitors/ast/complexity/overuses.py
+++ b/wemake_python_styleguide/visitors/ast/complexity/overuses.py
@@ -56,7 +56,6 @@ class StringOveruseVisitor(base.BaseNodeVisitor):
         b'\n',
         b'\r\n',
         b'\t',
-        b'|',
     ))
 
     def __init__(self, *args, **kwargs) -> None:


### PR DESCRIPTION
# I have made things!

In my project I use a lot of new-style annotations - `Type1 | Type2` instead of `Union[Type1, Type2]` provided by Python 3.10. To get these annotations work on previous Python versions (e.g. 3.7) I use `from __future__ import annotations`, which converts all type hints to strings, so it is actually stored in `__annotations__` like `"Type1 | Type2"`.

If module contains a lot of optional annotations, such as:
```python
class MyClass:
  field1: int | None
  field2: str | None
  fiels3: datetime | int | None

...
class MyClass2(MyClass):
  fiels4: SomeType | None
```
and so on, WPS226 starts to fail:
```
WPS226 Found string literal over-use: |
```

In this PR I've added `|` literal to list of ignored strings which should fix the issue.

## Checklist

<!-- Please check everything that applies: -->

- [X I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [X] I have created at least one test case for the changes I have made
- [X] I have updated the documentation for the changes I have made
- [X] I have added my changes to the `CHANGELOG.md`

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->

🙏 Please, if you or your company is finding wemake-python-styleguide valuable, help us sustain the project by sponsoring it transparently on https://opencollective.com/wemake-python-styleguide. As a thank you, your profile/company logo will be added to our main README which receives hundreds of unique visitors per day.
