### PR TITLE
Adds `WPS241` which forbids to have too many subjects in `match` statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@ Semantic versioning in our case means:
 - Adds a new rule to check problematic function params, #1343
 - Adds a new rule to detect duplicate conditions in `if`s and `elif`s, #2241
 - Adds a new rule to detect duplicate `case` pattens in `match`, #3206
+- Adds a new rule to find many `match` subjects, #3201
 - Adds a new rule to find too complex `except` with too many exceptions
 - Adds a new rule to find too many `PEP695` type params
 - Adds a new rule to find useless ternary expressions, #1706

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,7 +101,7 @@ Semantic versioning in our case means:
 - Adds a new rule to check problematic function params, #1343
 - Adds a new rule to detect duplicate conditions in `if`s and `elif`s, #2241
 - Adds a new rule to detect duplicate `case` pattens in `match`, #3206
-- Adds a new rule to find many `match` subjects, #3201
+- Adds a new rule to find too many `match` subjects, #3201
 - Adds a new rule to find too complex `except` with too many exceptions
 - Adds a new rule to find too many `PEP695` type params
 - Adds a new rule to find useless ternary expressions, #1706

--- a/tests/fixtures/noqa/noqa.py
+++ b/tests/fixtures/noqa/noqa.py
@@ -631,6 +631,11 @@ except (TypeError, ValueError, LookupError, KeyboardInterrupt):  # noqa: WPS239
     my_print('except')
 
 
+match inst1, inst2, inst3, inst4, inst5, inst6, inst7, inst8:  # noqa: WPS241
+    case 1:
+        my_print('except')
+
+
 my_print("""
 text
 """)  # noqa: WPS462

--- a/tests/test_checker/test_noqa.py
+++ b/tests/test_checker/test_noqa.py
@@ -92,6 +92,7 @@ SHOULD_BE_RAISED = types.MappingProxyType(
         'WPS238': 1,
         'WPS239': 1,
         'WPS240': 0,  # only triggers on 3.12+
+        'WPS241': 0,
         'WPS300': 1,
         'WPS301': 1,
         'WPS302': 0,  # disabled since 1.0.0

--- a/tests/test_checker/test_noqa.py
+++ b/tests/test_checker/test_noqa.py
@@ -92,7 +92,7 @@ SHOULD_BE_RAISED = types.MappingProxyType(
         'WPS238': 1,
         'WPS239': 1,
         'WPS240': 0,  # only triggers on 3.12+
-        'WPS241': 0,
+        'WPS241': 1,
         'WPS300': 1,
         'WPS301': 1,
         'WPS302': 0,  # disabled since 1.0.0

--- a/tests/test_visitors/test_ast/test_compares/test_conditionals.py
+++ b/tests/test_visitors/test_ast/test_compares/test_conditionals.py
@@ -7,11 +7,6 @@ from wemake_python_styleguide.visitors.ast.compares import (
     WrongConditionalVisitor,
 )
 
-create_variable = """
-variable = 1
-{0}
-"""
-
 if_statement = 'if {0}: ...'
 ternary = 'ternary = 0 if {0} else 1'
 
@@ -83,9 +78,7 @@ def test_valid_conditional(
     mode,
 ):
     """Testing that conditionals work well."""
-    tree = parse_ast_tree(
-        mode(create_variable.format(code.format(comparators))),
-    )
+    tree = parse_ast_tree(mode(code.format(comparators)))
 
     visitor = WrongConditionalVisitor(default_options, tree=tree)
     visitor.run()
@@ -121,6 +114,7 @@ def test_valid_conditional(
         '("tuple",)',
         '[]',
         '[variable]',
+        '(1, var)',
         'variable or False',
         'variable and False',
         'variable or True',
@@ -139,9 +133,7 @@ def test_constant_condition(
     mode,
 ):
     """Testing that violations are when using invalid conditional."""
-    tree = parse_ast_tree(
-        mode(create_variable.format(code.format(comparators))),
-    )
+    tree = parse_ast_tree(mode(code.format(comparators)))
 
     visitor = WrongConditionalVisitor(default_options, tree=tree)
     visitor.run()
@@ -166,6 +158,7 @@ def test_constant_condition(
         '("tuple",)',
         '[]',
         '[1, 2]',
+        '(1, 2)',
         'variable or False',
         'variable and False',
         'variable or True',
@@ -180,11 +173,10 @@ def test_constant_condition_in_match(
     parse_ast_tree,
     comparators,
     default_options,
-    mode,
 ):
     """Testing that violations are when using invalid conditional in PM."""
     tree = parse_ast_tree(
-        mode(create_variable.format(match_statement.format(comparators))),
+        match_statement.format(comparators),
     )
 
     visitor = WrongConditionalVisitor(default_options, tree=tree)
@@ -202,6 +194,7 @@ def test_constant_condition_in_match(
         '[x, y]',
         '{test : "1"}',
         '{test}',
+        '(x, y)',
         '{**keys, "data": None}',
         'variable or other',
         'variable and other',
@@ -212,11 +205,10 @@ def test_regular_condition_in_match(
     parse_ast_tree,
     comparators,
     default_options,
-    mode,
 ):
     """Testing correct conditional in PM."""
     tree = parse_ast_tree(
-        mode(create_variable.format(match_statement.format(comparators))),
+        match_statement.format(comparators),
     )
 
     visitor = WrongConditionalVisitor(default_options, tree=tree)

--- a/tests/test_visitors/test_ast/test_complexity/test_pm/test_match_subjects.py
+++ b/tests/test_visitors/test_ast/test_complexity/test_pm/test_match_subjects.py
@@ -1,45 +1,25 @@
 import pytest
 
-from wemake_python_styleguide.violations.complexity import TooManyMatchSubjectsViolation
-from wemake_python_styleguide.visitors.ast.complexity.pm import MatchSubjectsVisitor
+from wemake_python_styleguide.violations.complexity import (
+    TooManyMatchSubjectsViolation,
+)
+from wemake_python_styleguide.visitors.ast.complexity.pm import (
+    MatchSubjectsVisitor,
+)
 
+match_subjects9 = """
+match a, b, c, d, e, f, g, h, i:
+    case 1: ...
+"""
+match_subjects8 = """
+match a, b, c, d, e, f, g, h:
+    case 1: ...
+"""
 
-match_subjects7 = '''
-match some_value:
-    case x | y | z:
-        pass
-    case a | b | c:
-        pass
-    case d | e | f:
-        pass
-    case g | h | i:
-        pass
-    case j | k | l:
-        pass
-    case m | n | o:
-        pass
-    case p | q | r:
-        pass
-'''
-match_subjects6 = '''
-match some_value:
-    case x | y | z:
-        pass
-    case a | b | c:
-        pass
-    case d | e | f:
-        pass
-    case g | h | i:
-        pass
-    case j | k | l:
-        pass
-    case m | n | o:
-        pass
-'''
 
 @pytest.mark.parametrize(
     'code',
-    [match_subjects7],
+    [match_subjects9],
 )
 def test_match_subjects_wrong_count(
     assert_errors,
@@ -55,12 +35,12 @@ def test_match_subjects_wrong_count(
     visitor.run()
 
     assert_errors(visitor, [TooManyMatchSubjectsViolation])
-    assert_error_text(visitor, '8', baseline=default_options.max_match_subjects)
+    assert_error_text(visitor, '9', baseline=default_options.max_match_subjects)
 
 
 @pytest.mark.parametrize(
     'code',
-    [match_subjects6],
+    [match_subjects8],
 )
 def test_match_subjects_correct_count(
     assert_errors,
@@ -80,8 +60,8 @@ def test_match_subjects_correct_count(
 @pytest.mark.parametrize(
     'code',
     [
-        match_subjects6,
-        match_subjects7,
+        match_subjects9,
+        match_subjects8,
     ],
 )
 def test_match_subjects_configured_count(
@@ -93,11 +73,8 @@ def test_match_subjects_configured_count(
     """Testing that settings can reflect the change for match subjects."""
     tree = parse_ast_tree(code)
 
-    option_values = options(max_match_subjects=6)
+    option_values = options(max_match_subjects=3)
     visitor = MatchSubjectsVisitor(option_values, tree=tree)
     visitor.run()
 
-    if code == match_subjects7:
-        assert_errors(visitor, [TooManyMatchSubjectsViolation])
-    else:
-        assert_errors(visitor, [])
+    assert_errors(visitor, [TooManyMatchSubjectsViolation])

--- a/tests/test_visitors/test_ast/test_complexity/test_pm/test_match_subjects.py
+++ b/tests/test_visitors/test_ast/test_complexity/test_pm/test_match_subjects.py
@@ -7,40 +7,50 @@ from wemake_python_styleguide.visitors.ast.complexity.pm import (
     MatchSubjectsVisitor,
 )
 
-match_subjects9 = """
-match a, b, c, d, e, f, g, h, i:
+match_call_expr = """
+match some_call():
     case 1: ...
 """
+
+match_case_long_tuple = """
+match some_call['a']:
+    case (a, b, c, d, e, f, g, h, i): ...
+"""
+
 match_subjects8 = """
-match a, b, c, d, e, f, g, h:
+match a1, b2, c3, d4, e5, f6, g7, h8:
+    case 1: ...
+"""
+
+match_subjects7 = """
+match a1, b2, c3, d4, e5, f6, g7:
     case 1: ...
 """
 
 
-@pytest.mark.parametrize(
-    'code',
-    [match_subjects9],
-)
 def test_match_subjects_wrong_count(
     assert_errors,
     assert_error_text,
     parse_ast_tree,
-    code,
     default_options,
 ):
     """Testing that default settings raise a warning."""
-    tree = parse_ast_tree(code)
+    tree = parse_ast_tree(match_subjects8)
 
     visitor = MatchSubjectsVisitor(default_options, tree=tree)
     visitor.run()
 
     assert_errors(visitor, [TooManyMatchSubjectsViolation])
-    assert_error_text(visitor, '9', baseline=default_options.max_match_subjects)
+    assert_error_text(visitor, '8', baseline=default_options.max_match_subjects)
 
 
 @pytest.mark.parametrize(
     'code',
-    [match_subjects8],
+    [
+        match_subjects7,
+        match_call_expr,
+        match_case_long_tuple,
+    ],
 )
 def test_match_subjects_correct_count(
     assert_errors,
@@ -60,8 +70,8 @@ def test_match_subjects_correct_count(
 @pytest.mark.parametrize(
     'code',
     [
-        match_subjects9,
         match_subjects8,
+        match_subjects7,
     ],
 )
 def test_match_subjects_configured_count(
@@ -73,7 +83,7 @@ def test_match_subjects_configured_count(
     """Testing that settings can reflect the change."""
     tree = parse_ast_tree(code)
 
-    option_values = options(max_match_subjects=3)
+    option_values = options(max_match_subjects=1)
     visitor = MatchSubjectsVisitor(option_values, tree=tree)
     visitor.run()
 

--- a/tests/test_visitors/test_ast/test_complexity/test_pm/test_match_subjects.py
+++ b/tests/test_visitors/test_ast/test_complexity/test_pm/test_match_subjects.py
@@ -28,7 +28,7 @@ def test_match_subjects_wrong_count(
     code,
     default_options,
 ):
-    """Testing that default settings raise a warning for too many match subjects."""
+    """Testing that default settings raise a warning."""
     tree = parse_ast_tree(code)
 
     visitor = MatchSubjectsVisitor(default_options, tree=tree)
@@ -48,7 +48,7 @@ def test_match_subjects_correct_count(
     code,
     default_options,
 ):
-    """Testing that default settings do not raise a warning for correct match subjects count."""
+    """Testing that default settings do not raise a warning."""
     tree = parse_ast_tree(code)
 
     visitor = MatchSubjectsVisitor(default_options, tree=tree)
@@ -70,7 +70,7 @@ def test_match_subjects_configured_count(
     code,
     options,
 ):
-    """Testing that settings can reflect the change for match subjects."""
+    """Testing that settings can reflect the change."""
     tree = parse_ast_tree(code)
 
     option_values = options(max_match_subjects=3)

--- a/tests/test_visitors/test_ast/test_complexity/test_pm/test_match_subjects.py
+++ b/tests/test_visitors/test_ast/test_complexity/test_pm/test_match_subjects.py
@@ -1,0 +1,103 @@
+import pytest
+
+from wemake_python_styleguide.violations.complexity import TooManyMatchSubjectsViolation
+from wemake_python_styleguide.visitors.ast.complexity.pm import MatchSubjectsVisitor
+
+
+match_subjects7 = '''
+match some_value:
+    case x | y | z:
+        pass
+    case a | b | c:
+        pass
+    case d | e | f:
+        pass
+    case g | h | i:
+        pass
+    case j | k | l:
+        pass
+    case m | n | o:
+        pass
+    case p | q | r:
+        pass
+'''
+match_subjects6 = '''
+match some_value:
+    case x | y | z:
+        pass
+    case a | b | c:
+        pass
+    case d | e | f:
+        pass
+    case g | h | i:
+        pass
+    case j | k | l:
+        pass
+    case m | n | o:
+        pass
+'''
+
+@pytest.mark.parametrize(
+    'code',
+    [match_subjects7],
+)
+def test_match_subjects_wrong_count(
+    assert_errors,
+    assert_error_text,
+    parse_ast_tree,
+    code,
+    default_options,
+):
+    """Testing that default settings raise a warning for too many match subjects."""
+    tree = parse_ast_tree(code)
+
+    visitor = MatchSubjectsVisitor(default_options, tree=tree)
+    visitor.run()
+
+    assert_errors(visitor, [TooManyMatchSubjectsViolation])
+    assert_error_text(visitor, '8', baseline=default_options.max_match_subjects)
+
+
+@pytest.mark.parametrize(
+    'code',
+    [match_subjects6],
+)
+def test_match_subjects_correct_count(
+    assert_errors,
+    parse_ast_tree,
+    code,
+    default_options,
+):
+    """Testing that default settings do not raise a warning for correct match subjects count."""
+    tree = parse_ast_tree(code)
+
+    visitor = MatchSubjectsVisitor(default_options, tree=tree)
+    visitor.run()
+
+    assert_errors(visitor, [])
+
+
+@pytest.mark.parametrize(
+    'code',
+    [
+        match_subjects6,
+        match_subjects7,
+    ],
+)
+def test_match_subjects_configured_count(
+    assert_errors,
+    parse_ast_tree,
+    code,
+    options,
+):
+    """Testing that settings can reflect the change for match subjects."""
+    tree = parse_ast_tree(code)
+
+    option_values = options(max_match_subjects=6)
+    visitor = MatchSubjectsVisitor(option_values, tree=tree)
+    visitor.run()
+
+    if code == match_subjects7:
+        assert_errors(visitor, [TooManyMatchSubjectsViolation])
+    else:
+        assert_errors(visitor, [])

--- a/wemake_python_styleguide/logic/tree/compares.py
+++ b/wemake_python_styleguide/logic/tree/compares.py
@@ -2,10 +2,9 @@ import ast
 import types
 from collections import defaultdict
 from collections.abc import Mapping
-from typing import Final, TypeAlias
+from typing import Final, TypeAlias, final
 
 import attr
-from typing_extensions import final
 
 from wemake_python_styleguide.logic import source
 

--- a/wemake_python_styleguide/logic/tree/pattern_matching.py
+++ b/wemake_python_styleguide/logic/tree/pattern_matching.py
@@ -2,7 +2,11 @@ import ast
 from collections.abc import Iterable
 
 from wemake_python_styleguide.logic.nodes import get_parent
+from wemake_python_styleguide.logic.tree import (
+    operators,
+)
 from wemake_python_styleguide.logic.walk import get_subnodes_by_type
+from wemake_python_styleguide.logic.walrus import get_assigned_expr
 
 
 def get_explicit_as_names(
@@ -21,3 +25,23 @@ def get_explicit_as_names(
             and match_as.name
         ):
             yield match_as
+
+
+def is_constant_subject(condition: ast.AST | list[ast.expr]) -> bool:
+    """Detect constant subjects for `ast.Match` nodes."""
+    if isinstance(condition, list):
+        return all(is_constant_subject(node) for node in condition)
+    node = operators.unwrap_unary_node(get_assigned_expr(condition))
+    if isinstance(node, ast.Constant):
+        return True
+    if isinstance(node, ast.Tuple | ast.List | ast.Set):
+        return is_constant_subject(node.elts)
+    if isinstance(node, ast.Dict):
+        return (
+            not any(dict_key is None for dict_key in node.keys)
+            and is_constant_subject([
+                dict_key for dict_key in node.keys if dict_key is not None
+            ])
+            and is_constant_subject(node.values)
+        )
+    return False

--- a/wemake_python_styleguide/options/config.py
+++ b/wemake_python_styleguide/options/config.py
@@ -153,6 +153,9 @@ You can also show all options that ``flake8`` supports by running:
 - ``max-type-params`` - maximum number of PEP695 type parameters,
     defaults to
     :str:`wemake_python_styleguide.options.defaults.MAX_TYPE_PARAMS`
+- ``max-match-subjects`` - maximum number of subjects in a match statement,
+    defaults to
+    :str:`wemake_python_styleguide.options.defaults.MAX_MATCH_SUBJECTS`
 
 .. rubric:: Formatter options
 
@@ -422,6 +425,11 @@ class Configuration:
             '--max-type-params',
             defaults.MAX_TYPE_PARAMS,
             'Maximum number of PEP695 type parameters.',
+        ),
+        _Option(
+            '--max-match-subjects',
+            defaults.MAX_MATCH_SUBJECTS,
+            'Maximum number of subjects in a match statement.',
         ),
         # Formatter:
         _Option(

--- a/wemake_python_styleguide/options/defaults.py
+++ b/wemake_python_styleguide/options/defaults.py
@@ -140,6 +140,9 @@ MAX_TUPLE_UNPACK_LENGTH: Final = 4  # guessed
 #: Maximum number of PEP695 type parameters.
 MAX_TYPE_PARAMS: Final = 6  # guessed
 
+#: Maximum number of subjects in a ``match`` statement.
+MAX_MATCH_SUBJECTS: Final = 8  # guessed
+
 # ==========
 # Formatter:
 # ==========

--- a/wemake_python_styleguide/options/defaults.py
+++ b/wemake_python_styleguide/options/defaults.py
@@ -138,10 +138,10 @@ MAX_IMPORT_FROM_MEMBERS: Final = 8  # guessed
 MAX_TUPLE_UNPACK_LENGTH: Final = 4  # guessed
 
 #: Maximum number of PEP695 type parameters.
-MAX_TYPE_PARAMS: Final = 6  # guessed
+MAX_TYPE_PARAMS: Final = 6  # 7-1, guessed
 
 #: Maximum number of subjects in a ``match`` statement.
-MAX_MATCH_SUBJECTS: Final = 8  # guessed
+MAX_MATCH_SUBJECTS: Final = 7  # 7 +- 0, guessed
 
 # ==========
 # Formatter:

--- a/wemake_python_styleguide/options/validation.py
+++ b/wemake_python_styleguide/options/validation.py
@@ -98,6 +98,7 @@ class _ValidatedOptions:
     max_import_from_members: int = attr.ib(validator=[_min_max(min=1)])
     max_tuple_unpack_length: int = attr.ib(validator=[_min_max(min=1)])
     max_type_params: int = attr.ib(validator=[_min_max(min=1)])
+    max_match_subjects: int = attr.ib(validator=[_min_max(min=1)])
     show_violation_links: bool
     exps_for_one_empty_line: int
 

--- a/wemake_python_styleguide/presets/topics/complexity.py
+++ b/wemake_python_styleguide/presets/topics/complexity.py
@@ -12,6 +12,7 @@ from wemake_python_styleguide.visitors.ast.complexity import (  # noqa: WPS235
     nested,
     offset,
     overuses,
+    pm,
 )
 
 #: Used to store all complexity related visitors to be later passed to checker:
@@ -36,4 +37,5 @@ PRESET: Final = (
     access.AccessVisitor,
     calls.CallChainsVisitor,
     annotations.AnnotationComplexityVisitor,
+    pm.MatchSubjectsVisitor,
 )

--- a/wemake_python_styleguide/types.py
+++ b/wemake_python_styleguide/types.py
@@ -231,3 +231,6 @@ class ConfigurationOptions(Protocol):
 
     @property
     def exps_for_one_empty_line(self) -> int: ...
+
+    @property
+    def max_match_subjects(self) -> int: ...

--- a/wemake_python_styleguide/violations/complexity.py
+++ b/wemake_python_styleguide/violations/complexity.py
@@ -61,6 +61,7 @@ Summary
    TooManyRaisesViolation
    TooManyExceptExceptionsViolation
    TooManyTypeParamsViolation
+   TooManyMatchSubjectsViolation
 
 Module complexity
 -----------------
@@ -105,6 +106,7 @@ Structure complexity
 .. autoclass:: TooManyRaisesViolation
 .. autoclass:: TooManyExceptExceptionsViolation
 .. autoclass:: TooManyTypeParamsViolation
+.. autoclass:: TooManyMatchSubjectsViolation
 
 """
 
@@ -1329,3 +1331,30 @@ class TooManyTypeParamsViolation(ASTViolation):
 
     error_template = 'Found too many type params: {0}'
     code = 240
+
+
+@final
+class TooManyMatchSubjectsViolation(ASTViolation):
+    """
+    Forbids to have too many subjects in ``match`` statements.
+
+    Reasoning:
+        Too many subjects in a ``match`` statement make the code
+        difficult to read and maintain. It indicates that the logic
+        could be simplified or broken down into smaller components.
+
+    Solution:
+        Refactor the ``match`` statement to reduce the number of subjects.
+        Consider splitting the logic into multiple ``match`` statements
+        or functions to improve clarity and maintainability.
+
+    Configuration:
+        This rule is configurable with ``--max-match-subjects``.
+        Default:
+        :str:`wemake_python_styleguide.options.defaults.MAX_MATCH_SUBJECTS`
+
+    .. versionadded:: 1.0.0
+
+    """
+    error_template = 'Found too many subjects in `match` statement: {0}'
+    code = 241

--- a/wemake_python_styleguide/violations/complexity.py
+++ b/wemake_python_styleguide/violations/complexity.py
@@ -1356,5 +1356,6 @@ class TooManyMatchSubjectsViolation(ASTViolation):
     .. versionadded:: 1.0.0
 
     """
+
     error_template = 'Found too many subjects in `match` statement: {0}'
     code = 241

--- a/wemake_python_styleguide/visitors/ast/complexity/pm.py
+++ b/wemake_python_styleguide/visitors/ast/complexity/pm.py
@@ -1,33 +1,28 @@
 import ast
-
-from typing_extensions import final
+from typing import final
 
 from wemake_python_styleguide.violations import complexity
 from wemake_python_styleguide.visitors.base import BaseNodeVisitor
-from wemake_python_styleguide.visitors.decorators import alias
 
 
 @final
-@alias(
-    'visit_match',
-    ('visit_Match',),
-)
 class MatchSubjectsVisitor(BaseNodeVisitor):
     """Finds excessive match subjects in `match` statements."""
 
-    def visit_match(self, node: ast.Match) -> None:
+    def visit_Match(self, node: ast.Match) -> None:
         """Finds all `match` statements and checks their subjects."""
         self._check_match_subjects_count(node)
         self.generic_visit(node)
 
     def _check_match_subjects_count(self, node: ast.Match) -> None:
-        if isinstance(node.subject, ast.Tuple):
-            elts = node.subject.elts
-            if len(elts) > self.options.max_match_subjects:
-                self.add_violation(
-                    complexity.TooManyMatchSubjectsViolation(
-                        node,
-                        text=str(len(elts)),
-                        baseline=self.options.max_match_subjects,
-                    )
-                )
+        if not isinstance(node.subject, ast.Tuple):
+            return
+        if len(node.subject.elts) <= self.options.max_match_subjects:
+            return
+        self.add_violation(
+            complexity.TooManyMatchSubjectsViolation(
+                node,
+                text=str(len(node.subject.elts)),
+                baseline=self.options.max_match_subjects,
+            )
+        )

--- a/wemake_python_styleguide/visitors/ast/complexity/pm.py
+++ b/wemake_python_styleguide/visitors/ast/complexity/pm.py
@@ -1,0 +1,31 @@
+import ast
+from typing_extensions import final
+
+from wemake_python_styleguide.violations import complexity
+from wemake_python_styleguide.visitors.base import BaseNodeVisitor
+from wemake_python_styleguide.visitors.decorators import alias
+
+
+@final
+@alias(
+    'visit_match',
+    ('visit_Match',)
+)
+class MatchSubjectsVisitor(BaseNodeVisitor):
+    """Finds excessive match subjects in `match` statements."""
+
+    def visit_match(self, node: ast.Match) -> None:
+        """Finds all `match` statements and checks their subjects."""
+        self._check_match_subjects_count(node)
+        self.generic_visit(node)
+
+    def _check_match_subjects_count(self, node: ast.Match) -> None:
+        match_subjects = getattr(node, 'subjects', [])
+        if len(match_subjects) > self.options.max_match_subjects:
+            self.add_violation(
+                complexity.TooManyMatchSubjectsViolation(
+                    node,
+                    text=str(len(match_subjects)),
+                    baseline=self.options.max_match_subjects,
+                )
+            )

--- a/wemake_python_styleguide/visitors/ast/complexity/pm.py
+++ b/wemake_python_styleguide/visitors/ast/complexity/pm.py
@@ -1,4 +1,5 @@
 import ast
+
 from typing_extensions import final
 
 from wemake_python_styleguide.violations import complexity
@@ -9,7 +10,7 @@ from wemake_python_styleguide.visitors.decorators import alias
 @final
 @alias(
     'visit_match',
-    ('visit_Match',)
+    ('visit_Match',),
 )
 class MatchSubjectsVisitor(BaseNodeVisitor):
     """Finds excessive match subjects in `match` statements."""
@@ -20,12 +21,13 @@ class MatchSubjectsVisitor(BaseNodeVisitor):
         self.generic_visit(node)
 
     def _check_match_subjects_count(self, node: ast.Match) -> None:
-        match_subjects = getattr(node, 'subjects', [])
-        if len(match_subjects) > self.options.max_match_subjects:
-            self.add_violation(
-                complexity.TooManyMatchSubjectsViolation(
-                    node,
-                    text=str(len(match_subjects)),
-                    baseline=self.options.max_match_subjects,
+        if isinstance(node.subject, ast.Tuple):
+            elts = node.subject.elts
+            if len(elts) > self.options.max_match_subjects:
+                self.add_violation(
+                    complexity.TooManyMatchSubjectsViolation(
+                        node,
+                        text=str(len(elts)),
+                        baseline=self.options.max_match_subjects,
+                    )
                 )
-            )


### PR DESCRIPTION
# I have made things!
## Checklist
- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made
- [x] I have added my changes to the `CHANGELOG.md`

## Related issues
- Closes #3201
