### PR TITLE
Augment `generic_visit()` search pattern to include `with` statements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ Semantic versioning in our case means:
 - Bump `flake8` to version `5.x`
 - Bump `flake8-bandit` to version `^4.1`
 
+### Bugfixes
+- Make `generic_visit()` check script properly handle `with` statements.
+
 ### Misc
 
 - Replaced `flakehell` mentions to `flakeheaven` #2409

--- a/scripts/check_generic_visit.py
+++ b/scripts/check_generic_visit.py
@@ -14,9 +14,9 @@ OK_CODE: Final = 0
 PATTERN: Final = """
 //ClassDef[contains(bases, Name[@id='BaseNodeVisitor'])]/body
 /FunctionDef[re:match('visit_.*', @name)
-and not(child::body/Expr[last()]/value/Call/func
-/Attribute[@attr='generic_visit'])]
-"""
+and not(child::body/Expr[last()]/value/Call/func/Attribute[@attr='generic_visit'] or
+child::body/With[last()]/body/Expr[last()]/value/Call/func/Attribute[@attr='generic_visit'])]
+"""  # noqa: E501
 
 # This is needed to stop linter from spewing WPS421 errors.
 report = print


### PR DESCRIPTION
# I have made things!

This fixes a problem when `self.generic_visit(node)` is inside `with` statement.

Minimal example:

```python
class DummyVisitor(BaseNodeVisitor):
    def visit_Attribute(self, node):
        with resource_cleanup():
            self.generic_visit(node)
```

## Checklist

<!-- Please check everything that applies: -->

- [X] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [ ] I have created at least one test case for the changes I have made
- [ ] I have updated the documentation for the changes I have made
- [X] I have added my changes to the `CHANGELOG.md`

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->

🙏 Please, if you or your company is finding wemake-python-styleguide valuable, help us sustain the project by sponsoring it transparently on https://opencollective.com/wemake-python-styleguide. As a thank you, your profile/company logo will be added to our main README which receives hundreds of unique visitors per day.
