### PR TITLE
Fix dedent definition for search function end

### DIFF
--- a/tests/test_visitors/test_ast/test_classes/test_wrong_empty_lines_count.py
+++ b/tests/test_visitors/test_ast/test_classes/test_wrong_empty_lines_count.py
@@ -190,7 +190,7 @@ def test_wrong(
     assert_errors(visitor, [WrongEmptyLinesCountViolation])
 
 
-@pytest.mark.parametrize('input_', [
+@pytest.mark.parametrize('template', [
     class_with_valid_method,
     allow_function,
     allow_function_with_comments,
@@ -202,14 +202,14 @@ def test_wrong(
     module_level_empty_lines,
 ])
 def test_success(
-    input_,
+    template,
     parse_tokens,
     default_options,
     assert_errors,
     mode,
 ):
     """Testing available cases."""
-    file_tokens = parse_tokens(mode(input_))
+    file_tokens = parse_tokens(mode(template))
 
     visitor = WrongEmptyLinesCountVisitor(
         default_options, file_tokens=file_tokens,
@@ -235,12 +235,12 @@ def test_zero_option(
     assert_errors(visitor, [WrongEmptyLinesCountViolation])
 
 
-@pytest.mark.parametrize('input_', [
+@pytest.mark.parametrize('template', [
     class_with_valid_method,
     file_with_few_class,
 ])
 def test_zero_option_with_valid_method(
-    input_,
+    template,
     parse_tokens,
     default_options,
     assert_errors,
@@ -248,7 +248,7 @@ def test_zero_option_with_valid_method(
     mode,
 ):
     """Test zero configuration with valid method."""
-    file_tokens = parse_tokens(mode(input_))
+    file_tokens = parse_tokens(mode(template))
     visitor = WrongEmptyLinesCountVisitor(
         options(exps_for_one_empty_line=0), file_tokens=file_tokens,
     )

--- a/tests/test_visitors/test_ast/test_classes/test_wrong_empty_lines_count.py
+++ b/tests/test_visitors/test_ast/test_classes/test_wrong_empty_lines_count.py
@@ -236,7 +236,7 @@ def test_zero_option(
 
 
 @pytest.mark.parametrize('input_', [
-    # class_with_valid_method,
+    class_with_valid_method,
     file_with_few_class,
 ])
 def test_zero_option_with_valid_method(

--- a/tests/test_visitors/test_ast/test_classes/test_wrong_empty_lines_count.py
+++ b/tests/test_visitors/test_ast/test_classes/test_wrong_empty_lines_count.py
@@ -235,7 +235,12 @@ def test_zero_option(
     assert_errors(visitor, [WrongEmptyLinesCountViolation])
 
 
+@pytest.mark.parametrize('input_', [
+    # class_with_valid_method,
+    file_with_few_class,
+])
 def test_zero_option_with_valid_method(
+    input_,
     parse_tokens,
     default_options,
     assert_errors,
@@ -243,7 +248,7 @@ def test_zero_option_with_valid_method(
     mode,
 ):
     """Test zero configuration with valid method."""
-    file_tokens = parse_tokens(mode(class_with_valid_method))
+    file_tokens = parse_tokens(mode(input_))
     visitor = WrongEmptyLinesCountVisitor(
         options(exps_for_one_empty_line=0), file_tokens=file_tokens,
     )

--- a/wemake_python_styleguide/visitors/ast/function_empty_lines.py
+++ b/wemake_python_styleguide/visitors/ast/function_empty_lines.py
@@ -26,7 +26,10 @@ class _Function(object):
         return ''.join([target_token.string for target_token in target_tokens])
 
     def _is_target_line(self, token: tokenize.TokenInfo) -> bool:
-        is_comment = '#' in token.line
+        stripped_token_line = token.line.strip()
+        is_comment = False
+        if stripped_token_line:
+            is_comment = '#' in stripped_token_line[0]
         is_string = token.type == tokenize.STRING
         is_multistring_end = '"""' in token.line
         return is_comment or is_string or is_multistring_end
@@ -53,7 +56,7 @@ class _FileFunctions(object):
             )
             if not in_function and self._is_function_start(token):
                 in_function = True
-                function_start_column = self._function_start_column(token)
+                function_start_column = token.start[1]
             elif function_ended:
                 in_function = False
                 function_start_column = 0
@@ -62,11 +65,8 @@ class _FileFunctions(object):
             if in_function:
                 function_tokens.append(token)
 
-    def _is_function_start(self, token: tokenize.TokenInfo) -> int:
+    def _is_function_start(self, token: tokenize.TokenInfo) -> bool:
         return token.type == tokenize.NAME and token.string in {'def', 'async'}
-
-    def _function_start_column(self, token) -> int:
-        return token.start[1]
 
     def _is_function_end(
         self,

--- a/wemake_python_styleguide/visitors/ast/function_empty_lines.py
+++ b/wemake_python_styleguide/visitors/ast/function_empty_lines.py
@@ -1,6 +1,6 @@
 import math
 import tokenize
-from typing import List
+from typing import Generator, List
 
 from typing_extensions import final
 
@@ -39,30 +39,44 @@ class _FileFunctions(object):
         self._file_tokens = file_tokens
 
     def as_list(self) -> List[_Function]:
-        functions = []
+        return list(self._search_functions())
+
+    def _search_functions(self) -> Generator[_Function, None, None]:
         function_tokens: List[tokenize.TokenInfo] = []
         in_function = False
+        function_start_column = 0
         for token in self._file_tokens:
-            if self._is_function_start(token):
+            function_ended = self._is_function_end(
+                token,
+                bool(function_tokens),
+                function_start_column,
+            )
+            if not in_function and self._is_function_start(token):
                 in_function = True
-            elif self._is_function_end(token, bool(function_tokens)):
+                function_start_column = self._function_start_column(token)
+            elif function_ended:
                 in_function = False
-                functions.append(_Function(function_tokens))
+                function_start_column = 0
+                yield _Function(function_tokens)
                 function_tokens = []
             if in_function:
                 function_tokens.append(token)
-        return functions
 
-    def _is_function_start(self, token: tokenize.TokenInfo) -> bool:
-        return token.type == tokenize.NAME and token.string == 'def'
+    def _is_function_start(self, token: tokenize.TokenInfo) -> int:
+        return token.type == tokenize.NAME and token.string in {'def', 'async'}
+
+    def _function_start_column(self, token) -> int:
+        return token.start[1]
 
     def _is_function_end(
         self,
         token: tokenize.TokenInfo,
         function_tokens_exists: bool,
+        function_start_column: int,
     ) -> bool:
-        is_dedent_token = token.type == tokenize.DEDENT and token.start[1] == 0
-        return is_dedent_token and function_tokens_exists
+        column_valid = token.start[1] in {0, function_start_column}
+        is_dedent_token = token.type == tokenize.DEDENT
+        return is_dedent_token and function_tokens_exists and column_valid
 
 
 @final
@@ -84,7 +98,7 @@ class _FileTokens(object):
                 line for line in splitted_function_body if line == ''
             ])
             if not empty_lines_count:
-                return []
+                continue
 
             available_empty_lines = self._available_empty_lines(
                 len(splitted_function_body), empty_lines_count,

--- a/wemake_python_styleguide/visitors/ast/function_empty_lines.py
+++ b/wemake_python_styleguide/visitors/ast/function_empty_lines.py
@@ -1,6 +1,6 @@
 import math
 import tokenize
-from typing import Generator, List
+from typing import Iterator, List
 
 from typing_extensions import final
 
@@ -44,7 +44,7 @@ class _FileFunctions(object):
     def as_list(self) -> List[_Function]:
         return list(self._search_functions())
 
-    def _search_functions(self) -> Generator[_Function, None, None]:
+    def _search_functions(self) -> Iterator[_Function]:
         function_tokens: List[tokenize.TokenInfo] = []
         in_function = False
         function_start_column = 0


### PR DESCRIPTION
# I have made things!

I'm test [last changes](https://github.com/wemake-services/wemake-python-styleguide/commit/44339d67b89faa2c5ae94226e19b50187f47075f) in `WrongEmptyLinesCountVisitor` in real project and I found that the algorithm for finding the end of the function is incorrect

## Checklist

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [ ] I have updated the documentation for the changes I have made
- [ ] I have added my changes to the `CHANGELOG.md`

🙏 Please, if you or your company is finding wemake-python-styleguide valuable, help us sustain the project by sponsoring it transparently on https://opencollective.com/wemake-python-styleguide. As a thank you, your profile/company logo will be added to our main README which receives hundreds of unique visitors per day.
