### PR TITLE
Use new github actions API to set output

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -33,8 +33,8 @@ fi
 
 # Sets the output variable for Github Action API:
 # See: https://help.github.com/en/articles/development-tools-for-github-action
-echo "::set-output name=output::$output"
-echo '================================='
+echo "output=$output" >> $GITHUB_OUTPUT
+echo '================================'
 echo
 
 # Fail the build in case status code is not 0:


### PR DESCRIPTION
Old one is deprecated.

Docs https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter
