### PR TITLE
Fixes #3417 #3420

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,8 @@ Semantic versioning in our case means:
 
 ### Bugfixes
 
-- Fixes `NewStyledDecoratorViolation` for generic type specifications `my_func[T]` #3417
+- Removes unnecessary WPS604 and WPS614 rules from the noqa.py, #3420
+- Fixes `NewStyledDecoratorViolation` for generic type specifications `my_func[T]`, #3417
 
 Due to PEP 695, it's now allowed to use [] in the decorator only for `python3.12+`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,21 @@ Semantic versioning in our case means:
 - Fixes `WPS115` false-positive on `StrEnum`, `IntEnum`, `IntFlag` attributes, #3381
 - Fixes `WPS432`, now it ignores magic numbers in `Literal`, #3397
 
+
+## 1.1.1
+
+### Bugfixes
+
+- Fixes `NewStyledDecoratorViolation` for generic type specifications `my_func[T]` #3417
+
+Due to PEP 695, it's now allowed to use [] in the decorator only for `python3.12+`.
+
+```python
+@decorator[T, V]
+def some_function(): ...
+```
+
+
 ## 1.1.0
 
 ### Command line utility

--- a/tests/fixtures/noqa/noqa.py
+++ b/tests/fixtures/noqa/noqa.py
@@ -730,7 +730,7 @@ for unique_element in range(10):
     my_print(4)
 
 
-@some_decorator['text']  # noqa: WPS466
+@some_decorator + other_decorator  # noqa: WPS466
 def my_function():
     return 1
 

--- a/tests/fixtures/noqa/noqa.py
+++ b/tests/fixtures/noqa/noqa.py
@@ -107,7 +107,7 @@ class TooManyPublicAtts:  # noqa: WPS230
         self.boom = 7
 
 
-@property  # noqa: WPS614
+@property
 def function_name(  # noqa: WPS614
     value: int = 0,  # noqa: WPS110
 ):
@@ -118,7 +118,7 @@ def function_name(  # noqa: WPS614
 
 def some():  # noqa: WPS110
     class Nested:  # noqa: WPS431
-        """Docs."""  # noqa: WPS604
+        """Docs."""
 
     def nested():  # noqa: WPS430
         ...

--- a/tests/test_visitors/test_ast/test_decorators/test_new_style_decorators.py
+++ b/tests/test_visitors/test_ast/test_decorators/test_new_style_decorators.py
@@ -1,4 +1,5 @@
 import pytest
+import sys
 
 from wemake_python_styleguide.violations.best_practices import (
     NewStyledDecoratorViolation,
@@ -18,6 +19,45 @@ class Some:
     def some(self): ...
 """
 
+if sys.version_info >= (3, 12):
+    wrong_decorators = [
+        'some + other',
+        'some[1] + other[1]',
+        'some.attr + other.attr',
+        'some[0].attr + other.attr[0]',
+        'really @ strange[0]',
+    ]
+else:
+    wrong_decorators = [
+        'some[1]',
+        'some.attr[0]',
+        'some[0].attr',
+        'call()[1].attr',
+        'some + other',
+        'really @ strange[0]',
+    ]
+
+if sys.version_info >= (3, 12):
+    correct_decorators = [
+        'some',
+        'some()',
+        'some(index[1])',
+        'some.attr',
+        'some.attr(1 + 1)',
+        'some[my_type]',
+        'some[my_type](index)',
+        'some.attr[my_type]()',
+        'some.attr(1)[my_type]',
+    ]
+else:
+    correct_decorators = [
+        'some',
+        'some()',
+        'some(index[1])',
+        'some.attr',
+        'some.attr(1 + 1)',
+    ]
+
 
 @pytest.mark.parametrize(
     'code',
@@ -28,14 +68,7 @@ class Some:
 )
 @pytest.mark.parametrize(
     'decorator',
-    [
-        'some[1]',
-        'some.attr[0]',
-        'some[0].attr',
-        'call()[1].attr',
-        'some + other',
-        'really @ strange[0]',
-    ],
+    wrong_decorators,
 )
 def test_invalid_decorators(
     assert_errors,
@@ -63,13 +96,7 @@ def test_invalid_decorators(
 )
 @pytest.mark.parametrize(
     'decorator',
-    [
-        'some',
-        'some()',
-        'some(index[1])',
-        'some.attr',
-        'some.attr(1 + 1)',
-    ],
+    correct_decorators,
 )
 def test_valid_decorators(
     assert_errors,

--- a/tests/test_visitors/test_ast/test_decorators/test_new_style_decorators.py
+++ b/tests/test_visitors/test_ast/test_decorators/test_new_style_decorators.py
@@ -28,17 +28,6 @@ if sys.version_info >= (3, 12):
         'some[0].attr + other.attr[0]',
         'really @ strange[0]',
     ]
-else:
-    wrong_decorators = [
-        'some[1]',
-        'some.attr[0]',
-        'some[0].attr',
-        'call()[1].attr',
-        'some + other',
-        'really @ strange[0]',
-    ]
-
-if sys.version_info >= (3, 12):
     correct_decorators = [
         'some',
         'some()',
@@ -51,6 +40,14 @@ if sys.version_info >= (3, 12):
         'some.attr(1)[my_type]',
     ]
 else:
+    wrong_decorators = [
+        'some[1]',
+        'some.attr[0]',
+        'some[0].attr',
+        'call()[1].attr',
+        'some + other',
+        'really @ strange[0]',
+    ]
     correct_decorators = [
         'some',
         'some()',

--- a/tests/test_visitors/test_ast/test_decorators/test_new_style_decorators.py
+++ b/tests/test_visitors/test_ast/test_decorators/test_new_style_decorators.py
@@ -1,5 +1,6 @@
-import pytest
 import sys
+
+import pytest
 
 from wemake_python_styleguide.violations.best_practices import (
     NewStyledDecoratorViolation,

--- a/wemake_python_styleguide/violations/best_practices.py
+++ b/wemake_python_styleguide/violations/best_practices.py
@@ -2662,7 +2662,8 @@ class NewStyledDecoratorViolation(ASTViolation):
        Because decorators should be simple and easy to read.
 
     Solution:
-        Use names, attributes, and calls as decorators only.
+        Use names, attributes and calls with generic type specifications
+        as decorators only.
         You are free to pass any args to function calls, however.
 
     Example::
@@ -2671,8 +2672,18 @@ class NewStyledDecoratorViolation(ASTViolation):
         @some.decorator(args)
         def my_function(): ...
 
+        Only for ``python3.12+``
+        @decorator[my_type](args)
+        def my_function(): ...
+
         # Wrong:
-        @some.decorator['method'] + other
+        @some.decorator + other.decorator
+        def my_function(): ...
+
+        @some.dict_decorators['method']
+        def my_function(): ...
+
+        @some.list_decorators[index]
         def my_function(): ...
 
     .. versionadded:: 0.15.0

--- a/wemake_python_styleguide/visitors/ast/decorators.py
+++ b/wemake_python_styleguide/visitors/ast/decorators.py
@@ -1,4 +1,5 @@
 import ast
+import sys
 from typing import Final, final
 
 from wemake_python_styleguide.logic.tree import attributes
@@ -9,11 +10,19 @@ from wemake_python_styleguide.violations.best_practices import (
 from wemake_python_styleguide.visitors.base import BaseNodeVisitor
 from wemake_python_styleguide.visitors.decorators import alias
 
-_ALLOWED_DECORATOR_TYPES: Final = (
-    ast.Attribute,
-    ast.Call,
-    ast.Name,
-)
+if sys.version_info >= (3, 12):
+    _ALLOWED_DECORATOR_TYPES: Final = (
+        ast.Attribute,
+        ast.Call,
+        ast.Name,
+        ast.Subscript,  # PEP 695 - Type Parameter Syntax
+    )
+else:
+    _ALLOWED_DECORATOR_TYPES: Final = (
+        ast.Attribute,
+        ast.Call,
+        ast.Name,
+    )
 
 
 @final


### PR DESCRIPTION
# I have made things!

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made
- [x] I have added my changes to the `CHANGELOG.md`

## Related issues

Closes #3417 #3420 

Hi,
- I've removed the unnecessary WPS604 and WPS614 rules from the noqa.py
- I've added variation to the rule `WPS466`.
Now, for `python312+` it is allowed to use [] in decorators due to the [PEP 695](https://peps.python.org/pep-0695/ "https://peps.python.org/pep-0695/")
