### PR TITLE
Fixes `WPS314` not detecting `match` statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,7 @@ Semantic versioning in our case means:
 - Fixes several bugs in `WPS322` with multiline strings detection
 - Fixes several violations not been detected in `case:` statements
 - Fixes `WPS434` not detecting reassignments in `:=` case
+- Fixes `WPS314` not detecting `match` statements
 
 ### Misc
 

--- a/tests/test_visitors/test_ast/test_compares/test_conditionals.py
+++ b/tests/test_visitors/test_ast/test_compares/test_conditionals.py
@@ -43,6 +43,11 @@ def container():
     (x for x in [1, 2, 3] if {0})
 """
 
+match_statement = """
+match {0}:
+    case SomeClassName(FirstParentClass): ...
+"""
+
 
 @pytest.mark.parametrize(
     'code',
@@ -53,6 +58,7 @@ def container():
         set_comprehension,
         dict_comprehension,
         gen_comprehension,
+        match_statement,
     ],
 )
 @pytest.mark.parametrize(
@@ -96,6 +102,7 @@ def test_valid_conditional(
         set_comprehension,
         dict_comprehension,
         gen_comprehension,
+        match_statement,
     ],
 )
 @pytest.mark.parametrize(

--- a/wemake_python_styleguide/violations/consistency.py
+++ b/wemake_python_styleguide/violations/consistency.py
@@ -661,7 +661,7 @@ class MissingSpaceBetweenKeywordAndParenViolation(TokenizeViolation):
 @final
 class ConstantConditionViolation(ASTViolation):
     """
-    Forbid using ``if`` statements that use invalid conditionals.
+    Forbid using ``if`` or ``match`` statements that use invalid conditionals.
 
     Reasoning:
         When invalid conditional arguments are used
@@ -675,9 +675,14 @@ class ConstantConditionViolation(ASTViolation):
 
         # Correct:
         if value is True: ...
+        match value:
+            case True:
+                ...
 
         # Wrong:
         if True: ...
+        match True:
+            case True: ...
 
     .. versionadded:: 0.3.0
 

--- a/wemake_python_styleguide/visitors/ast/compares.py
+++ b/wemake_python_styleguide/visitors/ast/compares.py
@@ -200,6 +200,11 @@ class WrongConditionalVisitor(BaseNodeVisitor):
             self._check_constant_condition(expr)
         self.generic_visit(node)
 
+    def visit_Match(self, node: ast.Match) -> None:
+        """Ensures that ``match`` nodes are using valid conditionals."""
+        self._check_constant_condition(node.subject)
+        self.generic_visit(node)
+
     def _check_constant_condition(self, node: ast.AST) -> None:
         if isinstance(node, ast.BoolOp):
             for condition in node.values:


### PR DESCRIPTION
# Fixes `WPS314` not detecting `match` statements

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Checklist

<!-- Please check everything that applies: -->

- [X] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [X] I have created at least one test case for the changes I have made
- [X] I have updated the documentation for the changes I have made
- [X] I have added my changes to the `CHANGELOG.md`

## Related issues

fixes #3207

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
