### PR TITLE
WPS345: forbid symmetric bitwise operations (#3593)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Semantic versioning in our case means:
 - Fixes false positive `WPS457` for ``while True`` loop with ``await`` expressions, #3753
 - Fixes the false positive `WPS617` by assigning a function that receives a lambda expression as a parameter.
 - Fixes false positive `WPS430` for whitelisted nested functions, #3589
+- Fixes `WPS345` to forbid symmetric bitwise operations, #3593
 
 ### Removals
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,13 +21,13 @@ Semantic versioning in our case means:
 ### Features
 
 - Allows walrus operator in `WPS332`, #3505
+- Forbids symmetric bitwise operations in `WPS345`, #3593
 
 ### Bugfixes
 
 - Fixes false positive `WPS457` for ``while True`` loop with ``await`` expressions, #3753
 - Fixes the false positive `WPS617` by assigning a function that receives a lambda expression as a parameter.
 - Fixes false positive `WPS430` for whitelisted nested functions, #3589
-- Fixes `WPS345` to forbid symmetric bitwise operations, #3593
 
 ### Removals
 

--- a/tests/test_visitors/test_ast/test_operators/test_useless_math.py
+++ b/tests/test_visitors/test_ast/test_operators/test_useless_math.py
@@ -140,6 +140,7 @@ def test_meaningless_symmetric_bitwise_math(
 @pytest.mark.parametrize(
     'expression',
     [
+        '7 ^ -7',
         '5 & 6',
         '(not -2) | 3',
         '-~7 ^ -~8',

--- a/wemake_python_styleguide/logic/tree/operators.py
+++ b/wemake_python_styleguide/logic/tree/operators.py
@@ -47,3 +47,25 @@ def count_unary_operator(
     if isinstance(parent.op, operator):
         return count_unary_operator(parent, operator, amount + 1)
     return count_unary_operator(parent, operator, amount)
+
+
+def get_reduced_unary_operators(
+    node: ast.AST,
+    opchain: list[type[ast.unaryop]] | None = None,
+) -> list[type[ast.unaryop]]:
+    """Returns a sequence of significant unary operators."""
+    if opchain is None:
+        opchain = []
+
+    parent = get_parent(node)
+    if not isinstance(parent, ast.UnaryOp):
+        return opchain
+
+    if not isinstance(parent.op, ast.UAdd):
+        lastop = opchain[-1] if opchain else None
+        if lastop and isinstance(parent.op, lastop):
+            opchain.pop()
+        else:
+            opchain.append(type(parent.op))
+
+    return get_reduced_unary_operators(parent, opchain)


### PR DESCRIPTION
# I have made things!

This forbids symmetric bitwise operations of constants.

## Checklist

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made
- [x] I have added my changes to the `CHANGELOG.md`

## Related issues
Refs #3593 
