### PR TITLE
Fix "Has a lot of plugins?" info for ruff

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ to make all people write **exactly** the same `Python` code.
 | Finds bugs?                |   🤔   |   ✅   |   ❌  |  ✅  |  ✅  |            ✅            |
 | Finds complex code?        |   ❌   |   🤔   |   ❌  |  ❌  |  ✅  |            ✅            |
 | Has a lot of strict rules? |   ❌   |   🤔   |   ❌  |  ❌  |  ✅  |            ✅            |
-| Has a lot of plugins?      |   ✅   |   ❌   |   ❌  |  🤔  |  ❌  |            ✅            |
+| Has a lot of plugins?      |   ✅   |   ❌   |   ❌  |  🤔  |  ✅  |            ✅            |
 
 We have several primary objectives:
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ to make all people write **exactly** the same `Python` code.
 | Finds bugs?                |   🤔   |   ✅   |   ❌  |  ✅  |  ✅  |            ✅            |
 | Finds complex code?        |   ❌   |   🤔   |   ❌  |  ❌  |  ✅  |            ✅            |
 | Has a lot of strict rules? |   ❌   |   🤔   |   ❌  |  ❌  |  ✅  |            ✅            |
-| Has a lot of plugins?      |   ✅   |   ❌   |   ❌  |  🤔  |  ✅  |            ✅            |
+| Has a lot of plugins?      |   ✅   |   ❌   |   ❌  |  🤔  |  🤔  |            ✅            |
 
 We have several primary objectives:
 


### PR DESCRIPTION
ruff has [a very long list of rule sets](https://docs.astral.sh/ruff/rules/) that can be used to extend existing rules. It's not fair to say it doesn't have a lot of plugins. Even [the ruff config in the repo](https://github.com/wemake-services/wemake-python-styleguide/blob/master/pyproject.toml) uses many of them, configure WPS itself as a ruff plugin.

And I don't think this style guide and ruff should be and can be compared with these data points. They are not really alternatives to each other.

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [ ] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made
- [ ] I have added my changes to the `CHANGELOG.md`
