### PR TITLE
Fix `IterableUnpackingViolation` for generic types with `TypeVarTuple`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Semantic versioning in our case means:
 
 - Fixes `OverusedStringViolation` not to include `'...'` string
 - Removes `astor` package in favour of `ast.unparse`
+- Fixes `IterableUnpackingViolation` with generic types and `TypeVarTuple`
 
 
 ## 0.19.2

--- a/tests/test_visitors/test_ast/test_iterables/test_unpacking.py
+++ b/tests/test_visitors/test_ast/test_iterables/test_unpacking.py
@@ -12,6 +12,11 @@ spread_list_definition = '[1, 2, *numbers, 74]'
 spread_set_definition = '{1, 2, *numbers, 74}'
 spread_tuple_definition = '(1, 2, *numbers, 74)'
 spread_assignment = 'first, *_ = [1, 2, 4, 3]'
+type_annotation1 = 'first: Tuple[*Shape]'
+type_annotation2 = 'first: tuple[*Shape]'
+type_alias = 'first = Tuple[*Shape]'
+generic_type = 'class MyClass(Generic[*Shape]): ...'
+similar_but_unrelated = 'my_obj[*my_iter]'
 
 wrong_list_definition = '[*numbers]'
 wrong_set_definition = '{*numbers}'
@@ -25,6 +30,14 @@ wrong_spread_assignment = '*_, = [1, 2, 4, 3]'
     spread_set_definition,
     spread_tuple_definition,
     spread_assignment,
+
+    # Type annotations should be allowed:
+    type_annotation1,
+    type_annotation2,
+    type_alias,
+    generic_type,
+    # As a side-effect of type annotations, we also allow this code in runtime:
+    similar_but_unrelated,
 ])
 def test_correct_iterable_unpacking_usage(
     assert_errors,

--- a/tests/test_visitors/test_ast/test_iterables/test_unpacking.py
+++ b/tests/test_visitors/test_ast/test_iterables/test_unpacking.py
@@ -1,10 +1,16 @@
 import pytest
 
+from wemake_python_styleguide.compat.constants import PY311
 from wemake_python_styleguide.violations.consistency import (
     IterableUnpackingViolation,
 )
 from wemake_python_styleguide.visitors.ast.iterables import (
     IterableUnpackingVisitor,
+)
+
+_skip_mark = pytest.mark.skipif(
+    not PY311,
+    reason='Unpacking in subscript is only allow in 3.11+',
 )
 
 args_unpacking_in_call = 'f(*args)'
@@ -32,12 +38,12 @@ wrong_spread_assignment = '*_, = [1, 2, 4, 3]'
     spread_assignment,
 
     # Type annotations should be allowed:
-    type_annotation1,
-    type_annotation2,
-    type_alias,
-    generic_type,
+    pytest.param(type_annotation1, marks=_skip_mark),
+    pytest.param(type_annotation2, marks=_skip_mark),
+    pytest.param(type_alias, marks=_skip_mark),
+    pytest.param(generic_type, marks=_skip_mark),
     # As a side-effect of type annotations, we also allow this code in runtime:
-    similar_but_unrelated,
+    pytest.param(similar_but_unrelated, marks=_skip_mark),
 ])
 def test_correct_iterable_unpacking_usage(
     assert_errors,

--- a/wemake_python_styleguide/violations/consistency.py
+++ b/wemake_python_styleguide/violations/consistency.py
@@ -2156,12 +2156,16 @@ class IterableUnpackingViolation(ASTViolation):
         {*iterable, *other_iterable}
         list(iterable)
         first, *iterable = other_iterable
+        GenericTuple = tuple[*Shape]
 
         # Wrong:
         [*iterable]
         *iterable, = other_iterable
 
     .. versionadded:: 0.13.0
+    .. versionchanged:: 0.19.3
+       Allow using ``TypeVarTuple`` unpacking in generic types.
+       As a side-effect we now allow all unpackings in ``ast.Subscript``.
 
     """
 

--- a/wemake_python_styleguide/visitors/ast/iterables.py
+++ b/wemake_python_styleguide/visitors/ast/iterables.py
@@ -28,6 +28,14 @@ class IterableUnpackingVisitor(base.BaseNodeVisitor):
 
     def _check_unnecessary_iterable_unpacking(self, node: ast.Starred) -> None:
         parent = get_parent(node)
-        if isinstance(parent, self._unpackable_iterable_parent_types):
-            if len(getattr(parent, 'elts', [])) == 1:
-                self.add_violation(IterableUnpackingViolation(node))
+        if not isinstance(parent, self._unpackable_iterable_parent_types):
+            return
+        if len(getattr(parent, 'elts', [])) != 1:
+            return
+
+        container = get_parent(parent)
+        if isinstance(container, ast.Subscript):
+            # We ignore cases like `Tuple[*Shape]`, because it is a type
+            # annotation which should be used like this.
+            return
+        self.add_violation(IterableUnpackingViolation(node))

--- a/wemake_python_styleguide/visitors/ast/iterables.py
+++ b/wemake_python_styleguide/visitors/ast/iterables.py
@@ -34,8 +34,9 @@ class IterableUnpackingVisitor(base.BaseNodeVisitor):
             return
 
         container = get_parent(parent)
-        if isinstance(container, ast.Subscript):
+        if isinstance(container, ast.Subscript):  # pragma: py-lt-311
             # We ignore cases like `Tuple[*Shape]`, because it is a type
             # annotation which should be used like this.
+            # It is only possible for Python 3.11+
             return
         self.add_violation(IterableUnpackingViolation(node))


### PR DESCRIPTION
Refs https://github.com/wemake-services/wemake-python-styleguide/issues/2699