### PR TITLE
WPS349 highlighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ Due to PEP-695, it's now allowed to use `[]` in the decorator only for `python3.
 def some_function(): ...
 ```
 
+- Improves `WPS349` highlighting, #3437
+
+
 ## 1.1.0
 
 ### Command line utility

--- a/tests/test_visitors/test_ast/test_subscripts/test_redundant_subscripts.py
+++ b/tests/test_visitors/test_ast/test_subscripts/test_redundant_subscripts.py
@@ -12,7 +12,6 @@ usage_template = 'constant[{0}]'
     'expression',
     [
         '0:7',
-        '0:7:1',
         'None:7',
         '3:None',
         '3:None:2',
@@ -20,7 +19,7 @@ usage_template = 'constant[{0}]'
         '3:7:1',
     ],
 )
-def test_redundant_subscript(
+def test_one_redundant_subscript(
     assert_errors,
     parse_ast_tree,
     expression,
@@ -33,6 +32,70 @@ def test_redundant_subscript(
     visitor.run()
 
     assert_errors(visitor, [RedundantSubscriptViolation])
+
+
+@pytest.mark.parametrize(
+    'expression',
+    [
+        '0:7:1',
+        '0:7:None',
+        '0:None',
+        'None:7:None',
+        'None:None',
+        '3:None:1',
+        ':None:None',
+    ],
+)
+def test_two_redundant_subscript(
+    assert_errors,
+    parse_ast_tree,
+    expression,
+    default_options,
+):
+    """Testing that redundant subscripts are forbidden."""
+    tree = parse_ast_tree(usage_template.format(expression))
+
+    visitor = SubscriptVisitor(default_options, tree=tree)
+    visitor.run()
+
+    assert_errors(
+        visitor,
+        [
+            RedundantSubscriptViolation,
+            RedundantSubscriptViolation,
+        ],
+    )
+
+
+@pytest.mark.parametrize(
+    'expression',
+    [
+        '0:None:1',
+        'None:None:1',
+        'None:None:None',
+        '0:None:None',
+    ],
+)
+def test_three_redundant_subscript(
+    assert_errors,
+    parse_ast_tree,
+    expression,
+    default_options,
+):
+    """Testing that redundant subscripts are forbidden."""
+    tree = parse_ast_tree(usage_template.format(expression))
+
+    visitor = SubscriptVisitor(default_options, tree=tree)
+    visitor.run()
+
+    assert_errors(
+        visitor,
+        [
+            RedundantSubscriptViolation,
+            RedundantSubscriptViolation,
+            RedundantSubscriptViolation,
+        ],
+    )
 
 
 @pytest.mark.parametrize(

--- a/wemake_python_styleguide/visitors/ast/subscripts.py
+++ b/wemake_python_styleguide/visitors/ast/subscripts.py
@@ -57,26 +57,30 @@ class SubscriptVisitor(base.BaseNodeVisitor):
         if not isinstance(node.slice, ast.Slice):
             return
 
+        indexes: list[ast.expr | None] = []
         lower_ok = node.slice.lower is None or (
             not self._is_zero(node.slice.lower)
             and not self._is_none(node.slice.lower)
         )
-
         upper_ok = node.slice.upper is None or not self._is_none(
             node.slice.upper,
         )
-
         step_ok = node.slice.step is None or (
             not self._is_one(node.slice.step)
             and not self._is_none(node.slice.step)
         )
 
-        if not (lower_ok and upper_ok and step_ok):
-            self.add_violation(
-                consistency.RedundantSubscriptViolation(
-                    node,
-                ),
-            )
+        if not lower_ok:
+            indexes.append(node.slice.lower)
+
+        if not upper_ok:
+            indexes.append(node.slice.upper)
+
+        if not step_ok:
+            indexes.append(node.slice.step)
+
+        for index in indexes:
+            self.add_violation(consistency.RedundantSubscriptViolation(index))
 
     def _check_slice_assignment(self, node: ast.Subscript) -> None:
         if not isinstance(node.ctx, ast.Store):


### PR DESCRIPTION
# I have made things!

- Improves `WPS349` RedundantSubscriptViolation highlighting: now a specific slice index is highlighted, not the entire slice;

```
if not lower_ok:
    self.add_violation(
        consistency.RedundantSubscriptViolation(node.slice.lower)
    )

if not upper_ok:
    self.add_violation(
        consistency.RedundantSubscriptViolation(node.slice.upper)
    )

if not step_ok:
    self.add_violation(
        consistency.RedundantSubscriptViolation(node.slice.step)
    )
```
instead of

```
if not (lower_ok and upper_ok and step_ok):
    self.add_violation(
        consistency.RedundantSubscriptViolation(node)
    )
```
I find it more appropriate to specify which index contains the redundant grammar

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made
- [x] I have added my changes to the `CHANGELOG.md`
