### PR TITLE
fix: WPS457 false positive when `while True` is inside `try/except`

### DIFF
--- a/tests/test_visitors/test_ast/test_loops/test_loops/test_infinite_while_loops.py
+++ b/tests/test_visitors/test_ast/test_loops/test_loops/test_infinite_while_loops.py
@@ -126,6 +126,43 @@ while True:
         ...
 """
 
+wrong_while3 = """
+try:
+    while True:
+        do_something()
+finally:
+    cleanup()
+"""
+
+# Correct: while inside try/except
+
+correct_while8 = """
+def gen():
+    try:
+        while True:
+            yield some()
+    except StopIteration:
+        pass
+"""
+
+correct_while9 = """
+def factory():
+    try:
+        while True:
+            yield async_to_sync(anext)(iterator)
+    except StopAsyncIteration:
+        pass
+"""
+
+correct_while10 = """
+try:
+    while 1:
+        do_something()
+except SomeError:
+    handle()
+"""
+
+
 
 @pytest.mark.parametrize(
     'template',
@@ -173,6 +210,9 @@ def test_correct_while_loops_with_statements(
         correct_while5,
         correct_while6,
         correct_while7,
+        correct_while8,
+        correct_while9,
+        correct_while10,
     ],
 )
 def test_correct_while_loops_with_try(
@@ -259,6 +299,7 @@ def test_wrong_while_loops(
     [
         wrong_while1,
         wrong_while2,
+        wrong_while3,
     ],
 )
 def test_wrong_while_loops_with_try(

--- a/tests/test_visitors/test_ast/test_loops/test_loops/test_infinite_while_loops.py
+++ b/tests/test_visitors/test_ast/test_loops/test_loops/test_infinite_while_loops.py
@@ -163,7 +163,6 @@ except SomeError:
 """
 
 
-
 @pytest.mark.parametrize(
     'template',
     [

--- a/tests/test_visitors/test_ast/test_loops/test_loops/test_infinite_while_loops.py
+++ b/tests/test_visitors/test_ast/test_loops/test_loops/test_infinite_while_loops.py
@@ -105,6 +105,36 @@ async def worker():
         await asyncio.sleep(1)
 """
 
+# Correct: while inside try/except
+
+correct_while8 = """
+def gen():
+    try:
+        while True:
+            yield some()
+    except StopIteration:
+        pass
+"""
+
+correct_while9 = """
+try:
+    while 1:
+        do_something()
+except SomeError:
+    handle()
+"""
+
+correct_while10 = """
+try:
+    while True:
+        try:
+            do_something()
+        except InnerError:
+            pass
+except OuterError:
+    handle()
+"""
+
 # Do raise:
 
 wrong_while1 = """
@@ -132,34 +162,6 @@ try:
         do_something()
 finally:
     cleanup()
-"""
-
-# Correct: while inside try/except
-
-correct_while8 = """
-def gen():
-    try:
-        while True:
-            yield some()
-    except StopIteration:
-        pass
-"""
-
-correct_while9 = """
-def factory():
-    try:
-        while True:
-            yield async_to_sync(anext)(iterator)
-    except StopAsyncIteration:
-        pass
-"""
-
-correct_while10 = """
-try:
-    while 1:
-        do_something()
-except SomeError:
-    handle()
 """
 
 

--- a/tests/test_visitors/test_ast/test_loops/test_loops/test_infinite_while_loops.py
+++ b/tests/test_visitors/test_ast/test_loops/test_loops/test_infinite_while_loops.py
@@ -108,12 +108,12 @@ async def worker():
 # Correct: while inside try/except
 
 correct_while8 = """
-def gen():
-    try:
+try:
+    if some:
         while True:
-            yield some()
-    except StopIteration:
-        pass
+            yield some
+except StopIteration:
+    pass
 """
 
 correct_while9 = """
@@ -132,6 +132,17 @@ try:
         except InnerError:
             pass
 except OuterError:
+    handle()
+"""
+
+# Wrong: try/except is outside a scope boundary, should not exempt the while
+
+wrong_while4 = """
+try:
+    def inner():
+        while True:
+            do_something()
+except SomeError:
     handle()
 """
 
@@ -301,6 +312,7 @@ def test_wrong_while_loops(
         wrong_while1,
         wrong_while2,
         wrong_while3,
+        wrong_while4,
     ],
 )
 def test_wrong_while_loops_with_try(

--- a/tests/test_visitors/test_ast/test_loops/test_loops/test_infinite_while_loops.py
+++ b/tests/test_visitors/test_ast/test_loops/test_loops/test_infinite_while_loops.py
@@ -111,7 +111,7 @@ correct_while8 = """
 try:
     if some:
         while True:
-            yield some
+            do_something()
 except StopIteration:
     pass
 """

--- a/tests/test_visitors/test_ast/test_loops/test_loops/test_infinite_while_loops.py
+++ b/tests/test_visitors/test_ast/test_loops/test_loops/test_infinite_while_loops.py
@@ -135,8 +135,6 @@ except OuterError:
     handle()
 """
 
-# Wrong: try/except is outside a scope boundary, should not exempt the while
-
 wrong_while4 = """
 try:
     def inner():

--- a/wemake_python_styleguide/logic/tree/loops.py
+++ b/wemake_python_styleguide/logic/tree/loops.py
@@ -28,7 +28,9 @@ def is_in_try_except(node: ast.AST) -> bool:
         if isinstance(parent, ast.Try) and parent.handlers:
             return True
         # Stop at function/class boundaries — don't look past them
-        if isinstance(parent, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+        if isinstance(
+            parent, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
+        ):
             break
         parent = get_parent(parent)
     return False
@@ -54,4 +56,3 @@ def has_break(
             if not is_nested_break:
                 return True
     return False
-

--- a/wemake_python_styleguide/logic/tree/loops.py
+++ b/wemake_python_styleguide/logic/tree/loops.py
@@ -1,6 +1,7 @@
 import ast
 
 from wemake_python_styleguide.compat.aliases import ForNodes
+from wemake_python_styleguide.logic.nodes import get_parent
 from wemake_python_styleguide.types import AnyLoop, AnyNodes
 
 
@@ -18,6 +19,19 @@ def _does_loop_contain_node(
         return False
 
     return any(to_check is inner_node for inner_node in ast.walk(loop))
+
+
+def is_in_try_except(node: ast.AST) -> bool:
+    """Checks whether a node is directly inside a ``try/except`` block."""
+    parent = get_parent(node)
+    while parent is not None:
+        if isinstance(parent, ast.Try) and parent.handlers:
+            return True
+        # Stop at function/class boundaries — don't look past them
+        if isinstance(parent, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            break
+        parent = get_parent(parent)
+    return False
 
 
 def has_break(
@@ -40,3 +54,4 @@ def has_break(
             if not is_nested_break:
                 return True
     return False
+

--- a/wemake_python_styleguide/logic/tree/loops.py
+++ b/wemake_python_styleguide/logic/tree/loops.py
@@ -1,8 +1,10 @@
 import ast
 
 from wemake_python_styleguide.compat.aliases import ForNodes
-from wemake_python_styleguide.logic.nodes import get_parent
+from wemake_python_styleguide.logic.walk import tree as walk
 from wemake_python_styleguide.types import AnyLoop, AnyNodes
+
+_SCOPE_BOUNDARIES = (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
 
 
 def _does_loop_contain_node(
@@ -23,17 +25,11 @@ def _does_loop_contain_node(
 
 def is_in_try_except(node: ast.AST) -> bool:
     """Checks whether a node is directly inside a ``try/except`` block."""
-    parent = get_parent(node)
-    while parent is not None:
-        if isinstance(parent, ast.Try) and parent.handlers:
-            return True
-        # Stop at function/class boundaries — don't look past them
-        if isinstance(
-            parent, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
-        ):
-            break
-        parent = get_parent(parent)
-    return False
+    # Find the closest Try or scope-boundary parent, whichever comes first.
+    closest = walk.get_closest_parent(
+        node, (*_SCOPE_BOUNDARIES, ast.Try),
+    )
+    return isinstance(closest, ast.Try) and bool(closest.handlers)
 
 
 def has_break(

--- a/wemake_python_styleguide/logic/tree/loops.py
+++ b/wemake_python_styleguide/logic/tree/loops.py
@@ -4,8 +4,6 @@ from wemake_python_styleguide.compat.aliases import ForNodes
 from wemake_python_styleguide.logic.walk import tree as walk
 from wemake_python_styleguide.types import AnyLoop, AnyNodes
 
-_SCOPE_BOUNDARIES = (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
-
 
 def _does_loop_contain_node(
     loop: AnyLoop | None,
@@ -28,7 +26,7 @@ def is_in_try_except(node: ast.AST) -> bool:
     # Find the closest Try or scope-boundary parent, whichever comes first.
     closest = walk.get_closest_parent(
         node,
-        (*_SCOPE_BOUNDARIES, ast.Try),
+        (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Try),
     )
     return isinstance(closest, ast.Try) and bool(closest.handlers)
 

--- a/wemake_python_styleguide/logic/tree/loops.py
+++ b/wemake_python_styleguide/logic/tree/loops.py
@@ -27,7 +27,8 @@ def is_in_try_except(node: ast.AST) -> bool:
     """Checks whether a node is directly inside a ``try/except`` block."""
     # Find the closest Try or scope-boundary parent, whichever comes first.
     closest = walk.get_closest_parent(
-        node, (*_SCOPE_BOUNDARIES, ast.Try),
+        node,
+        (*_SCOPE_BOUNDARIES, ast.Try),
     )
     return isinstance(closest, ast.Try) and bool(closest.handlers)
 

--- a/wemake_python_styleguide/visitors/ast/loops.py
+++ b/wemake_python_styleguide/visitors/ast/loops.py
@@ -174,6 +174,9 @@ class WrongLoopVisitor(base.BaseNodeVisitor):
         if loops.has_break(node, break_nodes=self._can_break_loop):
             return
 
+        if loops.is_in_try_except(node):
+            return
+
         with suppress(ValueError):
             evaled = ast.literal_eval(node.test)
             if not isinstance(evaled, ast.Name) and bool(evaled):


### PR DESCRIPTION
Fixes #3603

## Problem

`WPS457` (InfiniteWhileLoopViolation) was incorrectly triggered when a `while True` loop was wrapped in a `try/except` block:

```python
def factory() -> Iterator[bytes]:
    try:
        while True:
            yield async_to_sync(async_anext)(iterator)
    except StopAsyncIteration:
        pass
```

This is not an infinite loop — the `except` handler provides a clear termination path. The previous implementation only checked for `break`/`raise`/`return`/`ExceptHandler` *inside* the `while` body, but missed the case where the enclosing `try/except` itself acts as the exit mechanism.

## Fix

Added `is_in_try_except()` helper in `wemake_python_styleguide/logic/tree/loops.py` that walks up the AST parent chain to detect if the `while` node is directly inside a `try` block that has at least one `except` handler.

In `_check_infinite_while_loop`, if `is_in_try_except()` returns `True`, the violation is suppressed.

**Note:** A `try/finally` without `except` still triggers WPS457, since `finally` does not catch exceptions and cannot terminate the loop.

## Tests

Added three new correct cases (`correct_while8/9/10`) covering the reported pattern, and one new wrong case (`wrong_while3`) for `try/finally` without `except`.