### PR TITLE
Feat/allow re-exports in __init__.py files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Semantic versioning in our case means:
 
 ### Features
 
+- Allows `__init__.py` files to consist only of imports, #3486
 - Adds `--max-conditions` option, #3493
 
 ### Misc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Semantic versioning in our case means:
 
 ### Features
 
-- Allows `__init__.py` files to consist only of imports, #3486
+- Allows `__init__.py` files that consist only of imports, #3486
 - Adds `--max-conditions` option, #3493
 
 ### Misc

--- a/tests/test_visitors/test_ast/test_modules/test_empty_init.py
+++ b/tests/test_visitors/test_ast/test_modules/test_empty_init.py
@@ -24,6 +24,7 @@ from one import one_func
 from two import two_func
 """
 
+module_with_multiple_statements = 'x = 1\ny = 2'
 module_with_logic = """
 try:
     import some_module
@@ -40,6 +41,8 @@ except ImportError:
         empty_module,
         module_with_docstring,
         module_with_comments,
+        module_with_imports,
+        module_with_one_import,
     ],
 )
 def test_init_without_logic(
@@ -64,9 +67,8 @@ def test_init_without_logic(
 @pytest.mark.parametrize(
     'code',
     [
-        module_with_imports,
-        module_with_one_import,
         module_with_logic,
+        module_with_multiple_statements,
     ],
 )
 def test_init_with_logic(

--- a/wemake_python_styleguide/violations/best_practices.py
+++ b/wemake_python_styleguide/violations/best_practices.py
@@ -452,6 +452,7 @@ class InitModuleHasLogicViolation(SimpleViolation):
 
     1. comments, since they are dropped before AST comes in play
     2. docstrings are used sometimes when required to state something
+    3. imports and re-exports to define a public API for the package
 
     It is also fine when you have different users that use your code.
     And you do not want to break everything for them.

--- a/wemake_python_styleguide/violations/best_practices.py
+++ b/wemake_python_styleguide/violations/best_practices.py
@@ -452,7 +452,7 @@ class InitModuleHasLogicViolation(SimpleViolation):
 
     1. comments, since they are dropped before AST comes in play
     2. docstrings are used sometimes when required to state something
-    3. imports and re-exports to define a public API for the package
+    3. imports and re-exports to define a public module API
 
     It is also fine when you have different users that use your code.
     And you do not want to break everything for them.

--- a/wemake_python_styleguide/visitors/ast/modules.py
+++ b/wemake_python_styleguide/visitors/ast/modules.py
@@ -48,6 +48,13 @@ class EmptyModuleContentsVisitor(BaseNodeVisitor):
         if not self._is_init() or not node.body:
             return
 
+        only_imports = all(
+            isinstance(statement, (ast.Import, ast.ImportFrom))
+            for statement in node.body
+        )
+        if only_imports:
+            return
+
         if len(node.body) > 1:
             self.add_violation(InitModuleHasLogicViolation())
             return


### PR DESCRIPTION
# I have made things!
This PR relaxes the `InitModuleHasLogicViolation` to allow `__init__.py` files to consist solely of import statements.

---

## Checklist

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made
- [x] I have added my changes to the `CHANGELOG.md`

## Related issues

- Closes #3486 
