### PR TITLE
Fix issue 1901

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ Semantic versioning in our case means:
   But, in the future we might change the configuration names/logic,
   change the client facing API, change code conventions significantly, etc.
 
+## Unreleased
+
+### Features
+
+- Adds `WPS482`: forbid initializing multiple variables on one line, #1901
+
+
 ## 1.7.1
 
 ### Bugfixes

--- a/tests/fixtures/noqa/noqa.py
+++ b/tests/fixtures/noqa/noqa.py
@@ -148,7 +148,7 @@ def some_function():
     _should_not_be_used = 1  # noqa: WPS122
     my_print(_should_not_be_used)  # noqa: WPS121
 
-used, __ = 1, 2  # noqa: WPS123
+used, __ = 1, 2  # noqa: WPS123, WPS482
 
 class Mem0Output:  # noqa: WPS124
     # See:

--- a/tests/test_checker/test_noqa.py
+++ b/tests/test_checker/test_noqa.py
@@ -250,6 +250,7 @@ SHOULD_BE_RAISED = types.MappingProxyType(
         'WPS479': 0,
         'WPS480': 0,  # only triggers on 3.12+
         'WPS481': 10,
+        'WPS482': 1,
         'WPS500': 1,
         'WPS501': 1,
         'WPS502': 0,  # disabled since 1.0.0

--- a/tests/test_visitors/test_ast/test_builtins/test_assign/test_multiple_variables_initialization.py
+++ b/tests/test_visitors/test_ast/test_builtins/test_assign/test_multiple_variables_initialization.py
@@ -1,0 +1,74 @@
+import pytest
+
+from wemake_python_styleguide.violations.best_practices import (
+    MultipleVariablesInitializationViolation,
+)
+from wemake_python_styleguide.visitors.ast.builtins import (
+    MultipleVariablesInitializationVisitor,
+)
+
+# Correct usages:
+
+function_unpacking = 'first, second = some_tuple()'
+swap_assignment = 'first, second = second, first'
+single_assignment = 'constant = 1'
+spread_assignment = 'first, *_, second = [1, 2, 4, 3]'
+
+# Wrong usages:
+
+tuple_assignment = 'first, second = (1, 2)'
+list_unpacking = 'first, second = [], []'
+mixed_unpacking = 'first, second = (1, [])'
+
+
+@pytest.mark.parametrize(
+    'code',
+    [
+        single_assignment,
+        spread_assignment,
+        function_unpacking,
+        swap_assignment,
+    ],
+)
+def test_correct_assignments(
+    assert_errors,
+    parse_ast_tree,
+    code,
+    default_options,
+):
+    """Testing that correct assignments work."""
+    tree = parse_ast_tree(code)
+
+    visitor = MultipleVariablesInitializationVisitor(
+        default_options,
+        tree=tree,
+    )
+    visitor.run()
+
+    assert_errors(visitor, [])
+
+
+@pytest.mark.parametrize(
+    'code',
+    [
+        tuple_assignment,
+        list_unpacking,
+        mixed_unpacking,
+    ],
+)
+def test_multiple_variables_initialization(
+    assert_errors,
+    parse_ast_tree,
+    code,
+    default_options,
+):
+    """Testing that multiple variables initialization is restricted."""
+    tree = parse_ast_tree(code)
+
+    visitor = MultipleVariablesInitializationVisitor(
+        default_options,
+        tree=tree,
+    )
+    visitor.run()
+
+    assert_errors(visitor, [MultipleVariablesInitializationViolation])

--- a/wemake_python_styleguide/presets/types/tree.py
+++ b/wemake_python_styleguide/presets/types/tree.py
@@ -56,6 +56,7 @@ PRESET: Final = (
     builtins.WrongStringVisitor,
     builtins.WrongFormatStringVisitor,
     builtins.WrongAssignmentVisitor,
+    builtins.MultipleVariablesInitializationVisitor,
     builtins.WrongCollectionVisitor,
     operators.UselessOperatorsVisitor,
     operators.WrongMathOperatorVisitor,

--- a/wemake_python_styleguide/violations/best_practices.py
+++ b/wemake_python_styleguide/violations/best_practices.py
@@ -3031,3 +3031,35 @@ class LeakingForLoopViolation(ASTViolation):
 
     error_template = 'Found a leaking ``for`` loop in a class or module body'
     code = 481
+
+
+@final
+class MultipleVariablesInitializationViolation(ASTViolation):
+    """
+    Forbid initializing multiple variables on a single line.
+
+    Reasoning:
+        Assigning multiple variables in one line reduces readability.
+        It is harder to see where each variable is initialized.
+
+    Solution:
+        Use separate assignment statements for each variable.
+
+    Example::
+
+        # Correct:
+        ab = []
+        cd = []
+        a, b = some_tuple()
+        x, y = y, x
+
+        # Wrong:
+        ab, cd = [], []
+        x, y = (1, 2)
+
+    .. versionadded:: 1.8.0
+
+    """
+
+    error_template = 'Found multiple variables initialized on one line'
+    code = 482

--- a/wemake_python_styleguide/visitors/ast/builtins.py
+++ b/wemake_python_styleguide/visitors/ast/builtins.py
@@ -375,6 +375,34 @@ class WrongAssignmentVisitor(base.BaseNodeVisitor):
 
 
 @final
+class MultipleVariablesInitializationVisitor(base.BaseNodeVisitor):
+    """Ensures that multiple variables are not initialized on one line."""
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        """Checks assignments for multiple variables initialization."""
+        self._check_multiple_variables_initialization(node)
+        self.generic_visit(node)
+
+    def _check_multiple_variables_initialization(
+        self,
+        node: ast.Assign,
+    ) -> None:
+        if len(node.targets) != 1:
+            return
+        target = node.targets[0]
+        if not isinstance(target, ast.Tuple):
+            return
+        if not isinstance(node.value, ast.Tuple):
+            return
+        # Allow swapping: x, y = y, x (all elements in value are ast.Name)
+        if all(isinstance(elt, ast.Name) for elt in node.value.elts):
+            return
+        self.add_violation(
+            best_practices.MultipleVariablesInitializationViolation(node),
+        )
+
+
+@final
 class WrongCollectionVisitor(base.BaseNodeVisitor):
     """Ensures that collection definitions are correct."""
 


### PR DESCRIPTION
# I have made things!

This PR implements the rule requested in #1901: forbidding the initialization of multiple variables on a single line.

## **Problem**

Assignments like:

```python
ab, cd = [], []
x, y = (1, 2)
```
reduce readability because it is harder to see where each variable is initialized. The issue asked to detect this pattern while keeping legitimate unpacking (function returns) and variable swaps intact.

## **Solution**

Added `WPS482` (`MultipleVariablesInitializationViolation`) and a new AST visitor `MultipleVariablesInitializationVisitor`.

The visitor checks `ast.Assign` nodes with a single `Tuple` target and a `Tuple` value. If both sides are tuple literals, it raises a violation, **except** for pure name-swapping (`x, y = y, x`), which is explicitly allowed because all elements on the right-hand side are `ast.Name` nodes.

## What is forbidden
```
ab, cd = [], []        # tuple literal unpacking
x, y = (1, 2)          # tuple literal unpacking
a, b = (1, [])         # mixed literal unpacking
```
## What is allowed
```
a, b = some_tuple()    # function return unpacking
x, y = y, x            # variable swap
first, *_, second = [1, 2, 3]  # spread unpacking
```
## Why a separate visitor class?**

The existing `WrongAssignmentVisitor` already contains 7 public/protected methods. Adding one more would trigger `WPS214` (too many methods). To keep the architecture clean and avoid mixing unrelated rules, I created `MultipleVariablesInitializationVisitor` as a standalone class and registered it in `tree.py`.

# Files changed**

- `wemake_python_styleguide/violations/best_practices.py` — new `MultipleVariablesInitializationViolation` (WPS482) with full docstring (`Reasoning`, `Solution`, `Example`, `versionadded:: 1.7.0`)
- `wemake_python_styleguide/visitors/ast/builtins.py` — new `MultipleVariablesInitializationVisitor`
- `wemake_python_styleguide/presets/types/tree.py` — registered the new visitor
- `tests/test_visitors/test_ast/test_builtins/test_assign/test_multiple_variables_initialization.py` — test cases for allowed and forbidden patterns
- `CHANGELOG.md` — added entry under `## Unreleased`

# Checklist
- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made
- [x] I have added my changes to the `CHANGELOG.md`

Related issues
Closes #1901

🙏 Please, if you or your company is finding wemake-python-styleguide valuable, help us sustain the project by sponsoring it transparently on https://opencollective.com/wemake-python-styleguide. As a thank you, your profile/company logo will be added to our main README which receives hundreds of unique visitors per day.