### PR TITLE
fix flakeheaven base link for getting it as raw text

### DIFF
--- a/docs/pages/usage/integrations/flakeheaven.rst
+++ b/docs/pages/usage/integrations/flakeheaven.rst
@@ -24,7 +24,7 @@ Then you will have to configure ``flakeheaven`` inside your ``pyproject.toml``:
 
     [tool.flakeheaven]
     # optionally inherit from remote config (or local if you want)
-    base = "https://github.com/wemake-services/wemake-python-styleguide/blob/master/styles/flakeheaven.toml"
+    base = "https://raw.githubusercontent.com/wemake-services/wemake-python-styleguide/master/styles/flakeheaven.toml"
 
 And then:
 


### PR DESCRIPTION
# I have made things!

Hello, I replace`flakehell -> flakeheaven` in #2520 , but link to baseline leads to github page. I replace this link

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->

🙏 Please, if you or your company is finding wemake-python-styleguide valuable, help us sustain the project by sponsoring it transparently on https://opencollective.com/wemake-python-styleguide. As a thank you, your profile/company logo will be added to our main README which receives hundreds of unique visitors per day.
