### PR TITLE
Disable `WPS305`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Semantic versioning in our case means:
 - **Breaking**: Drops `nitpick` support
 - **Breaking**: Removes `WPS302`, because it is covered by `ruff` formatter
 - **Breaking**: Removes `WPS304`, because it is covered by `ruff` formatter
+- **Breaking**: Removes `WPS305`, because it is covered by `ruff` formatter
 - **Breaking**: Removes `WPS306`, because it is covered by `ruff` formatter
 - **Breaking**: Removes `WPS310`, because it is covered by `ruff` formatter
 - **Breaking**: Removes `WPS313`, because it is covered by `ruff` formatter

--- a/tests/fixtures/noqa/noqa.py
+++ b/tests/fixtures/noqa/noqa.py
@@ -74,8 +74,7 @@ some_int = 1  # type: int
 
 phone_number = 555_123_999  # noqa:  WPS303
 float_zero = 0.0  # noqa: WPS358
-formatted_string = f'Hi, {full_name}'  # noqa: WPS305
-formatted_string_complex = f'1+1={1 + 1}'  # noqa: WPS305, WPS237
+formatted_string_complex = f'1+1={1 + 1}'  # noqa: WPS237
 
 
 def __getattr__():  # noqa: WPS413

--- a/tests/test_checker/test_noqa.py
+++ b/tests/test_checker/test_noqa.py
@@ -97,7 +97,7 @@ SHOULD_BE_RAISED = types.MappingProxyType({
     'WPS302': 0,  # deprecated since 1.0.0
     'WPS303': 1,
     'WPS304': 0,  # deprecated since 1.0.0
-    'WPS305': 2,
+    'WPS305': 0,
     'WPS306': 0,  # deprecated since 1.0.0
     'WPS307': 1,
     'WPS308': 1,

--- a/tests/test_visitors/test_ast/test_builtins/test_strings/test_alphabet_string.py
+++ b/tests/test_visitors/test_ast/test_builtins/test_strings/test_alphabet_string.py
@@ -5,9 +5,6 @@ import pytest
 from wemake_python_styleguide.violations.best_practices import (
     StringConstantRedefinedViolation,
 )
-from wemake_python_styleguide.violations.consistency import (
-    FormattedStringViolation,
-)
 from wemake_python_styleguide.visitors.ast.builtins import WrongStringVisitor
 
 
@@ -60,7 +57,6 @@ def test_alphabet_as_fstring_violation(
     assert_errors(
         visitor,
         [StringConstantRedefinedViolation],
-        ignored_types=FormattedStringViolation,
     )
 
 

--- a/tests/test_visitors/test_ast/test_builtins/test_strings/test_formatted_string.py
+++ b/tests/test_visitors/test_ast/test_builtins/test_strings/test_formatted_string.py
@@ -118,3 +118,25 @@ def test_complex_f_string(assert_errors, parse_ast_tree, code, default_options):
         visitor,
         [TooComplexFormattedStringViolation],
     )
+
+
+@pytest.mark.parametrize('code', [
+    f_dict_lookup_str_key,
+    f_function_empty_args,
+    f_list_index_lookup,
+    f_variable_lookup,
+    f_single_chained_attr,
+    f_attr_on_function,
+    f_true_index,
+    f_none_index,
+    f_byte_index,
+    f_string_comma_format,
+])
+def test_simple_f_string(assert_errors, parse_ast_tree, code, default_options):
+    """Testing that non complex ``f`` strings are allowed."""
+    tree = parse_ast_tree(code)
+
+    visitor = WrongFormatStringVisitor(default_options, tree=tree)
+    visitor.run()
+
+    assert_errors(visitor, [])

--- a/tests/test_visitors/test_ast/test_builtins/test_strings/test_formatted_string.py
+++ b/tests/test_visitors/test_ast/test_builtins/test_strings/test_formatted_string.py
@@ -3,9 +3,6 @@ import pytest
 from wemake_python_styleguide.violations.complexity import (
     TooComplexFormattedStringViolation,
 )
-from wemake_python_styleguide.violations.consistency import (
-    FormattedStringViolation,
-)
 from wemake_python_styleguide.visitors.ast.builtins import (
     WrongFormatStringVisitor,
     WrongStringVisitor,
@@ -90,7 +87,6 @@ def test_wrong_string(assert_errors, parse_ast_tree, code, default_options):
 
     assert_errors(visitor, [
         TooComplexFormattedStringViolation,
-        FormattedStringViolation,
     ])
 
 
@@ -121,27 +117,4 @@ def test_complex_f_string(assert_errors, parse_ast_tree, code, default_options):
     assert_errors(
         visitor,
         [TooComplexFormattedStringViolation],
-        ignored_types=FormattedStringViolation,
     )
-
-
-@pytest.mark.parametrize('code', [
-    f_dict_lookup_str_key,
-    f_function_empty_args,
-    f_list_index_lookup,
-    f_variable_lookup,
-    f_single_chained_attr,
-    f_attr_on_function,
-    f_true_index,
-    f_none_index,
-    f_byte_index,
-    f_string_comma_format,
-])
-def test_simple_f_string(assert_errors, parse_ast_tree, code, default_options):
-    """Testing that non complex ``f`` strings are allowed."""
-    tree = parse_ast_tree(code)
-
-    visitor = WrongFormatStringVisitor(default_options, tree=tree)
-    visitor.run()
-
-    assert_errors(visitor, [FormattedStringViolation])

--- a/tests/test_visitors/test_ast/test_builtins/test_strings/test_modulo_formatting.py
+++ b/tests/test_visitors/test_ast/test_builtins/test_strings/test_modulo_formatting.py
@@ -4,7 +4,6 @@ from wemake_python_styleguide.violations.complexity import (
     TooComplexFormattedStringViolation,
 )
 from wemake_python_styleguide.violations.consistency import (
-    FormattedStringViolation,
     ModuloStringFormatViolation,
 )
 from wemake_python_styleguide.visitors.ast.builtins import WrongStringVisitor
@@ -99,7 +98,6 @@ def test_modulo_formatting(
     assert_errors(
         visitor,
         [ModuloStringFormatViolation],
-        ignored_types=FormattedStringViolation,
     )
 
 
@@ -148,7 +146,6 @@ def test_regular_modulo_string(
         visitor,
         [],
         ignored_types=(
-            FormattedStringViolation,
             TooComplexFormattedStringViolation,
         ),
     )
@@ -178,7 +175,7 @@ def test_functions_modulo_string(
     visitor = WrongStringVisitor(default_options, tree=tree)
     visitor.run()
 
-    assert_errors(visitor, [], ignored_types=FormattedStringViolation)
+    assert_errors(visitor, [])
 
 
 @pytest.mark.parametrize('code', [

--- a/wemake_python_styleguide/violations/consistency.py
+++ b/wemake_python_styleguide/violations/consistency.py
@@ -357,11 +357,15 @@ class FormattedStringViolation(ASTViolation):
         f'Result is: {2 + 2}'
 
     .. versionadded:: 0.1.0
+    .. versionchanged:: 1.0.0
+       No longer produced, kept here for historic reasons.
+       This is covered with ``ruff`` formatter. See ``WPS237``.
 
     """
 
     error_template = 'Found `f` string'
     code = 305
+    disabled_since = '1.0.0'
 
 
 @final

--- a/wemake_python_styleguide/visitors/ast/builtins.py
+++ b/wemake_python_styleguide/visitors/ast/builtins.py
@@ -160,11 +160,9 @@ class WrongFormatStringVisitor(base.BaseNodeVisitor):
     def visit_JoinedStr(self, node: ast.JoinedStr) -> None:
         """Forbids use of ``f`` strings and too complex ``f`` strings."""
         if not isinstance(nodes.get_parent(node), ast.FormattedValue):
-            # We don't allow `f` strings by default,
-            # But, we need this condition to make sure that this
+            # We need this condition to make sure that this
             # is not a part of complex string format like `f"Count={count:,}"`:
             self._check_complex_formatted_string(node)
-            self.add_violation(consistency.FormattedStringViolation(node))
         self.generic_visit(node)
 
     def _check_complex_formatted_string(self, node: ast.JoinedStr) -> None:


### PR DESCRIPTION
We now allow `f` strings officially. It is not 2018 anymore.