### PR TITLE
Fix enforce python version usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ to make all people write **exactly** the same `Python` code.
 
 We have several primary objectives:
 
-0. Enforce `python3.6+` usage
+0. Enforce `python3.7+` usage
 1. Significantly reduce the complexity of your code and make it more maintainable
 2. Enforce "There should be one -- and preferably only one -- obvious way to do it" rule to coding and naming styles
 3. Protect developers from possible errors and enforce best practices


### PR DESCRIPTION
# I have made things!

In #2499 python 3.6 support was removed. But README.md informs about this tool work with `python3.6+`

## Checklist

<!-- Please check everything that applies: -->

- [ ] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [ ] I have created at least one test case for the changes I have made
- [ ] I have updated the documentation for the changes I have made
- [ ] I have added my changes to the `CHANGELOG.md`

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->

🙏 Please, if you or your company is finding wemake-python-styleguide valuable, help us sustain the project by sponsoring it transparently on https://opencollective.com/wemake-python-styleguide. As a thank you, your profile/company logo will be added to our main README which receives hundreds of unique visitors per day.
