### PR TITLE
Issue 3310: _SELF name should not trigger WPS117

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ This version introduces `wps` CLI tool.
 - Fixes `WPS432`, now it shows literal num, #1402
 - Fixes `WPS226`, now it points to the first string literal occurrence, #3267
 - Fixes `WPS605` false-positive on `@staticmethod`, #3292
+- Fixes `_SELF` name should not trigger `WPS117`, #3310
 
 ## 1.0.0
 

--- a/tests/test_visitors/test_ast/test_naming/conftest.py
+++ b/tests/test_visitors/test_ast/test_naming/conftest.py
@@ -273,6 +273,28 @@ _FOREIGN_NAMING_PATTERNS = frozenset(
     ),
 )
 
+_VARIABLES = (
+    frozenset(
+        (
+            variable_def,
+            variable_typed_def,
+            variable_typed,
+            unpacking_variables,
+            unpacking_star_variables,
+            for_variable,
+            for_star_variable,
+            with_variable,
+            with_star_variable,
+            exception,
+            match_variable,
+            match_as_explicit,
+            match_inner,
+            match_star,
+        ),
+    )
+    | _FOREIGN_NAMING_PATTERNS
+)
+
 _ATTRIBUTES = (
     frozenset(
         (
@@ -391,3 +413,9 @@ def skip_match_case_syntax_error():
             pytest.skip('"_" cannot be used as "case" target')
 
     return factory
+
+
+@pytest.fixture(params=_VARIABLES)
+def simple_variables_template(request):
+    """Parametrized fixture that contains all variable naming templates."""
+    return request.param

--- a/tests/test_visitors/test_ast/test_naming/test_naming_rules/test_reserved_argument.py
+++ b/tests/test_visitors/test_ast/test_naming/test_naming_rules/test_reserved_argument.py
@@ -5,6 +5,7 @@ import pytest
 from wemake_python_styleguide.constants import SPECIAL_ARGUMENT_NAMES_WHITELIST
 from wemake_python_styleguide.violations.naming import (
     ReservedArgumentNameViolation,
+    TrailingUnderscoreViolation,
 )
 from wemake_python_styleguide.visitors.ast.naming.validation import (
     WrongNameVisitor,
@@ -79,7 +80,23 @@ def test_correct_argument_name(
 
 @pytest.mark.parametrize(
     'variable_name',
-    ['_SELF', '_Self', 'Self', '_CLS', 'cLs', '_clS', '_MCS', 'mcS', '_mCs'],
+    [
+        '_SELF',
+        '_Self',
+        'Self',
+        '_CLS',
+        'cLs',
+        '_clS',
+        '_MCS',
+        'mcS',
+        '_mCs',
+        '__self__',
+        '__cls__',
+        '__mcs__',
+        'self_',
+        'cls_',
+        'mcs_',
+    ],
 )
 def test_reserved_argument_name_variations(
     assert_errors,
@@ -95,4 +112,4 @@ def test_reserved_argument_name_variations(
     visitor = WrongNameVisitor(default_options, tree=tree)
     visitor.run()
 
-    assert_errors(visitor, [])
+    assert_errors(visitor, [], ignored_types=TrailingUnderscoreViolation)

--- a/tests/test_visitors/test_ast/test_naming/test_naming_rules/test_reserved_argument.py
+++ b/tests/test_visitors/test_ast/test_naming/test_naming_rules/test_reserved_argument.py
@@ -75,3 +75,24 @@ def test_correct_argument_name(
     visitor.run()
 
     assert_errors(visitor, [])
+
+
+@pytest.mark.parametrize(
+    'variable_name',
+    ['_SELF', '_Self', 'Self', '_CLS', 'cLs', '_clS', '_MCS', 'mcS', '_mCs'],
+)
+def test_reserved_argument_name_variations(
+    assert_errors,
+    parse_ast_tree,
+    default_options,
+    simple_variables_template,
+    mode,
+    variable_name,
+):
+    """Ensures variations of special names are allowed for simple variables."""
+    tree = parse_ast_tree(mode(simple_variables_template.format(variable_name)))
+
+    visitor = WrongNameVisitor(default_options, tree=tree)
+    visitor.run()
+
+    assert_errors(visitor, [])

--- a/wemake_python_styleguide/visitors/ast/naming/validation.py
+++ b/wemake_python_styleguide/visitors/ast/naming/validation.py
@@ -113,7 +113,7 @@ class _SimpleNameValidator:
         if is_first_argument:
             return
 
-        if not logical.is_wrong_name(name, SPECIAL_ARGUMENT_NAMES_WHITELIST):
+        if name not in SPECIAL_ARGUMENT_NAMES_WHITELIST:
             return
 
         self._error_callback(


### PR DESCRIPTION
I modified the naming logic validation so that variations of reserved argument names do not trigger WPS117 for simple variables.

I added a test case that checks all patterns related to simple variables.

## Checklist

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made

## Related issues

- Closes #issue-3310
- Refs #issue-3310