### PR TITLE
Issue 3520

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ Semantic versioning in our case means:
   change the client facing API, change code conventions significantly, etc.
 
 
+## 1.5.0
+
+### Features
+
+- Adds `WPS365`: match statement can be simplified to `if`, #3520
+
+
 ## 1.4.0
 
 ### Features

--- a/docs/pages/usage/setup.rst
+++ b/docs/pages/usage/setup.rst
@@ -29,7 +29,7 @@ Required configuration
 ----------------------
 
 You must either provide ``--select=WPS`` to all your ``flake8`` calls,
-or add ``select = WPS`` into your ``flake8`` configration file.
+or add ``select = WPS`` into your ``flake8`` configuration file.
 
 Running
 -------

--- a/tests/fixtures/noqa/noqa.py
+++ b/tests/fixtures/noqa/noqa.py
@@ -616,6 +616,12 @@ match x:  # noqa: WPS242
     case 8:
         my_print('eighth')
 
+match subject:  # noqa: WPS365
+    case 1:
+        ...
+    case _:
+        ...
+
 
 my_print("""
 text

--- a/tests/test_checker/test_noqa.py
+++ b/tests/test_checker/test_noqa.py
@@ -166,6 +166,7 @@ SHOULD_BE_RAISED = types.MappingProxyType(
         'WPS362': 2,
         'WPS363': 1,
         'WPS364': 1,
+        'WPS365': 1,
         'WPS400': 0,  # defined in ignored violations.
         'WPS401': 0,  # logically unacceptable.
         'WPS402': 0,  # defined in ignored violations.

--- a/tests/test_visitors/test_ast/test_conditions/test_simplified_match_conditions.py
+++ b/tests/test_visitors/test_ast/test_conditions/test_simplified_match_conditions.py
@@ -101,8 +101,6 @@ match subject:
         '"string"',
         'ns.CONST',
         'State.REJECTED',
-        '[1, 2]',
-        '{"status": "ok"}',
     ],
 )
 def test_simplifiable_single_match(

--- a/tests/test_visitors/test_ast/test_conditions/test_simplified_match_conditions.py
+++ b/tests/test_visitors/test_ast/test_conditions/test_simplified_match_conditions.py
@@ -1,0 +1,165 @@
+import pytest
+
+from wemake_python_styleguide.violations.consistency import (
+    SimplifiableMatchViolation,
+)
+from wemake_python_styleguide.visitors.ast.conditions import (
+    SimplifiableMatchVisitor,
+)
+
+simplifiable_match_template = """
+match subject:
+    case {0}:
+        pass
+    case _:
+        pass
+"""
+
+simplifiable_union_match_template = """
+match subject:
+    case {0} | {1}:
+        pass
+    case _:
+        pass
+"""
+
+complex_match = """
+match subject:
+    case State.FIRST:
+        pass
+    case State.SECOND:
+        pass
+    case _:
+        pass
+"""
+
+no_wildcard_match = """
+match subject:
+    case State.FIRST:
+        pass
+    case State.SECOND:
+        pass
+"""
+
+sequence_match = """
+match subject:
+    case [1, 2]:
+        pass
+    case _:
+        pass
+"""
+
+mapping_match = """
+match subject:
+    case {"status": "ok"}:
+        pass
+    case _:
+        pass
+"""
+
+class_match = """
+match subject:
+    case SomeClass():
+        pass
+    case _:
+        pass
+"""
+
+guard_match = """
+match subject:
+    case x if x > 0:
+        pass
+    case _:
+        pass
+"""
+
+
+@pytest.mark.parametrize(
+    'code',
+    [
+        '1',
+        'True',
+        'None',
+        '"string"',
+        'ns.CONST',
+        'State.REJECTED',
+    ],
+)
+def test_simplifiable_single_match(
+    code: str,
+    assert_errors,
+    parse_ast_tree,
+    default_options,
+):
+    """Test that simple single-case match raises a violation."""
+    tree = parse_ast_tree(simplifiable_match_template.format(code))
+    visitor = SimplifiableMatchVisitor(default_options, tree=tree)
+    visitor.run()
+    assert_errors(visitor, [SimplifiableMatchViolation])
+
+
+@pytest.mark.parametrize(
+    ('left', 'right'),
+    [
+        ('1', '2'),
+        ('True', 'False'),
+        ('"a"', '"b"'),
+        ('State.OK', 'State.ERROR'),
+        ('"first" | "second"', '"third"'),
+    ],
+)
+def test_simplifiable_union_match(
+    left: str,
+    right: str,
+    assert_errors,
+    parse_ast_tree,
+    default_options,
+):
+    """Test that union pattern raises violation."""
+    tree = parse_ast_tree(simplifiable_union_match_template.format(left, right))
+    visitor = SimplifiableMatchVisitor(default_options, tree=tree)
+    visitor.run()
+    assert_errors(visitor, [SimplifiableMatchViolation])
+
+
+def test_simplifiable_with_const_as_binding(
+    assert_errors,
+    parse_ast_tree,
+    default_options,
+):
+    """Test that `case CONST as name:` is still simplifiable."""
+    code = """
+    match subject:
+        case State.REJECTED as status:
+            pass
+        case _:
+            pass
+    """
+    tree = parse_ast_tree(code)
+    visitor = SimplifiableMatchVisitor(default_options, tree=tree)
+    visitor.run()
+    assert_errors(visitor, [SimplifiableMatchViolation])
+
+
+@pytest.mark.parametrize(
+    'template',
+    [
+        complex_match,
+        no_wildcard_match,
+        sequence_match,
+        mapping_match,
+        class_match,
+        guard_match,
+    ],
+)
+def test_not_simplifiable_match_templates(
+    template: str,
+    assert_errors,
+    parse_ast_tree,
+    default_options,
+):
+    """Test that complex or non-simplifiable matches do not raise violations."""
+    tree = parse_ast_tree(template)
+    visitor = SimplifiableMatchVisitor(default_options, tree=tree)
+    visitor.run()
+    assert_errors(visitor, [])

--- a/tests/test_visitors/test_ast/test_conditions/test_simplified_match_conditions.py
+++ b/tests/test_visitors/test_ast/test_conditions/test_simplified_match_conditions.py
@@ -8,7 +8,7 @@ from wemake_python_styleguide.visitors.ast.conditions import (
 )
 
 # Wrong:
-simplifiable_match_template = """
+simplifiable_match_match = """
 match subject:
     case {0}:
         pass
@@ -16,7 +16,7 @@ match subject:
         pass
 """
 
-simplifiable_union_match_template = """
+simplifiable_union_match_match = """
 match subject:
     case {0} | {1}:
         pass
@@ -24,7 +24,7 @@ match subject:
         pass
 """
 
-simplifiable_with_const_as_binding_template = """
+simplifiable_with_const_as_binding_match = """
     match subject:
         case State.REJECTED as status:
             pass
@@ -110,7 +110,7 @@ def test_simplifiable_single_match(
     default_options,
 ):
     """Test that simple single-case match raises a violation."""
-    tree = parse_ast_tree(simplifiable_match_template.format(code))
+    tree = parse_ast_tree(simplifiable_match_match.format(code))
     visitor = SimplifiableMatchVisitor(default_options, tree=tree)
     visitor.run()
     assert_errors(visitor, [SimplifiableMatchViolation])
@@ -134,7 +134,7 @@ def test_simplifiable_union_match(
     default_options,
 ):
     """Test that union pattern raises violation."""
-    tree = parse_ast_tree(simplifiable_union_match_template.format(left, right))
+    tree = parse_ast_tree(simplifiable_union_match_match.format(left, right))
     visitor = SimplifiableMatchVisitor(default_options, tree=tree)
     visitor.run()
     assert_errors(visitor, [SimplifiableMatchViolation])
@@ -146,7 +146,7 @@ def test_simplifiable_with_const_as_binding(
     default_options,
 ):
     """Test that `case CONST as name:` is still simplifiable."""
-    tree = parse_ast_tree(simplifiable_with_const_as_binding_template)
+    tree = parse_ast_tree(simplifiable_with_const_as_binding_match)
     visitor = SimplifiableMatchVisitor(default_options, tree=tree)
     visitor.run()
     assert_errors(visitor, [SimplifiableMatchViolation])

--- a/tests/test_visitors/test_ast/test_conditions/test_simplified_match_conditions.py
+++ b/tests/test_visitors/test_ast/test_conditions/test_simplified_match_conditions.py
@@ -53,7 +53,7 @@ match subject:
 
 guard_match = """
 match subject:
-    case x if x > 0:
+    case [x] if x > 0:
         pass
     case _:
         pass
@@ -101,6 +101,7 @@ match subject:
         '"string"',
         'ns.CONST',
         'State.REJECTED',
+        'x if x > 0',
     ],
 )
 def test_simplifiable_single_match(

--- a/wemake_python_styleguide/logic/tree/pattern_matching.py
+++ b/wemake_python_styleguide/logic/tree/pattern_matching.py
@@ -47,10 +47,14 @@ def is_constant_subject(condition: ast.AST | list[ast.expr]) -> bool:
     return False
 
 
-def is_wildcard_case(case: ast.match_case) -> bool:
+def is_wildcard_pattern(case: ast.match_case) -> bool:
     """Returns True only for `case _:`."""
     pattern = case.pattern
-    return isinstance(pattern, ast.MatchAs) and pattern.pattern is None
+    return (
+        isinstance(pattern, ast.MatchAs)
+        and pattern.pattern is None
+        and pattern.name is None
+    )
 
 
 def is_simple_pattern(pattern: ast.pattern) -> bool:
@@ -85,3 +89,16 @@ def _is_simple_value_or_singleton(pattern: ast.pattern) -> bool:
             pattern.value, (ast.Constant, ast.Name, ast.Attribute)
         )
     return False
+
+
+def is_irrefutable_binding(pattern: ast.pattern) -> bool:
+    """
+    Returns True for patterns like ``case x:`` or ``case data:``.
+
+    These always match and just bind the subject to a name.
+    """
+    return (
+        isinstance(pattern, ast.MatchAs)
+        and pattern.pattern is None
+        and pattern.name is not None
+    )

--- a/wemake_python_styleguide/logic/tree/pattern_matching.py
+++ b/wemake_python_styleguide/logic/tree/pattern_matching.py
@@ -45,3 +45,43 @@ def is_constant_subject(condition: ast.AST | list[ast.expr]) -> bool:
             and is_constant_subject(node.values)
         )
     return False
+
+
+def is_wildcard_case(case: ast.match_case) -> bool:
+    """Returns True only for `case _:`."""
+    pattern = case.pattern
+    return isinstance(pattern, ast.MatchAs) and pattern.pattern is None
+
+
+def is_simple_pattern(pattern: ast.pattern) -> bool:
+    """Returns True if the pattern is simple enough to replace with `==`."""
+    return _is_simple_value_or_singleton(pattern) or _is_simple_composite(
+        pattern
+    )
+
+
+def _is_simple_composite(pattern: ast.pattern) -> bool:
+    """Returns True/False for MatchOr and MatchAs, None otherwise."""
+    if isinstance(pattern, ast.MatchOr):
+        return all(is_simple_pattern(sub) for sub in pattern.patterns)
+    if isinstance(pattern, ast.MatchAs):
+        inner = pattern.pattern
+        return inner is not None and is_simple_pattern(inner)
+    return False
+
+
+def _is_simple_value_or_singleton(pattern: ast.pattern) -> bool:
+    """
+    Checks if a pattern is a simple literal or singleton.
+
+    Supports:
+    - Single values: ``1``, ``"text"``, ``ns.CONST``.
+    - Singleton values: ``True``, ``False``, ``None``.
+    """
+    if isinstance(pattern, ast.MatchSingleton):
+        return True
+    if isinstance(pattern, ast.MatchValue):
+        return isinstance(
+            pattern.value, (ast.Constant, ast.Name, ast.Attribute)
+        )
+    return False

--- a/wemake_python_styleguide/presets/types/tree.py
+++ b/wemake_python_styleguide/presets/types/tree.py
@@ -70,6 +70,7 @@ PRESET: Final = (
     conditions.BooleanConditionVisitor,
     conditions.MatchVisitor,
     conditions.ChainedIsVisitor,
+    conditions.SimplifiableMatchVisitor,
     iterables.IterableUnpackingVisitor,
     blocks.AfterBlockVariablesVisitor,
     subscripts.SubscriptVisitor,

--- a/wemake_python_styleguide/violations/consistency.py
+++ b/wemake_python_styleguide/violations/consistency.py
@@ -2431,8 +2431,8 @@ class SimplifiableMatchViolation(ASTViolation):
     Solution:
         Replace violating ``match ... case _`` statements with ``if ... else``.
 
-    When is this violation is issued?
-        - When there are exactly two cases
+    When is this violation is raised?
+        - When there are exactly two ``case`` statements
         - When the first case uses a simple pattern (e.g. liter, const, enums)
         - When the second case is a wildcard: ``case _:``
         - When the first case has no guard (i.e. no ``if ...`` condition)

--- a/wemake_python_styleguide/violations/consistency.py
+++ b/wemake_python_styleguide/violations/consistency.py
@@ -2435,7 +2435,6 @@ class SimplifiableMatchViolation(ASTViolation):
         - When there are exactly two ``case`` statements
         - When the first case uses a literal pattern
         - When the second case is a wildcard: ``case _:``
-        - When the first case has literal guard (e.g. ``x if x > 0``)
 
 
     Example::

--- a/wemake_python_styleguide/violations/consistency.py
+++ b/wemake_python_styleguide/violations/consistency.py
@@ -2452,6 +2452,7 @@ class SimplifiableMatchViolation(ASTViolation):
                 user = 'active'
 
     .. versionadded:: 1.5.0
+
     """
 
     error_template = (

--- a/wemake_python_styleguide/violations/consistency.py
+++ b/wemake_python_styleguide/violations/consistency.py
@@ -2433,9 +2433,9 @@ class SimplifiableMatchViolation(ASTViolation):
 
     When is this violation is raised?
         - When there are exactly two ``case`` statements
-        - When the first case uses a simple pattern (e.g. liter, const, enums)
+        - When the first case uses a literal pattern
         - When the second case is a wildcard: ``case _:``
-        - When the first case has simple guard (e.g. ``x if x > 0``)
+        - When the first case has literal guard (e.g. ``x if x > 0``)
 
 
     Example::

--- a/wemake_python_styleguide/violations/consistency.py
+++ b/wemake_python_styleguide/violations/consistency.py
@@ -2420,7 +2420,7 @@ class NotInWithUnaryOpViolation(ASTViolation):
 @final
 class SimplifiableMatchViolation(ASTViolation):
     """
-    Match statement can be simplified to `if`.
+    Some ``match`` statements can be simplified to ``if`` statements.
 
     Reasoning:
         Using ``match`` for simple two-case conditions
@@ -2429,12 +2429,14 @@ class SimplifiableMatchViolation(ASTViolation):
         Simple conditions should prefer readability and simplicity.
 
     Solution:
-        Replace simple ``match ... case _`` constructs with ``if ... else``.
+        Replace violating ``match ... case _`` statements with ``if ... else``.
 
-    When is this violation not issued?
-        - When there are more than two cases
-        - When the pattern is complex (e.g. deconstructing dicts, classes)
-        - When the wildcard case is not the last one
+    When is this violation is issued?
+        - When there are exactly two cases
+        - When the first case uses a simple pattern (e.g. liter, const, enums)
+        - When the second case is a wildcard: ``case _:``
+        - When the first case has no guard (i.e. no ``if ...`` condition)
+
 
     Example::
 

--- a/wemake_python_styleguide/violations/consistency.py
+++ b/wemake_python_styleguide/violations/consistency.py
@@ -2456,6 +2456,6 @@ class SimplifiableMatchViolation(ASTViolation):
     """
 
     error_template = (
-        'Found simple ``match ... case _`` constructs, use ``if ... else``'
+        'Found simplifiable `match` statement that can be just `if`'
     )
     code = 365

--- a/wemake_python_styleguide/violations/consistency.py
+++ b/wemake_python_styleguide/violations/consistency.py
@@ -2415,3 +2415,46 @@ class NotInWithUnaryOpViolation(ASTViolation):
 
     error_template = 'Found legacy `not ... in`, use `... not in` instead'
     code = 364
+
+
+@final
+class SimplifiableMatchViolation(ASTViolation):
+    """
+    Match statement can be simplified to `if`.
+
+    Reasoning:
+        Using ``match`` for simple two-case conditions
+        (including wildcard ``_``)
+        is unnecessarily verbose and less performant than a plain ``if/else``.
+        Simple conditions should prefer readability and simplicity.
+
+    Solution:
+        Replace simple ``match ... case _`` constructs with ``if ... else``.
+
+    When is this violation not issued?
+        - When there are more than two cases
+        - When the pattern is complex (e.g. deconstructing dicts, classes)
+        - When the wildcard case is not the last one
+
+    Example::
+
+        # Correct:
+        if state == EventType.REJECT:
+            user = 'rejected'
+        else:
+            user = 'active'
+
+        # Wrong:
+        match state:
+            case EventType.REJECT:
+                user = 'rejected'
+            case _:
+                user = 'active'
+
+    .. versionadded:: 1.5.0
+    """
+
+    error_template = (
+        'Found simple ``match ... case _`` constructs, use ``if ... else``'
+    )
+    code = 365

--- a/wemake_python_styleguide/violations/consistency.py
+++ b/wemake_python_styleguide/violations/consistency.py
@@ -2435,7 +2435,7 @@ class SimplifiableMatchViolation(ASTViolation):
         - When there are exactly two ``case`` statements
         - When the first case uses a simple pattern (e.g. liter, const, enums)
         - When the second case is a wildcard: ``case _:``
-        - When the first case has no guard (i.e. no ``if ...`` condition)
+        - When the first case has simple guard (e.g. ``x if x > 0``)
 
 
     Example::

--- a/wemake_python_styleguide/visitors/ast/conditions.py
+++ b/wemake_python_styleguide/visitors/ast/conditions.py
@@ -206,18 +206,10 @@ class SimplifiableMatchVisitor(BaseNodeVisitor):
         if len(cases) == 2:
             first, second = cases
 
-            if (
-                pattern_matching.is_wildcard_pattern(second)
-                and first.guard is None
-                and pattern_matching.is_simple_pattern(first.pattern)
-            ):
-                self.add_violation(consistency.SimplifiableMatchViolation(node))
+            if not pattern_matching.is_wildcard_pattern(second):
                 return
 
-            if (
-                pattern_matching.is_wildcard_pattern(second)
-                and first.guard is not None
-                and pattern_matching.is_irrefutable_binding(first.pattern)
-            ):
+            if pattern_matching.is_irrefutable_binding(
+                first.pattern
+            ) or pattern_matching.is_simple_pattern(first.pattern):
                 self.add_violation(consistency.SimplifiableMatchViolation(node))
-                return

--- a/wemake_python_styleguide/visitors/ast/conditions.py
+++ b/wemake_python_styleguide/visitors/ast/conditions.py
@@ -205,9 +205,19 @@ class SimplifiableMatchVisitor(BaseNodeVisitor):
         cases = node.cases
         if len(cases) == 2:
             first, second = cases
+
             if (
-                pattern_matching.is_wildcard_case(second)
+                pattern_matching.is_wildcard_pattern(second)
                 and first.guard is None
                 and pattern_matching.is_simple_pattern(first.pattern)
             ):
                 self.add_violation(consistency.SimplifiableMatchViolation(node))
+                return
+
+            if (
+                pattern_matching.is_wildcard_pattern(second)
+                and first.guard is not None
+                and pattern_matching.is_irrefutable_binding(first.pattern)
+            ):
+                self.add_violation(consistency.SimplifiableMatchViolation(node))
+                return

--- a/wemake_python_styleguide/visitors/tokenize/comments.py
+++ b/wemake_python_styleguide/visitors/tokenize/comments.py
@@ -332,7 +332,7 @@ class CommentInFormattedStringVisitor(BaseTokenVisitor):  # pragma: >=3.12 cover
     )
 
     def visit_fstring_start(self, token: tokenize.TokenInfo) -> None:
-        """Preforms fstring check."""
+        """Performs fstring check."""
         self._check_is_fstring_ends_with_comment(token)
 
     def _check_is_fstring_ends_with_comment(


### PR DESCRIPTION
# I have made things!
Adds a new consistency violation to enforce using `if` instead of simple two-case `match` statements with a wildcard `_`.

> - Implemented `SimplifiableMatchViolation` with code `WPS365`
> - Created `SimplifiableMatchVisitor` to detect:
>   - Exactly two cases
>   - Second case is `case _:`
>   - First case uses a simple pattern (e.g. `CONST`, `ENUM.VALUE`, `1`, or `A | B`)

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [ ] I have updated the documentation for the changes I have made
- [x] I have added my changes to the `CHANGELOG.md`

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->
Closes #3520 
<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->

