### PR TITLE
feat: add check for simplifiable match with sequence or mapping patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -212,3 +212,6 @@ fabric.properties
 # Used for testing:
 ex.py
 setup.py
+
+# CodeRabbit logs:
+logs/

--- a/tests/test_visitors/test_ast/test_conditions/test_simplified_match_with_sequence_or_mapping.py
+++ b/tests/test_visitors/test_ast/test_conditions/test_simplified_match_with_sequence_or_mapping.py
@@ -135,7 +135,9 @@ def test_simplifiable_sequence_or_mapping_match(
 ):
     """Test that simple sequence and mapping matches raise a violation."""
     tree = parse_ast_tree(code)
-    visitor = SimplifiableMatchWithSequenceOrMappingVisitor(default_options, tree=tree)
+    visitor = SimplifiableMatchWithSequenceOrMappingVisitor(
+        default_options, tree=tree
+    )
     visitor.run()
     assert_errors(visitor, [SimplifiableMatchWithSequenceOrMappingViolation])
 
@@ -160,6 +162,8 @@ def test_not_simplifiable_sequence_or_mapping_match(
 ):
     """Test that complex or non-simplifiable matches do not raise violations."""
     tree = parse_ast_tree(template)
-    visitor = SimplifiableMatchWithSequenceOrMappingVisitor(default_options, tree=tree)
+    visitor = SimplifiableMatchWithSequenceOrMappingVisitor(
+        default_options, tree=tree
+    )
     visitor.run()
     assert_errors(visitor, [])

--- a/tests/test_visitors/test_ast/test_conditions/test_simplified_match_with_sequence_or_mapping.py
+++ b/tests/test_visitors/test_ast/test_conditions/test_simplified_match_with_sequence_or_mapping.py
@@ -1,0 +1,165 @@
+import pytest
+
+from wemake_python_styleguide.violations.consistency import (
+    SimplifiableMatchWithSequenceOrMappingViolation,
+)
+from wemake_python_styleguide.visitors.ast.conditions import (
+    SimplifiableMatchWithSequenceOrMappingVisitor,
+)
+
+# Wrong: Simple sequence patterns
+simple_list_match = """
+match data:
+    case [1, 2]:
+        handle_pair()
+    case _:
+        ignore()
+"""
+
+simple_nested_list_match = """
+match data:
+    case [[1, 2], [3, 4]]:
+        handle_nested()
+    case _:
+        ignore()
+"""
+
+simple_tuple_match = """
+match data:
+    case (1, "a"):
+        handle_tuple()
+    case _:
+        ignore()
+"""
+
+simple_dict_match = """
+match data:
+    case {"key": "value"}:
+        handle_dict()
+    case _:
+        ignore()
+"""
+
+simple_nested_dict_match = """
+match data:
+    case {"outer": {"inner": 42}}:
+        handle_nested_dict()
+    case _:
+        ignore()
+"""
+
+mixed_list_dict_match = """
+match data:
+    case [{"key": "value"}, 42]:
+        handle_mixed()
+    case _:
+        ignore()
+"""
+
+# Correct: Complex patterns that should not be simplified
+complex_with_binding = """
+match data:
+    case [x, y]:
+        handle_with_binding(x, y)
+    case _:
+        ignore()
+"""
+
+with_star_pattern = """
+match data:
+    case [first, *rest]:
+        handle_with_rest(first, rest)
+    case _:
+        ignore()
+"""
+
+with_rest_name = """
+match data:
+    case {"key": value, **rest}:
+        handle_with_rest(value, rest)
+    case _:
+        ignore()
+"""
+
+with_guard = """
+match data:
+    case [1, 2] if condition > 0:
+        handle_guarded()
+    case _:
+        ignore()
+"""
+
+complex_match = """
+match data:
+    case SomeClass(x):
+        handle_class()
+    case _:
+        ignore()
+"""
+
+no_wildcard = """
+match data:
+    case [1, 2]:
+        handle_first()
+    case [3, 4]:
+        handle_second()
+"""
+
+more_than_two_cases = """
+match data:
+    case [1, 2]:
+        handle_first()
+    case [3, 4]:
+        handle_second()
+    case _:
+        handle_default()
+"""
+
+
+@pytest.mark.parametrize(
+    'code',
+    [
+        simple_list_match,
+        simple_nested_list_match,
+        simple_tuple_match,
+        simple_dict_match,
+        simple_nested_dict_match,
+        mixed_list_dict_match,
+    ],
+)
+def test_simplifiable_sequence_or_mapping_match(
+    code,
+    assert_errors,
+    parse_ast_tree,
+    default_options,
+):
+    """Test that simple sequence and mapping matches raise a violation."""
+    tree = parse_ast_tree(code)
+    visitor = SimplifiableMatchWithSequenceOrMappingVisitor(default_options, tree=tree)
+    visitor.run()
+    assert_errors(visitor, [SimplifiableMatchWithSequenceOrMappingViolation])
+
+
+@pytest.mark.parametrize(
+    'template',
+    [
+        complex_with_binding,
+        with_star_pattern,
+        with_rest_name,
+        with_guard,
+        complex_match,
+        no_wildcard,
+        more_than_two_cases,
+    ],
+)
+def test_not_simplifiable_sequence_or_mapping_match(
+    template,
+    assert_errors,
+    parse_ast_tree,
+    default_options,
+):
+    """Test that complex or non-simplifiable matches do not raise violations."""
+    tree = parse_ast_tree(template)
+    visitor = SimplifiableMatchWithSequenceOrMappingVisitor(default_options, tree=tree)
+    visitor.run()
+    assert_errors(visitor, [])

--- a/wemake_python_styleguide/logic/tree/pattern_matching.py
+++ b/wemake_python_styleguide/logic/tree/pattern_matching.py
@@ -180,7 +180,7 @@ def _is_simple_pattern_element(pattern: ast.pattern) -> bool:
         # If pattern.name is not None, it's a binding (not simple)
         if pattern.name is not None:
             return False
-        # If pattern.name is None but pattern.pattern is not None, 
+        # If pattern.name is None but pattern.pattern is not None,
         # check if the inner pattern is simple
         if pattern.pattern is not None:
             return _is_simple_pattern_element(pattern.pattern)

--- a/wemake_python_styleguide/presets/types/tree.py
+++ b/wemake_python_styleguide/presets/types/tree.py
@@ -71,6 +71,7 @@ PRESET: Final = (
     conditions.MatchVisitor,
     conditions.ChainedIsVisitor,
     conditions.SimplifiableMatchVisitor,
+    conditions.SimplifiableMatchWithSequenceOrMappingVisitor,
     conditions.LeakingForLoopVisitor,
     iterables.IterableUnpackingVisitor,
     blocks.AfterBlockVariablesVisitor,

--- a/wemake_python_styleguide/violations/consistency.py
+++ b/wemake_python_styleguide/violations/consistency.py
@@ -2460,3 +2460,54 @@ class SimplifiableMatchViolation(ASTViolation):
         'Found simplifiable `match` statement that can be just `if`'
     )
     code = 365
+
+
+@final
+class SimplifiableMatchWithSequenceOrMappingViolation(ASTViolation):
+    """
+    Some ``match`` statements with simple sequences or mappings can be.
+
+    Reasoning:
+        Using ``match`` for exact structural comparisons of simple literals
+        (like lists or dicts) is unnecessarily verbose. While match excels
+        at deconstruction, using it to check for an exact list or dict value
+        is better expressed with a direct equality comparison (``==``),
+        which is more readable and performant.
+
+    Solution:
+        Replace ``match`` statements that check for simple sequences or
+        mappings (with no deconstruction) with ``if`` statements using ``==``.
+
+    When is this violation is raised?
+        - When there are exactly two ``case`` statements
+        - When the first case uses a simple sequence or mapping pattern
+        - When the second case is a wildcard: ``case _:``
+        - When the pattern contains only literals/contants (no
+      variable bindings)
+        - When there are no guards or starred patterns
+
+
+    Example::
+
+        # Correct:
+        if data == [1, 2]:
+            handle_pair()
+        else:
+            ignore()
+
+        # Wrong:
+        match data:
+            case [1, 2]:
+                handle_pair()
+            case _:
+                ignore()
+
+    .. versionadded:: 1.5.0
+
+    """
+
+    error_template = (
+        'Found simplifiable `match` statement with sequence or mapping '
+        'that can be just `if`'
+    )
+    code = 366

--- a/wemake_python_styleguide/visitors/ast/conditions.py
+++ b/wemake_python_styleguide/visitors/ast/conditions.py
@@ -245,7 +245,11 @@ class SimplifiableMatchWithSequenceOrMappingVisitor(BaseNodeVisitor):
                 )
                 and first.guard is None  # No guard clause
             ):
-                self.add_violation(consistency.SimplifiableMatchWithSequenceOrMappingViolation(node))
+                self.add_violation(
+                    consistency.SimplifiableMatchWithSequenceOrMappingViolation(
+                        node
+                    )
+                )
 
 
 @final


### PR DESCRIPTION
## Overview
This PR adds a new check for simplifiable `match` statements that use simple sequences or mappings (like lists or dicts with literal values). The check identifies when a `match` statement can be replaced with a simpler `if` statement using equality comparison.

## Checklist
- [x] Code changes implemented
- [x] Tests added and passing
- [x] Documentation updated in violation docstring

## Proof
The new visitor `SimplifiableMatchWithSequenceOrMappingVisitor` checks for `match` statements that:
- Have exactly two cases
- The first case uses a simple sequence or mapping pattern (with literals, no variable bindings)
- The second case is a wildcard (`case _:`)
- No guards or starred patterns are present

When these conditions are met, it raises `SimplifiableMatchWithSequenceOrMappingViolation` with code 366. The test file `test_simplified_match_with_sequence_or_mapping.py` validates both simplifiable and non-simplifiable patterns.

## Closes #3527