### PR TITLE
fix: lambda class attribute visitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Semantic versioning in our case means:
 ### Bugfixes
 
 - Fixes false positive `WPS457` for ``while True`` loop with ``await`` expressions, #3753
+- Fixes the false positive `WPS617` by assigning a function that receives a lambda expression as a parameter.
 
 
 ## 1.5.0

--- a/tests/test_visitors/test_ast/test_classes/test_lambda_attr_assign.py
+++ b/tests/test_visitors/test_ast/test_classes/test_lambda_attr_assign.py
@@ -50,6 +50,11 @@ class A:
         self.other.api = lambda x: x * 2
 """
 
+correct_lambda_attr_assign7 = """
+def some(other):
+    other.api = sorted([], key=lambda x: x * 2)
+"""
+
 # Wrong:
 
 wrong_lambda_assign1 = """
@@ -112,6 +117,7 @@ def test_wrong_lambda_assign(
         correct_lambda_attr_assign4,
         correct_lambda_attr_assign5,
         correct_lambda_attr_assign6,
+        correct_lambda_attr_assign7,
     ],
 )
 def test_correct_lambda_assign(

--- a/wemake_python_styleguide/visitors/ast/classes/attributes.py
+++ b/wemake_python_styleguide/visitors/ast/classes/attributes.py
@@ -65,10 +65,11 @@ class ClassAttributeVisitor(base.BaseNodeVisitor):
             return  # it is not assigned in a method of a class
 
         for attribute in assigned.targets:
-            if isinstance(
-                attribute,
-                ast.Attribute,
-            ) and attributes.is_special_attr(attribute):
+            if (
+                isinstance(attribute, ast.Attribute)
+                and attributes.is_special_attr(attribute)
+                and isinstance(assigned.value, ast.Lambda)
+            ):
                 self.add_violation(oop.LambdaAttributeAssignedViolation(node))
 
 


### PR DESCRIPTION
# I have made things!
i fixed false positive WPS617 by assigning a function that receives a lambda expression as a parameter.

## Checklist

<!-- Please check everything that applies: -->

- [X] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [X] I have created at least one test case for the changes I have made
- [ ] I have updated the documentation for the changes I have made
- [X] I have added my changes to the `CHANGELOG.md`

## Related issues 
- Closes #3596 3596

