### PR TITLE
feat: forbid confusing  syntax (WPS364); add visitor and tests

### DIFF
--- a/tests/fixtures/noqa/noqa.py
+++ b/tests/fixtures/noqa/noqa.py
@@ -765,3 +765,7 @@ finally:
     my_print('zero division error')
     my_print(3 / 3)
     my_print('no zero division error')
+
+# New violation example for WPS364:
+if not user in users:  # noqa: WPS364
+    my_print('legacy not-in style')

--- a/tests/test_checker/test_noqa.py
+++ b/tests/test_checker/test_noqa.py
@@ -165,6 +165,7 @@ SHOULD_BE_RAISED = types.MappingProxyType(
         'WPS361': 0,  # disabled since 1.0.0
         'WPS362': 2,
         'WPS363': 1,
+        'WPS364': 1,
         'WPS400': 0,  # defined in ignored violations.
         'WPS401': 0,  # logically unacceptable.
         'WPS402': 0,  # defined in ignored violations.

--- a/tests/test_visitors/test_ast/test_compares/test_not_in_unary.py
+++ b/tests/test_visitors/test_ast/test_compares/test_not_in_unary.py
@@ -1,0 +1,60 @@
+import pytest
+
+from wemake_python_styleguide.violations.consistency import (
+    NotInWithUnaryOpViolation,
+)
+from wemake_python_styleguide.visitors.ast.compares import (
+    NotInUnaryVisitor,
+)
+
+
+@pytest.mark.parametrize(
+    'code',
+    [
+        'if not x in items: ...',
+        'if not (x in items): ...',
+        'result = not value in data',
+        'flag = not (value in data)',
+        'while not a in b: ...',
+    ],
+)
+def test_not_in_unary_detects(
+    assert_errors,
+    parse_ast_tree,
+    default_options,
+    code,
+):
+    """Ensures that ``not a in b`` forms are reported."""
+    tree = parse_ast_tree(code)
+
+    visitor = NotInUnaryVisitor(default_options, tree=tree)
+    visitor.run()
+
+    assert_errors(visitor, [NotInWithUnaryOpViolation])
+
+
+@pytest.mark.parametrize(
+    'code',
+    [
+        'if x not in items: ...',
+        'result = x not in data',
+        'if (not x) in items: ...',
+        'if not_called() in seq: ...',
+        'if y in items: ...',
+        'if not a is b: ...',
+        'if not (a is b): ...',
+    ],
+)
+def test_not_in_unary_ok(
+    assert_errors,
+    parse_ast_tree,
+    default_options,
+    code,
+):
+    """Ensures that correct forms are not reported."""
+    tree = parse_ast_tree(code)
+
+    visitor = NotInUnaryVisitor(default_options, tree=tree)
+    visitor.run()
+
+    assert_errors(visitor, [])

--- a/wemake_python_styleguide/presets/types/tree.py
+++ b/wemake_python_styleguide/presets/types/tree.py
@@ -65,6 +65,7 @@ PRESET: Final = (
     compares.WrongConstantCompareVisitor,
     compares.InCompareSanityVisitor,
     compares.WrongFloatComplexCompareVisitor,
+    compares.NotInUnaryVisitor,
     conditions.IfStatementVisitor,
     conditions.BooleanConditionVisitor,
     conditions.MatchVisitor,

--- a/wemake_python_styleguide/violations/consistency.py
+++ b/wemake_python_styleguide/violations/consistency.py
@@ -2381,3 +2381,38 @@ class RaiseSystemExitViolation(ASTViolation):
 
     error_template = 'Found `raise SystemExit`, instead of using `sys.exit`'
     code = 363
+
+
+@final
+class NotInWithUnaryOpViolation(ASTViolation):
+    """
+    Forbid using ``not a in b`` instead of ``a not in b``.
+
+    Reasoning:
+        The expression ``not a in b`` is parsed as ``not (a in b)`` and is
+        equivalent to ``a not in b``. However, it is easy to misread as
+        ``(not a) in b`` or require extra parsing effort. Using the explicit
+        ``not in`` operator is clearer and idiomatic.
+
+    Solution:
+        Replace ``not a in b`` (or ``not (a in b)``) with ``a not in b``.
+
+    Example::
+
+        # Correct:
+        if user not in users:
+            ...
+
+        # Wrong:
+        if not user in users:
+            ...
+        if not (user in users):
+            ...
+
+    .. versionadded:: 1.0.0
+
+    """
+
+    error_template = 'Found `not ... in ...`, use `not in`'
+    code = 364
+


### PR DESCRIPTION
# Forbid confusing `not a in b` (WPS364)

This PR forbids the confusing historical syntax "not a in b".

- Adds WPS364 NotInWithUnaryOpViolation
- Implements NotInUnaryVisitor and registers it
- Adds tests covering `not a in b` and related forms
- Updates noqa fixtures and counts

All tests pass locally with 100% coverage.

Rationale: `not a in b` is parsed as `not (a in b)`, which many read
ambiguously. The explicit `a not in b` is clearer and idiomatic.

## Checklist

<!-- Please check everything that applies: -->

- [X] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [X] I have created at least one test case for the changes I have made
- [ ] I have updated the documentation for the changes I have made
- [ ] I have added my changes to the `CHANGELOG.md`

## Related issues

https://github.com/wemake-services/wemake-python-styleguide/issues/3509