### PR TITLE
fix: WPS529 false positive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Semantic versioning in our case means:
 ### Bugfixes
 
 - Fixes the false positive `WPS222` for nested conditions, #3630
+- Fixes the false positive `WPS529` for dict subscripts in the `else` branch, #3501
 
 
 ## 1.6.1

--- a/tests/test_visitors/test_ast/test_subscripts/test_implicit_get.py
+++ b/tests/test_visitors/test_ast/test_subscripts/test_implicit_get.py
@@ -44,6 +44,13 @@ elif other:
     ...
 """
 
+else_subscripts = """
+if 'a' in kwargs:
+    pass
+else:
+    kwargs['a'] = other(kwargs)
+"""
+
 
 @pytest.mark.parametrize(
     'template',
@@ -117,6 +124,27 @@ def test_correct_if(
 ):
     """Testing that correct `if` can be used."""
     tree = parse_ast_tree(template.format(compare, expression))
+
+    visitor = ImplicitDictGetVisitor(default_options, tree=tree)
+    visitor.run()
+
+    assert_errors(visitor, [])
+
+
+@pytest.mark.parametrize(
+    'code',
+    [
+        else_subscripts,
+    ],
+)
+def test_no_implicit_dict_get_in_else_branch(
+    assert_errors,
+    parse_ast_tree,
+    default_options,
+    code,
+):
+    """Testing that subscripts in `else` branch do not trigger violation."""
+    tree = parse_ast_tree(code)
 
     visitor = ImplicitDictGetVisitor(default_options, tree=tree)
     visitor.run()

--- a/wemake_python_styleguide/violations/refactoring.py
+++ b/wemake_python_styleguide/violations/refactoring.py
@@ -1135,9 +1135,6 @@ class ImplicitDictGetViolation(ASTViolation):
             print(collection[key])
 
     .. versionadded:: 0.13.0
-    .. versionadded:: 1.7.0
-        Excluded the `else` branch, check scope changed from
-        the whole ast.If to node.body.
     """
 
     error_template = 'Found implicit `.get()` dict usage'

--- a/wemake_python_styleguide/violations/refactoring.py
+++ b/wemake_python_styleguide/violations/refactoring.py
@@ -1135,7 +1135,9 @@ class ImplicitDictGetViolation(ASTViolation):
             print(collection[key])
 
     .. versionadded:: 0.13.0
-
+    .. versionadded:: 1.7.0
+        Excluded the `else` branch, check scope changed from
+        the whole ast.If to node.body.
     """
 
     error_template = 'Found implicit `.get()` dict usage'

--- a/wemake_python_styleguide/visitors/ast/subscripts.py
+++ b/wemake_python_styleguide/visitors/ast/subscripts.py
@@ -1,4 +1,5 @@
 import ast
+from collections.abc import Iterator
 from typing import ClassVar, final
 
 from wemake_python_styleguide.logic import source
@@ -127,6 +128,11 @@ class ImplicitDictGetVisitor(base.BaseNodeVisitor):
         self._check_implicit_get(node)
         self.generic_visit(node)
 
+    def _walk_body(self, body: list[ast.stmt]) -> Iterator[ast.AST]:
+        """Yields all nodes strictly within a list of statements."""
+        for stmt in body:
+            yield from ast.walk(stmt)
+
     def _check_implicit_get(self, node: ast.If) -> None:
         if not isinstance(node.test, ast.Compare):
             return
@@ -136,7 +142,7 @@ class ImplicitDictGetVisitor(base.BaseNodeVisitor):
         checked_key = source.node_to_string(node.test.left)
         checked_collection = source.node_to_string(node.test.comparators[0])
 
-        for sub in ast.walk(node):
+        for sub in self._walk_body(node.body):
             if not isinstance(sub, ast.Subscript):
                 continue
 


### PR DESCRIPTION
# I have made things!
1. Modified `ImplicitDictGetVisitor._check_implicit_get` and add `_walk_body ` func, `else` exluded from check scope.
2. Added negative test and test case for `else` 

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made
- [x] I have added my changes to the `CHANGELOG.md`

## Related issues

Closes #3501 
<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->

🙏 Please, if you or your company is finding wemake-python-styleguide valuable, help us sustain the project by sponsoring it transparently on https://opencollective.com/wemake-python-styleguide. As a thank you, your profile/company logo will be added to our main README which receives hundreds of unique visitors per day.
