### PR TITLE
Revert "docs: typo fix - max-annotations-complexity"

### DIFF
--- a/wemake_python_styleguide/options/config.py
+++ b/wemake_python_styleguide/options/config.py
@@ -138,7 +138,7 @@ You can also show all options that ``flake8`` supports by running:
     :str:`wemake_python_styleguide.options.defaults.NESTED_CLASSES_WHITELIST`
 - ``max-call-level`` - maximum number of call chains, defaults to
     :str:`wemake_python_styleguide.options.defaults.MAX_CALL_LEVEL`
-- ``max-annotations-complexity`` - maximum number of nested annotations,
+- ``max-annotation-complexity`` - maximum number of nested annotations,
     defaults to
     :str:`wemake_python_styleguide.options.defaults.MAX_ANN_COMPLEXITY`
 - ``max-import-from-members`` - maximum number of names that can be imported


### PR DESCRIPTION
Reverts wemake-services/wemake-python-styleguide#2522