### PR TITLE
WPS366: allow single constant of any type in `or`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ Semantic versioning in our case means:
   change the client facing API, change code conventions significantly, etc.
 
 
+## WIP
+
+### Bugfixes
+
+- Fixes false positive `WPS366` allowing the use of a single constant in `or`, #3610
+
 ## 1.6.0
 
 ### Features

--- a/tests/test_visitors/test_ast/test_operators/test_useless_bool.py
+++ b/tests/test_visitors/test_ast/test_operators/test_useless_bool.py
@@ -18,10 +18,9 @@ from wemake_python_styleguide.visitors.ast.operators import (
         # `and` containing at least one constant
         'value and True',
         'value1 and 4 and value2 and "py" and True',
-        # `or` containing True/False
-        'value or False',
+        # `or` containing everythhing after constant
+        'value or False or True',
         'value1 or True or value2 or False or False',
-        # `or` containing everything after non-bool constant
         'value1 or 0 or value2',
         'value or "py" or 4',
         # `and`/`or` operators containing a duplicate name
@@ -54,6 +53,9 @@ def test_useless_bool(
 @pytest.mark.parametrize(
     'expression',
     [
+        'value or True',
+        'value or False',
+        'value or 0',
         'value or -value or ~value',
         'value1 or value2 or value3',
         'value1 or value2 or 4',

--- a/wemake_python_styleguide/violations/consistency.py
+++ b/wemake_python_styleguide/violations/consistency.py
@@ -2482,14 +2482,9 @@ class MeaninglessBooleanOperationViolation(ASTViolation):
 
     Explanation:
         - comparison of constants can be replaced with a single constant
-        - comparison with ``True``/``False`` can be removed or replaced
-            with ``True`` or ``False`` constant
         - comparison with constants in the ``and`` operator can lead to
             an implicit conditional assignment, which is better done explicitly
-        - comparison with false-like constants in the ``or`` operator
-            can be removed
-        - everything after the first true-like constant in ``or`` operator
-            can be removed
+        - everything after the first constant in ``or`` operator can be removed
         - comparison of duplicated variables can be reduced
 
     Solution:
@@ -2506,7 +2501,7 @@ class MeaninglessBooleanOperationViolation(ASTViolation):
         # Wrong:
         cond = 10 and 'value'
         cond = condition and 10
-        cond = condition or True
+        cond = condition or True or 2
         cond = condition or 'value' or 0
         cond = condition and condition
 

--- a/wemake_python_styleguide/visitors/ast/operators.py
+++ b/wemake_python_styleguide/visitors/ast/operators.py
@@ -133,11 +133,9 @@ class UselessOperatorsVisitor(base.BaseNodeVisitor):  # noqa: WPS214
             unwrapped = unwrap_unary_node(node)
 
             # `and` containing at least one constant
-            # `or` containing bool or everything after non-bool constant
+            # `or` containing everythhing after constant
             has_useless_constant = isinstance(unwrapped, ast.Constant) and (
-                isinstance(op, ast.And)
-                or isinstance(unwrapped.value, bool)
-                or position < len(nodes)
+                isinstance(op, ast.And) or position < len(nodes)
             )
             if has_useless_constant:
                 self.add_violation(


### PR DESCRIPTION
# I have made things!

## Checklist

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made
- [x] I have added my changes to the `CHANGELOG.md`

## Related issues
Closes #3610 
