### PR TITLE
Forbid chaining `is`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Semantic versioning in our case means:
 
 - Bump `flake8` to version `5.x`
 - Bump `flake8-bandit` to version `^4.1`
+- Added `ChainedIsViolation` #2443
 
 ### Misc
 

--- a/tests/fixtures/noqa/noqa.py
+++ b/tests/fixtures/noqa/noqa.py
@@ -816,3 +816,5 @@ first, *_rest = some_collection  # noqa: WPS472
 
 def foo2_func():
     return (1, 2, 3, 4, 5, 6)  # noqa: WPS227
+
+noqa_wps532 = variable is some_thing is other_thing  # noqa: WPS532

--- a/tests/test_checker/test_noqa.py
+++ b/tests/test_checker/test_noqa.py
@@ -299,6 +299,7 @@ SHOULD_BE_RAISED = types.MappingProxyType({
     'WPS529': 1,
     'WPS530': 1,
     'WPS531': 1,
+    'WPS532': 1,
 
     'WPS600': 1,
     'WPS601': 1,

--- a/wemake_python_styleguide/presets/types/tree.py
+++ b/wemake_python_styleguide/presets/types/tree.py
@@ -87,6 +87,7 @@ PRESET: Final = (
     conditions.BooleanConditionVisitor,
     conditions.ImplicitBoolPatternsVisitor,
     conditions.UselessElseVisitor,
+    conditions.ChainedIsVisitor,
 
     iterables.IterableUnpackingVisitor,
 

--- a/wemake_python_styleguide/violations/refactoring.py
+++ b/wemake_python_styleguide/violations/refactoring.py
@@ -45,6 +45,7 @@ Summary
    ImplicitDictGetViolation
    ImplicitNegativeIndexViolation
    SimplifiableReturningIfViolation
+   ChainedIsViolation
 
 Refactoring opportunities
 -------------------------
@@ -81,6 +82,7 @@ Refactoring opportunities
 .. autoclass:: ImplicitDictGetViolation
 .. autoclass:: ImplicitNegativeIndexViolation
 .. autoclass:: SimplifiableReturningIfViolation
+.. autoclass:: ChainedIsViolation
 
 """
 
@@ -1236,3 +1238,31 @@ class SimplifiableReturningIfViolation(ASTViolation):
 
     error_template = 'Found simplifiable returning `if` condition in a function'
     code = 531
+
+
+@final
+class ChainedIsViolation(ASTViolation):
+    """
+    Forbid `ast.Is` in `ast.Compare.ops` when it's size is not zero.
+
+    Reasoning:
+        From the AST perspective, `is` is an operator and can be chained.
+        That can lead to unexpected results when the author wanted to
+        compare the result of `a is b` operation. Instead, Python will chain
+        the operations and compare the last argument of the previous operation.
+
+    Solution:
+        Who knows at this point.
+
+    Example::
+        Correct:
+            a is b and b is None
+
+        Wrong:
+            a is b is None
+
+    .. versionadded:: 0.17.0
+    """
+
+    error_template = 'Found chained `is` operators in an expression'
+    code = 532

--- a/wemake_python_styleguide/visitors/ast/conditions.py
+++ b/wemake_python_styleguide/visitors/ast/conditions.py
@@ -20,6 +20,7 @@ from wemake_python_styleguide.violations.consistency import (
     MultilineConditionsViolation,
 )
 from wemake_python_styleguide.violations.refactoring import (
+    ChainedIsViolation,
     ImplicitInConditionViolation,
     NegatedConditionsViolation,
     SimplifiableReturningIfViolation,
@@ -324,3 +325,16 @@ class ImplicitBoolPatternsVisitor(BaseNodeVisitor):
 
         if not CompareBounds(node).is_valid():
             self.add_violation(ImplicitComplexCompareViolation(node))
+
+
+@final
+class ChainedIsVisitor(BaseNodeVisitor):
+    """Is used to find chained `is` comparisons."""
+
+    def visit_Compare(self, node: ast.Compare) -> None:
+        """Checks for chained 'is' operators in comparisons."""
+        if len(node.ops) > 1:
+            if all([isinstance(op, ast.Is) for op in node.ops]):
+                self.add_violation(ChainedIsViolation(node))
+
+        self.generic_visit(node)


### PR DESCRIPTION
# I have made things!

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Checklist

<!-- Please check everything that applies: -->

- [X] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [X] I have created at least one test case for the changes I have made
- [X] I have updated the documentation for the changes I have made
- [X] I have added my changes to the `CHANGELOG.md`

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->

🙏 Please, if you or your company is finding wemake-python-styleguide valuable, help us sustain the project by sponsoring it transparently on https://opencollective.com/wemake-python-styleguide. As a thank you, your profile/company logo will be added to our main README which receives hundreds of unique visitors per day.
