### PR TITLE
Fix `WPS430` false positive on whitelisted deep nested functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Semantic versioning in our case means:
 
 - Fixes false positive `WPS457` for ``while True`` loop with ``await`` expressions, #3753
 - Fixes the false positive `WPS617` by assigning a function that receives a lambda expression as a parameter.
+- Fixes false positive `WPS430` for whitelisted nested functions, #3589
 
 
 ## 1.5.0

--- a/tests/fixtures/noqa/noqa.py
+++ b/tests/fixtures/noqa/noqa.py
@@ -122,20 +122,13 @@ def some():  # noqa: WPS110
 
     def nested():  # noqa: WPS430
         ...
-    
-    def factory():  # ok
-        if some_condition():
-            def deep_nested():  # noqa: WPS430
-                    ...
-        else:
-            def wrapper(): # ok
-                ...
-            if some_other_condition():
-                def deep_nested():  # noqa: WPS430
-                    ...
-            else:
-                def decorator(): # ok
-                    ...
+
+    if some_condition():
+        def deep_nested():  # noqa: WPS430
+            ...
+    else:
+        async def deep_nested():  # noqa: WPS430
+            ...
 
 
 del {'a': 1}['a']  # noqa: WPS420

--- a/tests/fixtures/noqa/noqa.py
+++ b/tests/fixtures/noqa/noqa.py
@@ -122,6 +122,20 @@ def some():  # noqa: WPS110
 
     def nested():  # noqa: WPS430
         ...
+    
+    def factory():  # ok
+        if some_condition():
+            def deep_nested():  # noqa: WPS430
+                    ...
+        else:
+            def wrapper(): # ok
+                ...
+            if some_other_condition():
+                def deep_nested():  # noqa: WPS430
+                    ...
+            else:
+                def decorator(): # ok
+                    ...
 
 
 del {'a': 1}['a']  # noqa: WPS420

--- a/tests/test_checker/test_noqa.py
+++ b/tests/test_checker/test_noqa.py
@@ -197,7 +197,7 @@ SHOULD_BE_RAISED = types.MappingProxyType(
         'WPS427': 1,
         'WPS428': 0,  # disabled since 1.0.0
         'WPS429': 1,
-        'WPS430': 1,
+        'WPS430': 3,
         'WPS431': 2,
         'WPS432': 2,
         'WPS433': 0,  # disabled since 1.0.0

--- a/tests/test_visitors/test_ast/test_complexity/test_nested/test_nested_functions.py
+++ b/tests/test_visitors/test_ast/test_complexity/test_nested/test_nested_functions.py
@@ -257,8 +257,7 @@ def test_deep_whitelist_nested_functions(
     visitor = NestedComplexityVisitor(default_options, tree=tree)
     visitor.run()
 
-    assert_errors(visitor, [NestedFunctionViolation])
-    assert_error_text(visitor, whitelist_name)
+    assert_errors(visitor, [])
 
 
 @pytest.mark.parametrize(

--- a/tests/test_visitors/test_ast/test_complexity/test_nested/test_nested_functions.py
+++ b/tests/test_visitors/test_ast/test_complexity/test_nested/test_nested_functions.py
@@ -234,6 +234,34 @@ def test_whitelist_nested_functions(
     [
         nested_function_in_if,
         nested_function_in_if_else,
+    ],
+)
+def test_deep_whitelist_nested_functions_allowed(
+    assert_errors,
+    assert_error_text,
+    parse_ast_tree,
+    whitelist_name,
+    code,
+    default_options,
+    mode,
+):
+    """
+    Test for allowed whitelisted functions inside single if(/else) block.
+
+    See: https://github.com/wemake-services/wemake-python-styleguide/issues/3589
+    """
+    tree = parse_ast_tree(mode(code.format(whitelist_name)))
+
+    visitor = NestedComplexityVisitor(default_options, tree=tree)
+    visitor.run()
+
+    assert_errors(visitor, [])
+
+
+@pytest.mark.parametrize('whitelist_name', NESTED_FUNCTIONS_WHITELIST)
+@pytest.mark.parametrize(
+    'code',
+    [
         nested_function_while_loop,
         nested_function_in_for_loop,
         nested_function_in_try,
@@ -251,13 +279,14 @@ def test_deep_whitelist_nested_functions(
     default_options,
     mode,
 ):
-    """Testing that it is possible to nest whitelisted functions."""
+    """Testing that it is restricted to nest even whitelisted functions."""
     tree = parse_ast_tree(mode(code.format(whitelist_name)))
 
     visitor = NestedComplexityVisitor(default_options, tree=tree)
     visitor.run()
 
-    assert_errors(visitor, [])
+    assert_errors(visitor, [NestedFunctionViolation])
+    assert_error_text(visitor, whitelist_name)
 
 
 @pytest.mark.parametrize(

--- a/wemake_python_styleguide/visitors/ast/complexity/nested.py
+++ b/wemake_python_styleguide/visitors/ast/complexity/nested.py
@@ -46,6 +46,9 @@ class NestedComplexityVisitor(BaseNodeVisitor):
         Used to find nested functions.
 
         Uses ``NESTED_FUNCTIONS_WHITELIST`` to respect some nested functions.
+        Only whitelisted functions are allowed, either directly inside
+        a function or inside a single function-level ``if`` / ``if-else``.
+        All other nesting is forbidden.
         """
         self._check_nested_function(node)
         self.generic_visit(node)
@@ -56,23 +59,26 @@ class NestedComplexityVisitor(BaseNodeVisitor):
         self.generic_visit(node)
 
     def _check_nested_function(self, node: AnyFunctionDef) -> None:
-        if not isinstance(get_context(node), FunctionNodes):
+        context = get_context(node)
+        if not isinstance(context, FunctionNodes):
             return
 
         parent = get_parent(node)
 
         is_direct = isinstance(parent, FunctionNodes)
 
-        is_single_if = isinstance(parent, ast.If) and isinstance(
-            get_parent(parent), FunctionNodes
+        is_single_if = (
+            isinstance(parent, ast.If) and get_parent(parent) is context
         )
 
-        if node.name not in NESTED_FUNCTIONS_WHITELIST or not (
+        if node.name in NESTED_FUNCTIONS_WHITELIST and (
             is_direct or is_single_if
         ):
-            self.add_violation(
-                NestedFunctionViolation(node, text=node.name),
-            )
+            return
+
+        self.add_violation(
+            NestedFunctionViolation(node, text=node.name),
+        )
 
     def _check_nested_classes(self, node: ast.ClassDef) -> None:
         parent_context = get_context(node)

--- a/wemake_python_styleguide/visitors/ast/complexity/nested.py
+++ b/wemake_python_styleguide/visitors/ast/complexity/nested.py
@@ -58,10 +58,13 @@ class NestedComplexityVisitor(BaseNodeVisitor):
     def _check_nested_function(self, node: AnyFunctionDef) -> None:
         is_inside_function = isinstance(get_context(node), FunctionNodes)
 
+        is_not_whitelisted = node.name not in NESTED_FUNCTIONS_WHITELIST
         is_direct = isinstance(get_parent(node), FunctionNodes)
-        is_bad = is_direct and node.name not in NESTED_FUNCTIONS_WHITELIST
+        is_bad = is_direct and is_not_whitelisted
 
-        if is_bad or (is_inside_function and not is_direct):
+        if is_bad or (
+            is_inside_function and not is_direct and is_not_whitelisted
+        ):
             self.add_violation(NestedFunctionViolation(node, text=node.name))
 
     def _check_nested_classes(self, node: ast.ClassDef) -> None:


### PR DESCRIPTION
# I have made things!

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made
- [x] I have added my changes to the `CHANGELOG.md`

## Related issues

Closes #3589 
<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->

Actually, there was already a test case for this `/wemake-python-styleguide/tests/test_visitors/test_ast/test_complexity/test_nested/test_nested_functions.py`, but it was wrong and assumed that deep nested whitelisted functions must be reported. 
