### PR TITLE
Detect `super()` call being used in the wrong context.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Semantic versioning in our case means:
 - Bump `flake8` to version `5.x`
 - Bump `flake8-bandit` to version `^4.1`
 - Added `ChainedIsViolation` #2443
+- Added `WrongSuperCallAccessViolation` #2310
 
 ### Bugfixes
 - Make `generic_visit()` check script properly handle `with` statements.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Semantic versioning in our case means:
 - Bump `flake8` to version `5.x`
 - Bump `flake8-bandit` to version `^4.1`
 - Added `ChainedIsViolation` #2443
-- Added `WrongSuperCallAccessViolation` #2310
+- Added `BuggySuperContextViolation` #2310
 
 ### Bugfixes
 - Make `generic_visit()` check script properly handle `with` statements.

--- a/tests/fixtures/noqa/noqa.py
+++ b/tests/fixtures/noqa/noqa.py
@@ -818,3 +818,11 @@ def foo2_func():
     return (1, 2, 3, 4, 5, 6)  # noqa: WPS227
 
 noqa_wps532 = variable is some_thing is other_thing  # noqa: WPS532
+
+class Baseline(object):
+    def method(self, number):
+        return number + 1
+
+class Antediluvian(Baseline):
+    def method(self):
+        return list((super().method(some_item) for some_item in items))  # noqa: WPS616

--- a/tests/test_checker/test_noqa.py
+++ b/tests/test_checker/test_noqa.py
@@ -317,6 +317,7 @@ SHOULD_BE_RAISED = types.MappingProxyType({
     'WPS613': 1,
     'WPS614': 1,
     'WPS615': 2,
+    'WPS616': 1,
     'WPS473': 0,
 })
 

--- a/tests/test_visitors/test_ast/test_classes/test_buggy_super.py
+++ b/tests/test_visitors/test_ast/test_classes/test_buggy_super.py
@@ -58,6 +58,13 @@ correct_generator_expression = """
     (super(cls, self).transmute(it) for it in items)
 """
 
+correct_nested_methods = """
+class A:
+    def outer_method(self):
+        def inner_method(self):
+            super(A, self).ancestor()
+"""
+
 
 @pytest.mark.parametrize('code', [
     error_generator_expression,
@@ -88,6 +95,7 @@ def test_buggy_super_context(
     correct_list_comprehension,
     correct_dict_comprehension,
     correct_generator_expression,
+    correct_nested_methods,
 ])
 def test_correct_super_context(
     assert_errors,

--- a/tests/test_visitors/test_ast/test_classes/test_buggy_super.py
+++ b/tests/test_visitors/test_ast/test_classes/test_buggy_super.py
@@ -1,0 +1,96 @@
+import pytest
+
+from wemake_python_styleguide.violations.oop import BuggySuperContextViolation
+from wemake_python_styleguide.visitors.ast.classes import BuggySuperCallVisitor
+
+error_dict_comprehension = """
+    {super().make_key(it): make_value(it) for it in items}
+"""
+
+error_set_comprehension = """
+    {super().transmute(it) for it in items}
+"""
+
+error_list_comprehension = """
+    [super().transmute(it) for it in items]
+"""
+
+error_generator_expression = """
+    (super().transmute(it) for it in items)
+"""
+
+error_nested_comprehensions = """
+    [
+        it + 1
+        for it in (super().transmute(i) for i in range(10))
+    ]
+"""
+
+error_multiple_nested_comprehensions = """
+    [
+        it + k + el + 1
+        for it in (super().transmute(i) for i in range(10))
+        for k in {v:0 for v in range(10)}
+        for el in (n ** 2 for n in range(10))
+    ]
+"""
+
+correct_dict_comprehension = """
+    {super(cls, self).make_key(it): make_value(it) for it in items}
+"""
+
+correct_set_comprehension = """
+    {super(cls, self).transmute(it) for it in items}
+"""
+
+correct_list_comprehension = """
+    [super(cls, self).transmute(it) for it in items]
+"""
+
+correct_generator_expression = """
+    (super(cls, self).transmute(it) for it in items)
+"""
+
+
+@pytest.mark.parametrize('code', [
+    error_generator_expression,
+    error_nested_comprehensions,
+    error_multiple_nested_comprehensions,
+    error_set_comprehension,
+    error_list_comprehension,
+    error_dict_comprehension,
+])
+def test_buggy_super_context(
+    assert_errors,
+    parse_ast_tree,
+    default_options,
+    code,
+):
+    """Testing that calling `super()` without args is caught."""
+    tree = parse_ast_tree(code)
+
+    visitor = BuggySuperCallVisitor(default_options, tree=tree)
+    visitor.run()
+
+    assert_errors(visitor, [BuggySuperContextViolation])
+
+
+@pytest.mark.parametrize('code', [
+    correct_set_comprehension,
+    correct_list_comprehension,
+    correct_dict_comprehension,
+    correct_generator_expression,
+])
+def test_correct_super_context(
+    assert_errors,
+    parse_ast_tree,
+    default_options,
+    code,
+):
+    """Testing that calling `super()` without args is caught."""
+    tree = parse_ast_tree(code)
+
+    visitor = BuggySuperCallVisitor(default_options, tree=tree)
+    visitor.run()
+
+    assert_errors(visitor, [])

--- a/tests/test_visitors/test_ast/test_classes/test_buggy_super.py
+++ b/tests/test_visitors/test_ast/test_classes/test_buggy_super.py
@@ -26,6 +26,13 @@ error_nested_comprehensions = """
     ]
 """
 
+error_nested_methods = """
+class B(A):
+   def method(self):
+       def inner():
+           super().method()
+"""
+
 error_multiple_nested_comprehensions = """
     [
         it + k + el + 1
@@ -59,6 +66,7 @@ correct_generator_expression = """
     error_set_comprehension,
     error_list_comprehension,
     error_dict_comprehension,
+    error_nested_methods,
 ])
 def test_buggy_super_context(
     assert_errors,

--- a/wemake_python_styleguide/presets/types/tree.py
+++ b/wemake_python_styleguide/presets/types/tree.py
@@ -97,6 +97,7 @@ PRESET: Final = (
     classes.WrongSlotsVisitor,
     classes.ClassAttributeVisitor,
     classes.ClassMethodOrderVisitor,
+    classes.BuggySuperCallVisitor,
 
     blocks.BlockVariableVisitor,
     blocks.AfterBlockVariablesVisitor,

--- a/wemake_python_styleguide/violations/oop.py
+++ b/wemake_python_styleguide/violations/oop.py
@@ -675,6 +675,7 @@ class UnpythonicGetterSetterViolation(ASTViolation):
     code = 615
 
 
+@final
 class BuggySuperContextViolation(ASTViolation):
     """
     Calling super() in buggy context.
@@ -697,7 +698,7 @@ class BuggySuperContextViolation(ASTViolation):
         # Wrong
         (super().augment(it) for it in items)
 
-    .. versionadded:: 0.17.0
+    .. versionadded:: 0.18.0
     """
 
     error_template = 'Found incorrect form of `super()` call for the context'

--- a/wemake_python_styleguide/violations/oop.py
+++ b/wemake_python_styleguide/violations/oop.py
@@ -28,6 +28,7 @@ Summary
    WrongSuperCallAccessViolation
    WrongDescriptorDecoratorViolation
    UnpythonicGetterSetterViolation
+   BuggySuperContextViolation
 
 Respect your objects
 --------------------
@@ -48,6 +49,7 @@ Respect your objects
 .. autoclass:: WrongSuperCallAccessViolation
 .. autoclass:: WrongDescriptorDecoratorViolation
 .. autoclass:: UnpythonicGetterSetterViolation
+.. autoclass:: BuggySuperContextViolation
 
 """
 
@@ -671,3 +673,32 @@ class UnpythonicGetterSetterViolation(ASTViolation):
 
     error_template = 'Found unpythonic getter or setter'
     code = 615
+
+
+class BuggySuperContextViolation(ASTViolation):
+    """
+    Calling super() in buggy context.
+
+    Reasoning:
+        Call to `super()` without arguments will cause unexpected `TypeError`
+        in a number of specific contexts, e.g. dict/set/list comprehensions
+        and generator expressions.
+
+        Read more: https://bugs.python.org/issue46175
+
+    Solution:
+        Use `super(cls, self)` instead in those cases.
+
+    Example::
+
+        # Correct
+        (super(cls, self).augment(it) for it in items)
+
+        # Wrong
+        (super().augment(it) for it in items)
+
+    .. versionadded:: 0.17.0
+    """
+
+    error_template = 'Found incorrect form of `super()` call for the context'
+    code = 616

--- a/wemake_python_styleguide/violations/refactoring.py
+++ b/wemake_python_styleguide/violations/refactoring.py
@@ -1261,7 +1261,7 @@ class ChainedIsViolation(ASTViolation):
         Wrong:
             a is b is None
 
-    .. versionadded:: 0.17.0
+    .. versionadded:: 0.18.0
     """
 
     error_template = 'Found chained `is` operators in an expression'

--- a/wemake_python_styleguide/visitors/ast/classes.py
+++ b/wemake_python_styleguide/visitors/ast/classes.py
@@ -421,3 +421,40 @@ class ClassMethodOrderVisitor(base.BaseNodeVisitor):
         if access.is_private(first):
             return 0  # lowest priority
         return base_methods_order.get(first, public_and_magic_methods_priority)
+
+
+@final
+class BuggySuperCallVisitor(base.BaseNodeVisitor):
+    """
+    Responsible for finding wrong form of `super()` call for certain contexts.
+
+    Call to `super()` without arguments will cause unexpected `TypeError` in a
+    number of specific contexts. Read more: https://bugs.python.org/issue46175
+    """
+
+    _buggy_super_contexts: ClassVar[types.AnyNodes] = (
+        ast.GeneratorExp,
+        ast.SetComp,
+        ast.ListComp,
+        ast.DictComp,
+    )
+
+    def visit_Call(self, node: ast.Call) -> None:
+        """Checks if this is a `super()` call in a specific context."""
+        self._check_buggy_super_context(node)
+        self.generic_visit(node)
+
+    def _check_buggy_super_context(self, node: ast.Call):
+        if not isinstance(node.func, ast.Name):
+            return
+
+        if node.func.id != 'super' or node.args:
+            return
+
+        parent = nodes.get_parent(node)
+        while parent:
+            if isinstance(parent, self._buggy_super_contexts):
+                self.add_violation(oop.BuggySuperContextViolation(node))
+                break
+
+            parent = nodes.get_parent(parent)

--- a/wemake_python_styleguide/visitors/ast/classes.py
+++ b/wemake_python_styleguide/visitors/ast/classes.py
@@ -451,5 +451,13 @@ class BuggySuperCallVisitor(base.BaseNodeVisitor):
         if node.func.id != 'super' or node.args:
             return
 
+        # Check for being in a nested function
+        ctx = nodes.get_context(node)
+        if isinstance(ctx, FunctionNodes):
+            outer_ctx = nodes.get_context(ctx)
+            if isinstance(outer_ctx, FunctionNodes):
+                self.add_violation(oop.BuggySuperContextViolation(node))
+                return
+
         if walk.get_closest_parent(node, self._buggy_super_contexts):
             self.add_violation(oop.BuggySuperContextViolation(node))

--- a/wemake_python_styleguide/visitors/ast/classes.py
+++ b/wemake_python_styleguide/visitors/ast/classes.py
@@ -451,10 +451,5 @@ class BuggySuperCallVisitor(base.BaseNodeVisitor):
         if node.func.id != 'super' or node.args:
             return
 
-        parent = nodes.get_parent(node)
-        while parent:
-            if isinstance(parent, self._buggy_super_contexts):
-                self.add_violation(oop.BuggySuperContextViolation(node))
-                break
-
-            parent = nodes.get_parent(parent)
+        if walk.get_closest_parent(node, self._buggy_super_contexts):
+            self.add_violation(oop.BuggySuperContextViolation(node))


### PR DESCRIPTION
Resolves #2310.

# I have made things!

I've decided not to include the case of `super()` in a nested function due to the nature of the error there being fundamentally different from what is described in the bug report.
<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Checklist

<!-- Please check everything that applies: -->

- [X] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [X] I have created at least one test case for the changes I have made
- [X] I have updated the documentation for the changes I have made
- [X] I have added my changes to the `CHANGELOG.md`

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->

🙏 Please, if you or your company is finding wemake-python-styleguide valuable, help us sustain the project by sponsoring it transparently on https://opencollective.com/wemake-python-styleguide. As a thank you, your profile/company logo will be added to our main README which receives hundreds of unique visitors per day.
