### PR TITLE
WPS366: forbid useless bool expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Semantic versioning in our case means:
 
 - Allows walrus operator in `WPS332`, #3505
 - Forbids symmetric bitwise operations in `WPS345`, #3593
+- Adds `WPS366`: forbid meaningless boolean operations, #3593
 
 ### Bugfixes
 

--- a/tests/fixtures/noqa/noqa.py
+++ b/tests/fixtures/noqa/noqa.py
@@ -469,7 +469,7 @@ CONSTANT = []  # noqa: WPS407
 
 numbers = map(lambda string: int(string), ['1'])  # noqa: WPS506
 
-if numbers and numbers:  # noqa: WPS408
+if numbers and numbers:  # noqa: WPS408, WPS366
     my_print('duplicate boolop')
 
 if numbers == CONSTANT != [2]:  # noqa: WPS409

--- a/tests/test_checker/test_noqa.py
+++ b/tests/test_checker/test_noqa.py
@@ -167,6 +167,7 @@ SHOULD_BE_RAISED = types.MappingProxyType(
         'WPS363': 1,
         'WPS364': 1,
         'WPS365': 1,
+        'WPS366': 1,
         'WPS400': 0,  # defined in ignored violations.
         'WPS401': 0,  # logically unacceptable.
         'WPS402': 0,  # defined in ignored violations.

--- a/tests/test_visitors/test_ast/test_operators/test_useless_bool.py
+++ b/tests/test_visitors/test_ast/test_operators/test_useless_bool.py
@@ -1,0 +1,76 @@
+import pytest
+
+from wemake_python_styleguide.violations.consistency import (
+    MeaninglessBooleanOperationViolation,
+)
+from wemake_python_styleguide.visitors.ast.operators import (
+    UselessOperatorsVisitor,
+)
+
+
+@pytest.mark.parametrize(
+    'expression',
+    [
+        # containing constants only
+        '2 and -2',
+        'True and 0 and "py"',
+        'False or 2 or "py"',
+        # `and` containing at least one constant
+        'value and True',
+        'value1 and 4 and value2 and "py" and True',
+        # `or` containing True/False
+        'value or False',
+        'value1 or True or value2 or False or False',
+        # `or` containing everything after non-bool constant
+        'value1 or 0 or value2',
+        'value or "py" or 4',
+        # `and`/`or` operators containing a duplicate name
+        # with identical unary operations
+        'value and value and value',
+        'value or value or value',
+        'value1 and value2 and value1',
+        'value2 or value1 or value1',
+        'value or --value',
+        '~value or value or ~value',
+        # complex expression containing one of the cases listed above
+        '(value1 and value2) or (1 and 2)',
+    ],
+)
+def test_useless_bool(
+    assert_errors,
+    parse_ast_tree,
+    expression,
+    default_options,
+):
+    """Testing that some bool operations are useless."""
+    tree = parse_ast_tree(expression)
+
+    visitor = UselessOperatorsVisitor(default_options, tree=tree)
+    visitor.run()
+
+    assert_errors(visitor, [MeaninglessBooleanOperationViolation])
+
+
+@pytest.mark.parametrize(
+    'expression',
+    [
+        'value or -value or ~value',
+        'value1 or value2 or value3',
+        'value1 or value2 or 4',
+        'value1 and value2 and value3',
+        '(value1 and value2) or (value3 and value4)'
+    ],
+)
+def test_useful_bool(
+    assert_errors,
+    parse_ast_tree,
+    expression,
+    default_options,
+):
+    """Testing that all bool operations are useful."""
+    tree = parse_ast_tree(expression)
+
+    visitor = UselessOperatorsVisitor(default_options, tree=tree)
+    visitor.run()
+
+    assert_errors(visitor, [])

--- a/tests/test_visitors/test_ast/test_operators/test_useless_bool.py
+++ b/tests/test_visitors/test_ast/test_operators/test_useless_bool.py
@@ -58,7 +58,7 @@ def test_useless_bool(
         'value1 or value2 or value3',
         'value1 or value2 or 4',
         'value1 and value2 and value3',
-        '(value1 and value2) or (value3 and value4)'
+        '(value1 and value2) or (value3 and value4)',
     ],
 )
 def test_useful_bool(

--- a/tests/test_visitors/test_ast/test_operators/test_useless_math.py
+++ b/tests/test_visitors/test_ast/test_operators/test_useless_math.py
@@ -34,7 +34,7 @@ usage_template = 'constant {0}'
         '% 0o1',
         '* other / 1.0',
         '* 1 * other',
-        # Boolean ops:
+        # Bitwise ops:
         '>> 0',
         '<< 0',
         '| 0b0',
@@ -78,7 +78,7 @@ def test_meaningless_math(
         '/ -1.0',
         '* other / 1.5',
         '* -1 * other',
-        # Boolean ops:
+        # Bitwise ops:
         '>> 10',
         '<< 1',
         '| 0b1',

--- a/wemake_python_styleguide/violations/consistency.py
+++ b/wemake_python_styleguide/violations/consistency.py
@@ -2480,6 +2480,18 @@ class MeaninglessBooleanOperationViolation(ASTViolation):
         Some parts of a boolean expression may be redundant,
         making the logic difficult to understand.
 
+    Explanation:
+        - comparison of constants can be replaced with a single constant
+        - comparison with ``True``/``False`` can be removed or replaced
+            with ``True`` or ``False`` constant
+        - comparison with constants in the ``and`` operator can lead to
+            an implicit conditional assignment, which is better done explicitly
+        - comparison with false-like constants in the ``or`` operator
+            can be removed
+        - everything after the first true-like constant in ``or`` operator
+            can be removed
+        - comparison of duplicated variables can be reduced
+
     Solution:
         Remove useless operations.
 

--- a/wemake_python_styleguide/violations/consistency.py
+++ b/wemake_python_styleguide/violations/consistency.py
@@ -2469,3 +2469,38 @@ class SimplifiableMatchViolation(ASTViolation):
         'Found simplifiable `match` statement that can be just `if`'
     )
     code = 365
+
+
+@final
+class MeaninglessBooleanOperationViolation(ASTViolation):
+    """
+    Forbid meaningless boolean operations.
+
+    Reasoning:
+        Some parts of a boolean expression may be redundant,
+        making the logic difficult to understand.
+
+    Solution:
+        Remove useless operations.
+
+    Example::
+
+        # Correct:
+        cond = condition or -1
+        cond = condition1 or condition2
+        cond = condition1 and condition2 and condition3
+        cond = condition or -condition
+
+        # Wrong:
+        cond = 10 and 'value'
+        cond = condition and 10
+        cond = condition or True
+        cond = condition or 'value' or 0
+        cond = condition and condition
+
+    .. versionadded:: 1.6.0
+
+    """
+
+    error_template = 'Found meaningless boolean operation'
+    code = 366

--- a/wemake_python_styleguide/visitors/ast/operators.py
+++ b/wemake_python_styleguide/visitors/ast/operators.py
@@ -1,6 +1,6 @@
 import ast
 from collections import defaultdict
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from typing import ClassVar, TypeAlias, final
 
 from wemake_python_styleguide.compat.aliases import TextNodes
@@ -23,6 +23,7 @@ _MeaninglessOperators: TypeAlias = Mapping[
     tuple[type[ast.operator], ...],
 ]
 _OperatorLimits: TypeAlias = Mapping[type[ast.unaryop], int]
+_UnaryOperatorsChain: TypeAlias = Sequence[type[ast.unaryop]]
 
 
 @final
@@ -127,7 +128,7 @@ class UselessOperatorsVisitor(base.BaseNodeVisitor):  # noqa: WPS214
         op: ast.boolop,
         nodes: list[ast.expr],
     ) -> None:
-        unary_chains = defaultdict(set[tuple[type[ast.unaryop], ...]])
+        unary_chains: dict[str, set[_UnaryOperatorsChain]] = defaultdict(set)
         for position, node in enumerate(nodes, 1):
             unwrapped = unwrap_unary_node(node)
 

--- a/wemake_python_styleguide/visitors/ast/operators.py
+++ b/wemake_python_styleguide/visitors/ast/operators.py
@@ -1,4 +1,5 @@
 import ast
+from collections import defaultdict
 from collections.abc import Mapping
 from typing import ClassVar, TypeAlias, final
 
@@ -89,6 +90,11 @@ class UselessOperatorsVisitor(base.BaseNodeVisitor):  # noqa: WPS214
         self._check_useless_symmetric_operator(node.op, node.left, node.right)
         self.generic_visit(node)
 
+    def visit_BoolOp(self, node: ast.BoolOp) -> None:
+        """Visit boolean operators."""
+        self._check_useless_bool_operator(node.op, node.values)
+        self.generic_visit(node)
+
     def visit_AugAssign(self, node: ast.AugAssign) -> None:
         """Visits augmented assigns."""
         self._check_zero_division(node.op, node.value)
@@ -115,6 +121,36 @@ class UselessOperatorsVisitor(base.BaseNodeVisitor):  # noqa: WPS214
         )
         if is_zero_division:
             self.add_violation(consistency.ZeroDivisionViolation(number))
+
+    def _check_useless_bool_operator(  # noqa: WPS210
+        self,
+        op: ast.boolop,
+        nodes: list[ast.expr],
+    ) -> None:
+        unary_chains = defaultdict(set[tuple[type[ast.unaryop], ...]])
+        for position, node in enumerate(nodes, 1):
+            unwrapped = unwrap_unary_node(node)
+
+            # `and` containing at least one constant
+            # `or` containing bool or everything after non-bool constant
+            has_useless_constant = isinstance(unwrapped, ast.Constant) and (
+                isinstance(op, ast.And)
+                or isinstance(unwrapped.value, bool)
+                or position < len(nodes)
+            )
+            # `and`/`or` operators containing a duplicate name
+            # with identical unary operations
+            has_useless_name = False
+            if isinstance(unwrapped, ast.Name):
+                opchain = tuple(get_reduced_unary_operators(unwrapped))
+                has_useless_name = opchain in unary_chains[unwrapped.id]
+                unary_chains[unwrapped.id].add(opchain)
+
+            if has_useless_constant or has_useless_name:
+                self.add_violation(
+                    consistency.MeaninglessBooleanOperationViolation(node)
+                )
+                return
 
     def _check_useless_math_operator(
         self,


### PR DESCRIPTION
# I have made things!

This adds a new rule `WPS366` which disallows useless boolean operations.
It partially coincides with the ruff's `SIM223`, but complements it.

## Checklist

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made
- [x] I have added my changes to the `CHANGELOG.md`

## Related issues
Closes #3593 
