### PR TITLE
Redundant Tenary Check Added

### DIFF
--- a/tests/fixtures/noqa/noqa.py
+++ b/tests/fixtures/noqa/noqa.py
@@ -774,7 +774,11 @@ def many_raises_function(parameter):  # noqa: WPS238
         raise IndexError('3')
     raise TypeError('4')
 
-
+ternary_a = 1 
+ternary_b = 2
+ternary_result = ternary_a if ... else ternary_a # noqa: WPS475
+ternary_result = ternary_b if ternary_a == ternary_b else ternary_a # noqa: WPS475
+ternary_result = ternary_a if ternary_a is not None else None # noqa: WPS475
 my_print("""
 text
 """)  # noqa: WPS462

--- a/tests/fixtures/noqa/noqa.py
+++ b/tests/fixtures/noqa/noqa.py
@@ -777,8 +777,7 @@ def many_raises_function(parameter):  # noqa: WPS238
 ternary_a = 1 
 ternary_b = 2
 ternary_result = ternary_a if ... else ternary_a # noqa: WPS475
-ternary_result = ternary_b if ternary_a == ternary_b else ternary_a # noqa: WPS475
-ternary_result = ternary_a if ternary_a is not None else None # noqa: WPS475
+
 my_print("""
 text
 """)  # noqa: WPS462

--- a/tests/test_checker/test_noqa.py
+++ b/tests/test_checker/test_noqa.py
@@ -267,7 +267,7 @@ SHOULD_BE_RAISED = types.MappingProxyType({
     'WPS472': 1,
     'WPS473': 0,
     'WPS474': 1,
-    'WPS475': 3,
+    'WPS475': 1,
 
     'WPS500': 1,
     'WPS501': 1,

--- a/tests/test_checker/test_noqa.py
+++ b/tests/test_checker/test_noqa.py
@@ -267,6 +267,7 @@ SHOULD_BE_RAISED = types.MappingProxyType({
     'WPS472': 1,
     'WPS473': 0,
     'WPS474': 1,
+    'WPS475': 3,
 
     'WPS500': 1,
     'WPS501': 1,

--- a/tests/test_visitors/test_ast/test_redundancy/test_redundant_ternary.py
+++ b/tests/test_visitors/test_ast/test_redundancy/test_redundant_ternary.py
@@ -16,6 +16,14 @@ correct_not_equal = """
 a if a != b else c
 """
 
+non_compare = """
+a if a | b else None
+"""
+
+two_operation_compare = """
+a == b != c
+"""
+
 correct_ternary_none = """
 a.split() if a is not None else None
 """
@@ -78,3 +86,23 @@ def test_wrong_ternary(
     visitor.run()
 
     assert_errors(visitor, [RedundantTernaryViolation])
+
+
+@pytest.mark.parametrize('code', [
+    non_compare,
+    two_operation_compare,
+])
+def safety_check_ternary(
+    code,
+    assert_errors,
+    parse_ast_tree,
+    default_options,
+    mode,
+):
+    """Ensures that conditions for checking are met."""
+    tree = parse_ast_tree(mode(code))
+
+    visitor = RedundantTernaryVisitor(default_options, tree=tree)
+    visitor.run()
+
+    assert_errors(visitor, [])

--- a/tests/test_visitors/test_ast/test_redundancy/test_redundant_ternary.py
+++ b/tests/test_visitors/test_ast/test_redundancy/test_redundant_ternary.py
@@ -1,0 +1,92 @@
+import pytest
+
+from wemake_python_styleguide.violations.best_practices import (
+    RedundantTernaryViolation,
+)
+from wemake_python_styleguide.visitors.ast.redundancy import (
+    RedundantTernaryVisitor,
+)
+
+# Correct:
+correct_ternary_elipses = """
+a = 1
+c = 3
+a if ... else c
+"""
+
+correct_not_equal = """
+a = 1
+b = 2
+c = 3
+a if a != b else c
+"""
+
+correct_ternary_none = """
+a = 1
+a.split() if a is not None else None
+"""
+
+# Wrong:
+wrong_ternary_same_values = """
+a = 1
+a if ... else a
+"""
+
+wrong_ternary_useless_comparison_not_eq = """
+a = 1
+b = 2
+a if a != b else b
+"""
+wrong_ternary_useless_comparison_eq = """
+a = 1
+b = 2
+b if a == b else a
+"""
+
+wrong_ternarny_none = """
+a = 1
+a if a is not None else None
+"""
+
+
+@pytest.mark.parametrize('code', [
+    correct_ternary_elipses,
+    correct_not_equal,
+    correct_ternary_none,
+])
+def test_correct_ternary(
+    code,
+    assert_errors,
+    parse_ast_tree,
+    default_options,
+    mode,
+):
+    """Ensures that correct ternary expressions are fine."""
+    tree = parse_ast_tree(mode(code))
+
+    visitor = RedundantTernaryVisitor(default_options, tree=tree)
+    visitor.run()
+
+    assert_errors(visitor, [])
+
+
+@pytest.mark.parametrize('code', [
+    wrong_ternary_same_values,
+    wrong_ternary_useless_comparison_not_eq,
+    wrong_ternary_useless_comparison_eq,
+    wrong_ternarny_none,
+])
+def test_wrong_ternary(
+    code,
+    assert_errors,
+    parse_ast_tree,
+    default_options,
+    mode,
+):
+    """Ensures that redundant ternary expressions are forbidden."""
+    tree = parse_ast_tree(mode(code))
+
+    visitor = RedundantTernaryVisitor(default_options, tree=tree)
+    visitor.run()
+
+    assert_errors(visitor, [RedundantTernaryViolation])

--- a/tests/test_visitors/test_ast/test_redundancy/test_redundant_ternary.py
+++ b/tests/test_visitors/test_ast/test_redundancy/test_redundant_ternary.py
@@ -16,14 +16,6 @@ correct_not_equal = """
 a if a != b else c
 """
 
-non_compare = """
-a if a | b else None
-"""
-
-two_operation_compare = """
-a == b != c
-"""
-
 correct_ternary_none = """
 a.split() if a is not None else None
 """
@@ -55,10 +47,9 @@ def test_correct_ternary(
     assert_errors,
     parse_ast_tree,
     default_options,
-    mode,
 ):
     """Ensures that correct ternary expressions are fine."""
-    tree = parse_ast_tree(mode(code))
+    tree = parse_ast_tree(code)
 
     visitor = RedundantTernaryVisitor(default_options, tree=tree)
     visitor.run()
@@ -77,32 +68,11 @@ def test_wrong_ternary(
     assert_errors,
     parse_ast_tree,
     default_options,
-    mode,
 ):
     """Ensures that redundant ternary expressions are forbidden."""
-    tree = parse_ast_tree(mode(code))
+    tree = parse_ast_tree(code)
 
     visitor = RedundantTernaryVisitor(default_options, tree=tree)
     visitor.run()
 
     assert_errors(visitor, [RedundantTernaryViolation])
-
-
-@pytest.mark.parametrize('code', [
-    non_compare,
-    two_operation_compare,
-])
-def safety_check_ternary(
-    code,
-    assert_errors,
-    parse_ast_tree,
-    default_options,
-    mode,
-):
-    """Ensures that conditions for checking are met."""
-    tree = parse_ast_tree(mode(code))
-
-    visitor = RedundantTernaryVisitor(default_options, tree=tree)
-    visitor.run()
-
-    assert_errors(visitor, [])

--- a/tests/test_visitors/test_ast/test_redundancy/test_redundant_ternary.py
+++ b/tests/test_visitors/test_ast/test_redundancy/test_redundant_ternary.py
@@ -9,42 +9,30 @@ from wemake_python_styleguide.visitors.ast.redundancy import (
 
 # Correct:
 correct_ternary_elipses = """
-a = 1
-c = 3
 a if ... else c
 """
 
 correct_not_equal = """
-a = 1
-b = 2
-c = 3
 a if a != b else c
 """
 
 correct_ternary_none = """
-a = 1
 a.split() if a is not None else None
 """
 
 # Wrong:
 wrong_ternary_same_values = """
-a = 1
 a if ... else a
 """
 
 wrong_ternary_useless_comparison_not_eq = """
-a = 1
-b = 2
 a if a != b else b
 """
 wrong_ternary_useless_comparison_eq = """
-a = 1
-b = 2
 b if a == b else a
 """
 
 wrong_ternarny_none = """
-a = 1
 a if a is not None else None
 """
 

--- a/tests/test_visitors/test_ast/test_redundancy/test_redundant_ternary.py
+++ b/tests/test_visitors/test_ast/test_redundancy/test_redundant_ternary.py
@@ -8,23 +8,11 @@ from wemake_python_styleguide.visitors.ast.redundancy import (
 )
 
 # Correct:
-correct_ternary_elipses = """
-a if ... else c
-"""
-
 correct_not_equal = """
 a if a != b else c
 """
 
-correct_ternary_none = """
-a.split() if a is not None else None
-"""
-
 # Wrong:
-wrong_ternary_same_values = """
-a if ... else a
-"""
-
 wrong_ternary_useless_comparison_not_eq = """
 a if a != b else b
 """
@@ -32,15 +20,9 @@ wrong_ternary_useless_comparison_eq = """
 b if a == b else a
 """
 
-wrong_ternarny_none = """
-a if a is not None else None
-"""
-
 
 @pytest.mark.parametrize('code', [
-    correct_ternary_elipses,
     correct_not_equal,
-    correct_ternary_none,
 ])
 def test_correct_ternary(
     code,
@@ -58,10 +40,8 @@ def test_correct_ternary(
 
 
 @pytest.mark.parametrize('code', [
-    wrong_ternary_same_values,
     wrong_ternary_useless_comparison_not_eq,
     wrong_ternary_useless_comparison_eq,
-    wrong_ternarny_none,
 ])
 def test_wrong_ternary(
     code,

--- a/wemake_python_styleguide/presets/types/tree.py
+++ b/wemake_python_styleguide/presets/types/tree.py
@@ -109,6 +109,7 @@ PRESET: Final = (
     decorators.WrongDecoratorVisitor,
 
     redundancy.RedundantEnumerateVisitor,
+    redundancy.RedundantTernaryVisitor,
 
     function_empty_lines.WrongEmptyLinesCountVisitor,
 

--- a/wemake_python_styleguide/violations/best_practices.py
+++ b/wemake_python_styleguide/violations/best_practices.py
@@ -91,6 +91,7 @@ Summary
    GettingElementByUnpackingViolation
    WrongEmptyLinesCountViolation
    ImportObjectCollisionViolation
+   RedundantTernaryViolation
 
 Best practices
 --------------
@@ -170,6 +171,7 @@ Best practices
 .. autoclass:: GettingElementByUnpackingViolation
 .. autoclass:: WrongEmptyLinesCountViolation
 .. autoclass:: ImportObjectCollisionViolation
+.. autoclass:: RedundantTernaryViolation
 
 """
 
@@ -2849,3 +2851,33 @@ class ImportObjectCollisionViolation(ASTViolation):
 
     error_template = 'Found import object collision: {0}'
     code = 474
+
+
+@final
+class RedundantTernaryViolation(ASTViolation):
+    """
+    Forbid the redundant ternary operat which returns sanme value.
+
+    Reasoning:
+        There is no need to use a ternary operator to return the same value
+        for both the true and false cases.
+    Solution:
+        Instead of using a ternary operator, use the value directly.
+
+    Example::
+        Correct:
+        a if ... else c
+        a if a != b else c
+
+        Wrong:
+        a if ... else a
+        a if a is not None else None
+        a if a != b else b
+        b if a == b else a
+
+    .. versionadded:: 0.19.0
+
+    """
+
+    error_template = 'Found redundant ternary operator'
+    code = 475

--- a/wemake_python_styleguide/violations/best_practices.py
+++ b/wemake_python_styleguide/violations/best_practices.py
@@ -2859,8 +2859,9 @@ class RedundantTernaryViolation(ASTViolation):
     Forbid the redundant ternary expressions.
 
     Reasoning:
-        There is no need to use a ternary operator to return the same value
-        for both the true and false cases.
+        If the ternary expression can be simplified,
+        it should be simplified.
+
     Solution:
         Instead of using a ternary operator, use the value directly.
 

--- a/wemake_python_styleguide/violations/best_practices.py
+++ b/wemake_python_styleguide/violations/best_practices.py
@@ -2866,7 +2866,7 @@ class RedundantTernaryViolation(ASTViolation):
 
     Example::
         Correct:
-        a if ... else c
+        a if b is None else c
         a if a != b else c
 
         Wrong:

--- a/wemake_python_styleguide/violations/best_practices.py
+++ b/wemake_python_styleguide/violations/best_practices.py
@@ -2856,7 +2856,7 @@ class ImportObjectCollisionViolation(ASTViolation):
 @final
 class RedundantTernaryViolation(ASTViolation):
     """
-    Forbid the redundant ternary operat which returns sanme value.
+    Forbid the redundant ternary expressions.
 
     Reasoning:
         There is no need to use a ternary operator to return the same value

--- a/wemake_python_styleguide/visitors/ast/redundancy.py
+++ b/wemake_python_styleguide/visitors/ast/redundancy.py
@@ -6,6 +6,7 @@ from typing_extensions import final
 from wemake_python_styleguide.types import AnyComprehension, AnyFor
 from wemake_python_styleguide.violations.best_practices import (
     RedundantEnumerateViolation,
+    RedundantTernaryViolation,
 )
 from wemake_python_styleguide.visitors import decorators
 from wemake_python_styleguide.visitors.base import BaseNodeVisitor
@@ -53,3 +54,51 @@ class RedundantEnumerateVisitor(BaseNodeVisitor):
 
         if isinstance(index_receiver, ast.Name) and index_receiver.id == '_':
             self.add_violation(RedundantEnumerateViolation(index_receiver))
+
+
+@final
+class RedundantTernaryVisitor(BaseNodeVisitor):
+    """Finds useless ternary operators."""
+
+    def visit_IfExp(self, node: ast.IfExp) -> None:
+        """Finds useless ternary operators."""
+        body = ast.unparse(node.body)
+        orelse = ast.unparse(node.orelse)
+
+        # Check for specific patterns.
+        self.body_orelse_check(node, body, orelse)
+        self.check_computed_equal(node)
+
+        self.generic_visit(node)  # Visit all other node types.
+
+    def body_orelse_check(self, node, body, orelse) -> None:
+        """Check if body and orelse are the same."""
+        if body == orelse:
+            self.add_violation(RedundantTernaryViolation(node))
+
+    def check_computed_equal(self, node) -> None:
+        """Used to check if the computed branches are equal."""
+        if not isinstance(node.test, ast.Compare):
+            return
+
+        allowed_ops = (ast.NotEq, ast.Eq, ast.IsNot)
+        is_node_test = isinstance(node.test, ast.Compare)
+        correct_op = any(
+            isinstance(node.test.ops[0], op) for op in allowed_ops
+        )
+
+        if is_node_test and correct_op and len(node.test.ops) == 1:
+            left = ast.unparse(node.test.left)
+            right = ast.unparse(node.test.comparators[0])
+
+            self.compare_operands(node, left, right)
+
+    def compare_operands(self, node, left, right) -> None:
+        """Compare each operand to see if will result in same values."""
+        body_str = ast.unparse(node.body)
+        orelse_str = ast.unparse(node.orelse)
+
+        if body_str == left and orelse_str == right:
+            self.add_violation(RedundantTernaryViolation(node))
+        elif body_str == right and orelse_str == left:
+            self.add_violation(RedundantTernaryViolation(node))

--- a/wemake_python_styleguide/visitors/ast/redundancy.py
+++ b/wemake_python_styleguide/visitors/ast/redundancy.py
@@ -60,6 +60,8 @@ class RedundantEnumerateVisitor(BaseNodeVisitor):
 class RedundantTernaryVisitor(BaseNodeVisitor):
     """Finds useless ternary operators."""
 
+    allowed_ops = (ast.NotEq, ast.Eq, ast.IsNot)
+
     def visit_IfExp(self, node: ast.IfExp) -> None:
         """Finds useless ternary operators."""
         body = ast.unparse(node.body)
@@ -81,9 +83,8 @@ class RedundantTernaryVisitor(BaseNodeVisitor):
         if not isinstance(node.test, ast.Compare):
             return
 
-        allowed_ops = (ast.NotEq, ast.Eq, ast.IsNot)
         correct_op = any(
-            isinstance(node.test.ops[0], op) for op in allowed_ops
+            isinstance(node.test.ops[0], op) for op in self.allowed_ops
         )
 
         if correct_op and len(node.test.ops) == 1:

--- a/wemake_python_styleguide/visitors/ast/redundancy.py
+++ b/wemake_python_styleguide/visitors/ast/redundancy.py
@@ -82,12 +82,11 @@ class RedundantTernaryVisitor(BaseNodeVisitor):
             return
 
         allowed_ops = (ast.NotEq, ast.Eq, ast.IsNot)
-        is_node_test = isinstance(node.test, ast.Compare)
         correct_op = any(
             isinstance(node.test.ops[0], op) for op in allowed_ops
         )
 
-        if is_node_test and correct_op and len(node.test.ops) == 1:
+        if correct_op and len(node.test.ops) == 1:
             left = ast.unparse(node.test.left)
             right = ast.unparse(node.test.comparators[0])
 

--- a/wemake_python_styleguide/visitors/ast/redundancy.py
+++ b/wemake_python_styleguide/visitors/ast/redundancy.py
@@ -73,12 +73,14 @@ class RedundantTernaryVisitor(BaseNodeVisitor):
 
         self.generic_visit(node)  # Visit all other node types.
 
-    def body_orelse_check(self, node, body, orelse) -> None:
+    def body_orelse_check(
+        self, node: ast.IfExp, body: str, orelse: str,
+    ) -> None:
         """Check if body and orelse are the same."""
         if body == orelse:
             self.add_violation(RedundantTernaryViolation(node))
 
-    def check_computed_equal(self, node) -> None:
+    def check_computed_equal(self, node: ast.IfExp) -> None:
         """Used to check if the computed branches are equal."""
         if not isinstance(node.test, ast.Compare):
             return
@@ -93,7 +95,7 @@ class RedundantTernaryVisitor(BaseNodeVisitor):
 
             self.compare_operands(node, left, right)
 
-    def compare_operands(self, node, left, right) -> None:
+    def compare_operands(self, node: ast.IfExp, left: str, right: str) -> None:
         """Compare each operand to see if will result in same values."""
         body_str = ast.unparse(node.body)
         orelse_str = ast.unparse(node.orelse)

--- a/wemake_python_styleguide/visitors/ast/redundancy.py
+++ b/wemake_python_styleguide/visitors/ast/redundancy.py
@@ -60,8 +60,6 @@ class RedundantEnumerateVisitor(BaseNodeVisitor):
 class RedundantTernaryVisitor(BaseNodeVisitor):
     """Finds useless ternary operators."""
 
-    allowed_ops = (ast.NotEq, ast.Eq, ast.IsNot)
-
     def visit_IfExp(self, node: ast.IfExp) -> None:
         """Finds useless ternary operators."""
         body = ast.unparse(node.body)
@@ -85,15 +83,10 @@ class RedundantTernaryVisitor(BaseNodeVisitor):
         if not isinstance(node.test, ast.Compare):
             return
 
-        correct_op = any(
-            isinstance(node.test.ops[0], op) for op in self.allowed_ops
-        )
+        left = ast.unparse(node.test.left)
+        right = ast.unparse(node.test.comparators[0])
 
-        if correct_op and len(node.test.ops) == 1:
-            left = ast.unparse(node.test.left)
-            right = ast.unparse(node.test.comparators[0])
-
-            self.compare_operands(node, left, right)
+        self.compare_operands(node, left, right)
 
     def compare_operands(self, node: ast.IfExp, left: str, right: str) -> None:
         """Compare each operand to see if will result in same values."""


### PR DESCRIPTION
# Added usless ternary rule

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [ ] I have updated the documentation for the changes I have made
- [ ] I have added my changes to the `CHANGELOG.md`

## Last Commit on my branch
Added RedundantTernaryViolation to best_practices.py with code 475. The error template for this code is set to 'Found redundant ternary operator'. Added RedundantTernaryVisistor to redundancy.py. This visistor checks for all the cases mentioned in the original issue request. Added The RedundantTernaryVisistor to the list of visitors in tree.py. Added a test case for the RedundantTernaryVisistor to new file test_redundant_ternary.py. Added 3 test cases to noqa.py to test the new check under code 475. Reflected this in test_noqa.py.

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->

🙏 Please, if you or your company is finding wemake-python-styleguide valuable, help us sustain the project by sponsoring it transparently on https://opencollective.com/wemake-python-styleguide. As a thank you, your profile/company logo will be added to our main README which receives hundreds of unique visitors per day.
