### PR TITLE
Add `WPS534` to find useless ternary expressions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: test
 
-on:
+'on':
   push:
     branches:
       - master

--- a/.github/workflows/wps.yml
+++ b/.github/workflows/wps.yml
@@ -1,6 +1,6 @@
 name: wps
 
-on:
+'on':
   pull_request:
     branches:
       - master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,7 @@ Semantic versioning in our case means:
 
 - Adds official `python3.13` support
 - Allows any compares in `assert` statements for `WPS520`, #3112
-- Allows walrus operator (`:=`) in comprehesions #3121
+- Allows walrus operator (`:=`) in comprehesions, #3121
 - Allows `pass` in `case` bodies, #2642
 - Allows subclassing builtins in `WPS600`, when creating an `Enum`, #2506
 - Allows using variables after blocks for `WPS441` in `assert` statements, #2543
@@ -89,11 +89,12 @@ Semantic versioning in our case means:
 - Allows any number of instance attributes on `@dataclass`es in `WPS230`, #2448
 - Allows any number of function parameters
   in `@overload` definitions for `WPS211`, #1957
-- Adds new rule to forbid `lambda` assigns to special attributes, #1733
-- Adds new rule to check problematic function params, #1343
-- Adds new rule to detect duplicate conditions in `if`s and `elif`s, #2241
+- Adds a new rule to forbid `lambda` assigns to special attributes, #1733
+- Adds a new rule to check problematic function params, #1343
+- Adds a new rule to detect duplicate conditions in `if`s and `elif`s, #2241
 - Adds a new rule to find too complex `except` with too many exceptions
-- Adds a new rule to find too many PEP695 type params
+- Adds a new rule to find too many `PEP695` type params
+- Adds a new rule to find useless ternary expressions, #1706
 - Adds support to run `wemake-python-styleguide` as a `pre-commit` hook, #2588
 - GitHub Action can now use `cwd:` parameter to specify
   where your configuration file is, #2474

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -189,6 +189,7 @@ inline-quotes = "single"
 # The mypy configurations: http://bit.ly/2zEl9WI
 ignore_missing_imports = true
 strict = true
+local_partial_types = true
 warn_unreachable = true
 
 enable_error_code = [
@@ -199,13 +200,14 @@ enable_error_code = [
   # "ignore-without-code",
   "possibly-undefined",
   "redundant-self",
+  # "explicit-override",
   # "mutable-override",
   "unimported-reveal",
   "deprecated",
 ]
 
 disable_error_code = [
-  "no-untyped-def",
+  "no-untyped-def",  # TODO: fix
 ]
 
 [[tool.mypy.overrides]]

--- a/tests/fixtures/noqa/noqa.py
+++ b/tests/fixtures/noqa/noqa.py
@@ -671,6 +671,8 @@ if noqa_wps533:  # noqa: WPS533
 elif noqa_wps533:
     my_print('2')
 
+noqa_wps534 = second if first == second else first  # noqa: WPS534
+
 class Baseline:
     def method(self, number):
         return number + 1

--- a/tests/test_checker/test_noqa.py
+++ b/tests/test_checker/test_noqa.py
@@ -265,6 +265,7 @@ SHOULD_BE_RAISED = types.MappingProxyType(
         'WPS531': 0,  # disabled since 1.0.0
         'WPS532': 1,
         'WPS533': 1,
+        'WPS534': 1,
         'WPS600': 1,
         'WPS601': 1,
         'WPS602': 2,

--- a/tests/test_visitors/test_ast/test_conditions/test_useless_ternary.py
+++ b/tests/test_visitors/test_ast/test_conditions/test_useless_ternary.py
@@ -1,0 +1,76 @@
+import pytest
+
+from wemake_python_styleguide.violations.refactoring import (
+    NegatedConditionsViolation,
+    UselessTernaryViolation,
+)
+from wemake_python_styleguide.visitors.ast.conditions import IfStatementVisitor
+
+template = '{0} if {1} else {2}'
+
+
+@pytest.mark.parametrize(
+    ('left', 'compare', 'right'),
+    [
+        ('x', 'condition', 'y'),
+        ('x', 'x > y', 'y'),
+        ('x', 'x == y and y > 0', 'y'),
+        ('2', 'x == y', 'call().attr'),
+        ('a', 'x == y', 'b'),
+        ('x[0]', 'x == y', 'x[1]'),
+        ('x[0]', 'x[0] == y[1]', 'y[0]'),
+        ('a.x', 'x == y', 'b.y'),
+        ('call.method()', 'x != y', 'obj.attr'),
+    ],
+)
+def test_useful_ternary(
+    assert_errors,
+    parse_ast_tree,
+    left,
+    compare,
+    right,
+    default_options,
+):
+    """Testing that correct code works."""
+    tree = parse_ast_tree(template.format(left, compare, right))
+
+    visitor = IfStatementVisitor(default_options, tree=tree)
+    visitor.run()
+
+    assert_errors(visitor, [], ignored_types=NegatedConditionsViolation)
+
+
+@pytest.mark.parametrize(
+    ('left', 'compare', 'right'),
+    [
+        ('x', 'x == y', 'y'),
+        ('[x]', '[x] == [y]', '[y]'),
+        ('{x}', '{x} == {y}', '{y}'),
+        ('(x,)', '(x,) == (y,)', '(y,)'),
+        ('x.a', 'x.a == y.b', 'y.b'),
+        ('x.a', 'x.a is None', 'None'),
+        ('None', 'x[0] is None', 'x[0]'),
+        ('False', 'x[0] is False', 'x[0]'),
+        ('x[0]', 'x[0] is not None', 'None'),
+        ('x.attr[0]', 'x.attr[0] != y.b', 'y.b'),
+    ],
+)
+def test_useless_ternary(
+    assert_errors,
+    parse_ast_tree,
+    left,
+    compare,
+    right,
+    default_options,
+):
+    """Testing that incorrect code raises a violation."""
+    tree = parse_ast_tree(template.format(left, compare, right))
+
+    visitor = IfStatementVisitor(default_options, tree=tree)
+    visitor.run()
+
+    assert_errors(
+        visitor,
+        [UselessTernaryViolation],
+        ignored_types=NegatedConditionsViolation,
+    )

--- a/wemake_python_styleguide/logic/tree/attributes.py
+++ b/wemake_python_styleguide/logic/tree/attributes.py
@@ -2,7 +2,7 @@ import ast
 from collections.abc import Iterable
 
 from wemake_python_styleguide.constants import SPECIAL_ARGUMENT_NAMES_WHITELIST
-from wemake_python_styleguide.types import AnyChainable, AnyVariableDef
+from wemake_python_styleguide.types import AnyNodes, AnyVariableDef
 
 
 def _chained_item(iterator: ast.AST) -> ast.AST | None:
@@ -13,7 +13,7 @@ def _chained_item(iterator: ast.AST) -> ast.AST | None:
     return None
 
 
-def parts(node: AnyChainable) -> Iterable[ast.AST]:
+def parts(node: ast.AST) -> Iterable[ast.AST]:
     """
     Returns all ``.`` separated elements for attributes, subscripts and calls.
 
@@ -25,7 +25,7 @@ def parts(node: AnyChainable) -> Iterable[ast.AST]:
 
     We need all parts from it.
     """
-    iterator: ast.AST = node
+    iterator = node
 
     while True:
         yield iterator
@@ -34,6 +34,11 @@ def parts(node: AnyChainable) -> Iterable[ast.AST]:
         if chained_item is None:
             return
         iterator = chained_item
+
+
+def only_consists_of_parts(node: ast.AST, allowed: AnyNodes) -> bool:
+    """Returns `True` if some node consists of only given parts."""
+    return all(isinstance(part, allowed) for part in parts(node))
 
 
 def is_foreign_attribute(node: AnyVariableDef) -> bool:

--- a/wemake_python_styleguide/logic/tree/classes.py
+++ b/wemake_python_styleguide/logic/tree/classes.py
@@ -23,6 +23,7 @@ _DATACLASS_NAMES: Final = frozenset((
     'attr.attributes',
     'attr.frozen',
     'attr.mutable',
+    'attr.dataclass',
     # pydantic also has `dataclass` and `dataclasses.dataclass`
 ))
 

--- a/wemake_python_styleguide/violations/refactoring.py
+++ b/wemake_python_styleguide/violations/refactoring.py
@@ -47,6 +47,7 @@ Summary
    SimplifiableReturningIfViolation
    ChainedIsViolation
    DuplicateIfConditionViolation
+   UselessTernaryViolation
 
 Refactoring opportunities
 -------------------------
@@ -85,6 +86,7 @@ Refactoring opportunities
 .. autoclass:: SimplifiableReturningIfViolation
 .. autoclass:: ChainedIsViolation
 .. autoclass:: DuplicateIfConditionViolation
+.. autoclass:: UselessTernaryViolation
 
 """
 
@@ -1323,3 +1325,32 @@ class DuplicateIfConditionViolation(ASTViolation):
 
     error_template = 'Found duplicate condition in `if`: {0}'
     code = 533
+
+
+@final
+class UselessTernaryViolation(ASTViolation):
+    """
+    Forbid having useless ternary expressions.
+
+    Reasoning:
+        When ternary expression can be replaced with a single name,
+        it is way more readable and more performant.
+
+    Solution:
+        Remove the ternary expression.
+
+    Example::
+
+        # Correct:
+        first if some_condition else second
+
+        # Wrong:
+        a if a is not None else None
+        b if a == b else a
+
+    .. versionadded:: 1.0.0
+
+    """
+
+    error_template = 'Found useless ternary expression'
+    code = 534

--- a/wemake_python_styleguide/visitors/ast/conditions.py
+++ b/wemake_python_styleguide/visitors/ast/conditions.py
@@ -15,7 +15,6 @@ from wemake_python_styleguide.logic.tree import (
     ifs,
     operators,
 )
-from wemake_python_styleguide.logic.tree.compares import CompareBounds
 from wemake_python_styleguide.logic.tree.functions import given_function_called
 from wemake_python_styleguide.types import AnyIf, AnyNodes
 from wemake_python_styleguide.violations import (
@@ -100,7 +99,8 @@ class IfStatementVisitor(BaseNodeVisitor):
         if not isinstance(node, ast.IfExp):
             return
 
-        if not isinstance(node.test, ast.Compare) or len(node.test.ops) > 1:
+        comp = node.test
+        if not isinstance(comp, ast.Compare) or len(comp.ops) > 1:
             return  # We only check for compares with exactly one op
 
         if not attributes.only_consists_of_parts(
@@ -114,9 +114,9 @@ class IfStatementVisitor(BaseNodeVisitor):
 
         if compares.is_useless_ternary(
             node,
-            node.test.ops[0],
-            node.test.left,
-            node.test.comparators[0],
+            comp.ops[0],
+            comp.left,
+            comp.comparators[0],
         ):
             self.add_violation(refactoring.UselessTernaryViolation(node))
 
@@ -201,7 +201,7 @@ class ImplicitBoolPatternsVisitor(BaseNodeVisitor):
         if not isinstance(node.op, ast.And):
             return
 
-        if not CompareBounds(node).is_valid():
+        if not compares.CompareBounds(node).is_valid():
             self.add_violation(
                 consistency.ImplicitComplexCompareViolation(node),
             )


### PR DESCRIPTION
Closes #1706 
Closes https://github.com/wemake-services/wemake-python-styleguide/pull/2579