### PR TITLE
Fixes #3427

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Semantic versioning in our case means:
 - Adds `WPS478`: forbids using non strict slice operations, #1011
 - Adds `WPS479`: forbids using multiline fstrings, #3405
 - Adds `WPS480`: forbids using comments inside formatted string, #3404
+- Adds `WPS481`: forbids using complex slice indexes, #3427
 
 ### Bugfixes
 

--- a/tests/fixtures/noqa/noqa.py
+++ b/tests/fixtures/noqa/noqa.py
@@ -756,3 +756,6 @@ async def test_await_in_loop():
 
 some_sequence = some_sequence[::-1]  # noqa: WPS478
 
+array = array[my_dict["index"] :]  # noqa: WPS481
+array = array[: end_index()]  # noqa: WPS481
+array = array[:: (var_x * (var_y + 1))]  # noqa: WPS481

--- a/tests/test_checker/test_noqa.py
+++ b/tests/test_checker/test_noqa.py
@@ -245,6 +245,7 @@ SHOULD_BE_RAISED = types.MappingProxyType(
         'WPS478': 1,
         'WPS479': 0,
         'WPS480': 0,  # only triggers on 3.12+
+        'WPS481': 3,
         'WPS500': 1,
         'WPS501': 1,
         'WPS502': 0,  # disabled since 1.0.0

--- a/tests/test_visitors/test_ast/test_subscripts/test_slice_indexes.py
+++ b/tests/test_visitors/test_ast/test_subscripts/test_slice_indexes.py
@@ -1,0 +1,78 @@
+import pytest
+
+from wemake_python_styleguide.violations.best_practices import (
+    ComplexSliceIndexViolation,
+)
+from wemake_python_styleguide.visitors.ast.subscripts import SliceIndexVisitor
+
+usage_template = 'constant[{0}]'
+
+
+@pytest.mark.parametrize(
+    'expression',
+    [
+        'my_dict["start_index"]:',
+        '::my_dict["step"]',
+        'my_list[0]:',
+        '::my_list[-1]',
+        'start_index():',
+        '::step()',
+        'Slice().start:',
+        'Slice(arg_1).start:',
+        'index.start():',
+        ':-(-x + 1)',
+        ':-(-x + -y)',
+        ':-(-x + -(y + 1))',
+        ':-(-(x + 1) + -(y + 1))',
+        '(1 - (x + 2)):',
+        '(1 - (x + 2) * 2):',
+        '(index.start + 1):',
+        '(x + y + z):',
+        ':x + y + z',
+    ],
+)
+def test_invalid_slice_indexes(
+    assert_errors,
+    parse_ast_tree,
+    expression,
+    default_options,
+):
+    """Testing that invalid indexes are forbidden."""
+    tree = parse_ast_tree(usage_template.format(expression))
+
+    visitor = SliceIndexVisitor(default_options, tree=tree)
+    visitor.run()
+
+    assert_errors(visitor, [ComplexSliceIndexViolation])
+
+
+@pytest.mark.parametrize(
+    'expression',
+    [
+        '1:3',
+        '1:3:2',
+        'start:end',
+        '::step',
+        'index.start:',
+        'index.start::index.step',
+        'Slice.start:',
+        ':-start',
+        '(x + 1):',
+        '(-x + 1):',
+        ':-(x + 1)',
+        '::-index.step',
+    ],
+)
+def test_valid_slice_indexes(
+    assert_errors,
+    parse_ast_tree,
+    expression,
+    default_options,
+):
+    """Testing that valid indexes are allowed."""
+    tree = parse_ast_tree(usage_template.format(expression))
+
+    visitor = SliceIndexVisitor(default_options, tree=tree)
+    visitor.run()
+
+    assert_errors(visitor, [])

--- a/wemake_python_styleguide/presets/types/tree.py
+++ b/wemake_python_styleguide/presets/types/tree.py
@@ -75,6 +75,7 @@ PRESET: Final = (
     subscripts.ImplicitDictGetVisitor,
     subscripts.CorrectKeyVisitor,
     subscripts.StrictSliceOperations,
+    subscripts.SliceIndexVisitor,
     decorators.WrongDecoratorVisitor,
     redundancy.RedundantEnumerateVisitor,
     pm.MatchSubjectVisitor,

--- a/wemake_python_styleguide/violations/base.py
+++ b/wemake_python_styleguide/violations/base.py
@@ -251,5 +251,6 @@ class SimpleViolation(BaseViolation):
 
 def _prepend_skipping_whitespaces(prefix: str, text: str) -> str:
     lstripped_text = text.lstrip()
-    leading_whitespaces = text[: len(text) - len(lstripped_text)]
+    end_index = len(text) - len(lstripped_text)
+    leading_whitespaces = text[:end_index]
     return leading_whitespaces + prefix + lstripped_text

--- a/wemake_python_styleguide/violations/best_practices.py
+++ b/wemake_python_styleguide/violations/best_practices.py
@@ -97,6 +97,7 @@ Summary
    NonStrictSliceOperationsViolation
    MultilineFormattedStringViolation
    CommentInFormattedStringViolation
+   ComplexSliceIndexViolation
 
 Best practices
 --------------
@@ -182,6 +183,7 @@ Best practices
 .. autoclass:: NonStrictSliceOperationsViolation
 .. autoclass:: MultilineFormattedStringViolation
 .. autoclass:: CommentInFormattedStringViolation
+.. autoclass:: ComplexSliceIndexViolation
 
 """
 
@@ -3150,3 +3152,42 @@ class CommentInFormattedStringViolation(TokenizeViolation):
 
     error_template = 'Found comment inside formatted string'
     code = 480
+
+
+@final
+class ComplexSliceIndexViolation(ASTViolation):
+    """
+    Forbid using complex grammar for slice index.
+
+    Reasoning:
+        It is probably not a good idea to use complex grammar in slice indexes.
+        Because indexes should be simple and easy to read.
+
+    Solution:
+        Use names, constants and attributes as indexes only.
+        Without complex expressions in parentheses.
+
+    Example::
+
+        # Correct:
+        array[3:7]
+        array[:-(x + 3)]
+        array[::-index.step]
+        array[start_index:end_index]
+        array[index.start:index.end]
+        array[Slice.start:]
+
+        # Wrong:
+        array[my_dict["start_index"]:my_list[-1]]
+        array[start_index():index.end()]
+        array[Slice().start:]
+        array[-(-x + 1):]
+        array[(x * (y + 2)):]
+        array[(x + y + z):]
+
+    .. versionadded:: 1.2.0
+
+    """
+
+    error_template = 'Found complex slice index'
+    code = 481


### PR DESCRIPTION
# I have made things!

- Adds `WPS481`: forbids using complex slice indexes, #3427 . Only the Name, Constant, Attribute, Unary and Bin operators with simple expressions inside parentheses are allowed.

Correct:
```
array[3:7]
array[:-(x + 3)]
array[::-index.step]
array[start_index:end_index]
array[index.start:index.end]
array[Slice.start:]
array[(x // y):]
```

Wrong:
```
array[my_dict["start_index"]:my_list[-1]]
array[start_index():index.end()]
array[Slice().start:]
array[-(-x + 1):]
array[(x * (y + 2)):]
array[(x + y + z):]
```

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made
- [x] I have added my changes to the `CHANGELOG.md`

## Related issues

- Closes #3427 

The new check `WPS481` found a complex slice in the `wemake_python_styleguide/violations/base.py` file. It has been updated and moved to a separate variable.
```
end_index = len(text) - len(lstripped_text)
leading_whitespaces = text[:end_index]
```