### PR TITLE
docs/conf.py fix: Remove duplicate autodoc_member_order configuration

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -70,8 +70,6 @@ extensions = [
 
 autoclass_content = 'class'
 autodoc_member_order = 'bysource'
-
-autodoc_member_order = 'bysource'
 autodoc_default_options = {
     'members': True,
     'undoc-members': True,


### PR DESCRIPTION
# Remove duplicate Sphinx configuration setting

## Checklist
- [ ] I have double checked that there are no unrelated changes in this pull request
- [ ] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made
- [ ] I have added my changes to the `CHANGELOG.md`

## Related issues
Refs #0

## Changes
Fixed a duplicate `autodoc_member_order = 'bysource'` configuration on line 72 in `docs/conf.py`. This change improves code clarity and removes redundancy.

## Additional Notes
This is a simple configuration cleanup that has no functional impact on the documentation output, as the duplicate setting was using the same value.