### PR TITLE
docs: warn about darglint perf issues (#2287)

### DIFF
--- a/docs/pages/usage/configuration.rst
+++ b/docs/pages/usage/configuration.rst
@@ -73,6 +73,17 @@ following settings:
 Our `darglint.toml <https://github.com/wemake-services/wemake-python-styleguide/blob/master/styles/darglint.toml>`_
 file is available with the core settings for ``isort``.
 
+.. warning::
+
+  There is a `known issue <https://github.com/terrencepreilly/darglint/issues/186>`_
+  with ``darglint``'s performance when using ``google`` or ``numpy``
+  documentation style, if you face long running times during the linting
+  process you can use the ``sphinx`` style by setting
+  ``docstring-style = sphinx`` in the ``["setup.cfg".flake8]`` section in a
+  nitpick configuration file. Otherwise, you can run ``darglint`` manually and
+  through CIs only, disabling it in flake8 args with
+  ``--darglint-ignore-regex='.*'``.
+
 .. rubric:: Ignoring violations
 
 We know that people might not agree with 100% of our rules.


### PR DESCRIPTION
# Add warning about darglint performance issues with `numpy` and `google` styles

## Checklist

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [n/a] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made
- [n/a] I have added my changes to the `CHANGELOG.md`

## Related issues

- Closes #2287

I wasn't sure about the desired phrasing here, feel free to make suggestions! I based my suggestions on https://github.com/cjolowicz/cookiecutter-hypermodern-python-instance/pull/822 , where they disabled darglint on commits (pre-commit hooks). 
![image](https://user-images.githubusercontent.com/8299832/194799784-d67931b3-dc6d-4c6f-a59b-b32b50045104.png)
