### PR TITLE
fix: WPS222 false positive for nested conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ Semantic versioning in our case means:
   But, in the future we might change the configuration names/logic,
   change the client facing API, change code conventions significantly, etc.
 
+## WIP
+
+### Bugfixes
+
+- Fixes the false positive `WPS222` for nested conditions, #3630
+
 
 ## 1.6.1
 

--- a/tests/test_visitors/test_ast/test_complexity/test_counts/test_condition_counts.py
+++ b/tests/test_visitors/test_ast/test_complexity/test_counts/test_condition_counts.py
@@ -45,25 +45,39 @@ while True and 1 == 1:
     print(1)
 """
 
-# Real examples:
-
-complex_assignment = """
-some = zero and first or (second and last) or default()
-"""
-
-complex_condition = """
-if x == x1 and y == y1 and z == z1 or v == v1 or last():
+# 3 conditions, nested conditions are not counted.
+if_with_nested_conditions = """
+if (a is None or (func1(a) and b) or (func2(a) and c)):
     ...
 """
 
+# Real examples:
+
+complex_assignment = """
+some = zero and first or (second and last) or default() or c or d
+"""
+
+complex_condition = """
+if x == x1 and y == y1 and z == z1 or v == v1 or last() or to_be() \
+    or not_to_be():
+    ...
+"""
+
+complex_list_comprehension = """
+def example(x, y):
+    return [i for i in range(x) if i % 2 == 0 or i == y or i > 10 or \
+        y < 4 or i != 0]
+"""
+
 complex_while = """
-while (x > x1 or y < y1) or (small(z) and v) or last():
+while (x > x1 or y < y1) or (small(z) and v) or first() or second() or last():
     ...
 """
 
 complex_match = """
 match some:
-    case 1 if (x > x1 or y < y1) or (small(z) and v) or last():
+    case 1 if (x > x1 or y < y1) or (small(z) and v) or first() or \
+        second() or last():
         ...
 """
 
@@ -71,7 +85,8 @@ complex_gen_exp = """
 (
     ...
     for name in []
-    if (x > x1 or y < y1) or (small(z) and v) or last()
+    if (x > x1 or y < y1) or (small(z) and v) or (b() and g()) or \
+        second() or last()
 )
 """
 
@@ -89,6 +104,7 @@ complex_gen_exp = """
         condition_with_inline_for,
         condition_with_simple_inline_for,
         while_with_condition,
+        if_with_nested_conditions,
     ],
 )
 def test_module_condition_counts_normal(
@@ -111,6 +127,7 @@ def test_module_condition_counts_normal(
     [
         complex_assignment,
         complex_condition,
+        complex_list_comprehension,
         complex_while,
         complex_match,
         complex_gen_exp,
@@ -138,6 +155,7 @@ def test_module_condition_real_config(
     [
         complex_assignment,
         complex_condition,
+        complex_list_comprehension,
         complex_while,
         complex_match,
         complex_gen_exp,

--- a/wemake_python_styleguide/violations/complexity.py
+++ b/wemake_python_styleguide/violations/complexity.py
@@ -693,6 +693,8 @@ class TooManyConditionsViolation(ASTViolation):
     .. versionchanged:: 0.5.0
     .. versionchanged:: 1.4.0
         Added ``--max-conditions`` configuration options.
+    .. versionchanged:: 1.7.0
+        Stopped recursive counting of nested ``ast.BoolOp`` nodes.
     """
 
     error_template = 'Found a condition with too much logic: {0}'

--- a/wemake_python_styleguide/visitors/ast/complexity/counts.py
+++ b/wemake_python_styleguide/visitors/ast/complexity/counts.py
@@ -91,13 +91,7 @@ class ConditionsVisitor(BaseNodeVisitor):
         self.generic_visit(node)
 
     def _count_conditions(self, node: ast.BoolOp) -> int:
-        counter = 0
-        for condition in node.values:
-            if isinstance(condition, ast.BoolOp):
-                counter += self._count_conditions(condition)
-            else:
-                counter += 1
-        return counter
+        return len(node.values)
 
     def _check_conditions(self, node: ast.BoolOp) -> None:
         conditions_count = self._count_conditions(node)


### PR DESCRIPTION
# I have made things!
1. Removed recursion from ConditionsVisitor._count_conditions
2. Modified test cases in test_condition_counts.py - added more non-nested conditions to match the default max number of conditions (4).
3. Added test case for list comprehension with conditions to test_condition_counts.py

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made
- [x] I have added my changes to the `CHANGELOG.md`

## Related issues
Closes #3630 

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->