### PR TITLE
feat: forbid redundant trailing colon in slice (fixes #1071)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ Semantic versioning in our case means:
   But, in the future we might change the configuration names/logic,
   change the client facing API, change code conventions significantly, etc.
 
+## Unreleased
+
+### Features
+
+- Adds `WPS367`: forbid redundant trailing colon in slice, #1071
+
 ## 1.6.2
 
 ### Bugfixes

--- a/tests/test_visitors/test_ast/test_subscripts/test_redundant_subscripts.py
+++ b/tests/test_visitors/test_ast/test_subscripts/test_redundant_subscripts.py
@@ -17,6 +17,8 @@ usage_template = 'constant[{0}]'
         '3:None:2',
         '3:7:None',
         '3:7:1',
+        '::1',
+        '1::1',
     ],
 )
 def test_one_redundant_subscript(
@@ -44,6 +46,7 @@ def test_one_redundant_subscript(
         'None:None',
         '3:None:1',
         ':None:None',
+        '0::1',
     ],
 )
 def test_two_redundant_subscript(

--- a/tests/test_visitors/test_tokenize/test_subscripts/test_redundant_trailing_slice.py
+++ b/tests/test_visitors/test_tokenize/test_subscripts/test_redundant_trailing_slice.py
@@ -1,0 +1,69 @@
+import pytest
+
+from wemake_python_styleguide.violations.consistency import (
+    RedundantTrailingSliceViolation,
+)
+from wemake_python_styleguide.visitors.tokenize.subscripts import (
+    RedundantTrailingSliceVisitor,
+)
+
+# Wrong:
+trailing_colon_cases = [
+    'a[1:4:]',
+    'a[1::]',
+    'a[:4:]',
+    'a[None::]',
+    'a[1:None:]',
+    'a[1 + 2::]',
+]
+
+# Correct:
+correct_cases = [
+    'a[1:4]',
+    'a[1:]',
+    'a[:4]',
+    'a[::]',           # caught by NonStrictSliceOperationsViolation
+    'a[1:4:5]',
+    'a[1:4:None]',
+    'a[1]',
+    'a[1:4:1]',        # caught by RedundantSubscriptViolation, not ours
+    'a[b[1:4:5]]',     # nested valid slice
+    'a[b[1:4:]]',      # nested invalid — should flag inner
+    'a[{1: 2}]',       # dict literal inside subscript
+    'a[(1, 2)]',       # tuple inside subscript
+    'a[lambda x: x]',  # lambda inside subscript
+]
+
+
+@pytest.mark.parametrize('code', trailing_colon_cases)
+def test_redundant_trailing_colon(
+    parse_tokens,
+    assert_errors,
+    default_options,
+    code,
+):
+    """Ensure trailing colon in slice is forbidden."""
+    file_tokens = parse_tokens(code)
+    visitor = RedundantTrailingSliceVisitor(
+        default_options,
+        file_tokens=file_tokens,
+    )
+    visitor.run()
+    assert_errors(visitor, [RedundantTrailingSliceViolation])
+
+
+@pytest.mark.parametrize('code', correct_cases)
+def test_correct_slice_not_flagged(
+    parse_tokens,
+    assert_errors,
+    default_options,
+    code,
+):
+    """Ensure valid slices do not raise violation."""
+    file_tokens = parse_tokens(code)
+    visitor = RedundantTrailingSliceVisitor(
+        default_options,
+        file_tokens=file_tokens,
+    )
+    visitor.run()
+    assert_errors(visitor, [])

--- a/tests/test_visitors/test_tokenize/test_subscripts/test_redundant_trailing_slice.py
+++ b/tests/test_visitors/test_tokenize/test_subscripts/test_redundant_trailing_slice.py
@@ -22,15 +22,15 @@ correct_cases = [
     'a[1:4]',
     'a[1:]',
     'a[:4]',
-    'a[::]',           # caught by NonStrictSliceOperationsViolation
+    'a[::]',  # caught by NonStrictSliceOperationsViolation
     'a[1:4:5]',
     'a[1:4:None]',
     'a[1]',
-    'a[1:4:1]',        # caught by RedundantSubscriptViolation, not ours
-    'a[b[1:4:5]]',     # nested valid slice
-    'a[b[1:4:]]',      # nested invalid — should flag inner
-    'a[{1: 2}]',       # dict literal inside subscript
-    'a[(1, 2)]',       # tuple inside subscript
+    'a[1:4:1]',  # caught by RedundantSubscriptViolation, not ours
+    'a[b[1:4:5]]',  # nested valid slice
+    'a[b[1:4:]]',  # nested invalid — should flag inner
+    'a[{1: 2}]',  # dict literal inside subscript
+    'a[(1, 2)]',  # tuple inside subscript
     'a[lambda x: x]',  # lambda inside subscript
 ]
 

--- a/wemake_python_styleguide/presets/types/file_tokens.py
+++ b/wemake_python_styleguide/presets/types/file_tokens.py
@@ -5,6 +5,7 @@ from wemake_python_styleguide.visitors.tokenize import (
     conditions,
     primitives,
     statements,
+    subscripts,
     syntax,
 )
 
@@ -21,4 +22,5 @@ PRESET: Final = (
     statements.MultilineStringVisitor,
     conditions.IfElseVisitor,
     primitives.MultilineFormattedStringTokenVisitor,
+    subscripts.RedundantTrailingSliceVisitor,
 )

--- a/wemake_python_styleguide/violations/consistency.py
+++ b/wemake_python_styleguide/violations/consistency.py
@@ -2511,3 +2511,36 @@ class MeaninglessBooleanOperationViolation(ASTViolation):
 
     error_template = 'Found meaningless boolean operation'
     code = 366
+
+
+@final
+class RedundantTrailingSliceViolation(TokenizeViolation):
+    """
+    Forbid redundant trailing colon in subscript slice.
+
+    Reasoning:
+        Trailing colon inside a subscript slice does not change behavior.
+        For example, ``a[1:4:]`` is parsed identically to ``a[1:4]``.
+        It adds visual noise for no reason.
+
+    Solution:
+        Remove the trailing colon.
+
+    Example::
+
+        # Correct:
+        a[1:4]
+        a[1:]
+        a[:4]
+
+        # Wrong:
+        a[1:4:]
+        a[1::]
+        a[:4:]
+
+    .. versionadded:: 1.7.0
+
+    """
+
+    error_template = 'Found redundant trailing slice colon'
+    code = 367

--- a/wemake_python_styleguide/visitors/tokenize/subscripts.py
+++ b/wemake_python_styleguide/visitors/tokenize/subscripts.py
@@ -1,5 +1,5 @@
 import tokenize
-from typing import ClassVar, Final, TypedDict, final
+from typing import Final, TypedDict, final
 
 from wemake_python_styleguide.violations import consistency
 from wemake_python_styleguide.visitors.base import BaseTokenVisitor

--- a/wemake_python_styleguide/visitors/tokenize/subscripts.py
+++ b/wemake_python_styleguide/visitors/tokenize/subscripts.py
@@ -1,0 +1,95 @@
+import tokenize
+from typing import ClassVar, Final, TypedDict, final
+
+from wemake_python_styleguide.violations import consistency
+from wemake_python_styleguide.visitors.base import BaseTokenVisitor
+
+_INSIGNIFICANT_TYPES: Final = frozenset((
+    tokenize.NL,
+    tokenize.NEWLINE,
+    tokenize.COMMENT,
+    tokenize.INDENT,
+    tokenize.DEDENT,
+    tokenize.ENCODING,
+    tokenize.ENDMARKER,
+))
+
+
+_COLON_COUNT: Final = 'colon_count'
+_LAST_WAS_COLON: Final = 'last_was_colon'
+_LAST_COLON: Final = 'last_colon'
+_HAS_NON_COLON: Final = 'has_non_colon'
+
+
+@final
+class _SliceBracketState(TypedDict):
+    """Mutable state tracker for a single ``[...]`` bracket level."""
+
+    colon_count: int
+    last_was_colon: bool
+    last_colon: tokenize.TokenInfo | None
+    has_non_colon: bool
+
+
+@final
+class RedundantTrailingSliceVisitor(BaseTokenVisitor):
+    """Check for redundant trailing colon in subscript slices."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        """Initialize state for bracket tracking."""
+        super().__init__(*args, **kwargs)
+        self._bracket_stack: list[_SliceBracketState] = []
+
+    def visit(self, token: tokenize.TokenInfo) -> None:
+        """Track brackets and colons to detect trailing colon."""
+        self._maybe_push_bracket(token)
+        self._maybe_pop_bracket(token)
+        self._maybe_track_colon(token)
+        self._maybe_track_other(token)
+        super().visit(token)
+
+    def _maybe_push_bracket(self, token: tokenize.TokenInfo) -> None:
+        if token.exact_type == tokenize.OP and token.string == '[':
+            self._bracket_stack.append({
+                _COLON_COUNT: 0,
+                _LAST_WAS_COLON: False,
+                _LAST_COLON: None,
+                _HAS_NON_COLON: False,
+            })
+
+    def _maybe_pop_bracket(self, token: tokenize.TokenInfo) -> None:
+        if not (token.exact_type == tokenize.OP and token.string == ']'):
+            return
+        if not self._bracket_stack:
+            return
+        entry = self._bracket_stack.pop()
+        if (
+            entry[_LAST_WAS_COLON]
+            and entry[_COLON_COUNT] >= 2
+            and entry[_HAS_NON_COLON]
+        ):
+            self.add_violation(
+                consistency.RedundantTrailingSliceViolation(
+                    entry[_LAST_COLON],
+                ),
+            )
+
+    def _maybe_track_colon(self, token: tokenize.TokenInfo) -> None:
+        if not (
+            token.exact_type == tokenize.OP
+            and token.string == ':'
+            and self._bracket_stack
+        ):
+            return
+        entry = self._bracket_stack[-1]
+        entry[_COLON_COUNT] += 1
+        entry[_LAST_WAS_COLON] = True
+        entry[_LAST_COLON] = token
+
+    def _maybe_track_other(self, token: tokenize.TokenInfo) -> None:
+        if token.type in _INSIGNIFICANT_TYPES or not self._bracket_stack:
+            return
+        entry = self._bracket_stack[-1]
+        entry[_LAST_WAS_COLON] = False
+        if token.string != ':':
+            entry[_HAS_NON_COLON] = True


### PR DESCRIPTION
# I have made things!

Added `WPS367` (`RedundantTrailingSliceViolation`) to detect redundant trailing colons inside subscript slices that the AST parser cannot distinguish. Introduced `RedundantTrailingSliceVisitor` in `visitors/tokenize/subscripts.py` to catch cases like `a[1:4:]`, `a[1::]`, and `a[:4:]` at the token level. Also extended the existing `RedundantSubscriptViolation` test suite with previously uncovered `step=1` scenarios (`::1`, `1::1`, `0::1`).

## Checklist
- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made
- [x] I have added my changes to the `CHANGELOG.md`

## Related issues
Closes #1071

🙏 Please, if you or your company is finding wemake-python-styleguide valuable, help us sustain the project by sponsoring it transparently on https://opencollective.com/wemake-python-styleguide. As a thank you, your profile/company logo will be added to our main README which receives hundreds of unique visitors per day.
