### PR TITLE
docs: add PyCharm File Watcher integration guide (fixes wemake-services#2904)

### DIFF
--- a/docs/pages/usage/integrations/editors.rst
+++ b/docs/pages/usage/integrations/editors.rst
@@ -10,5 +10,5 @@ with ``format = default`` in your configuration.
 - `atom plugin <https://atom.io/packages/linter-flake8>`_
 - `vim plugin <https://github.com/nvie/vim-flake8>`_
 - `emacs plugin <https://github.com/flycheck/flycheck>`_
-- `pycharm plugin <https://plugins.jetbrains.com/plugin/11563-flake8-support>`_
+- :doc:`PyCharm integration <pycharm>`
 - `wing plugin <https://github.com/grahamu/flake8panel>`_

--- a/docs/pages/usage/integrations/index.rst
+++ b/docs/pages/usage/integrations/index.rst
@@ -10,7 +10,7 @@ WPS can integrate with lots of popular and mainstream technologies. In this sect
 
   - `vscode plugin <https://code.visualstudio.com/docs/python/linting>`_
   - `vim plugin <https://github.com/nvie/vim-flake8>`_
-  - `pycharm plugin <https://plugins.jetbrains.com/plugin/11563-flake8-support>`_
+  - :doc:`PyCharm integration <pycharm>`
 
 - :doc:`Run WPS linting in GitHub Actions pipelines <github-actions>`
 
@@ -27,3 +27,4 @@ WPS can integrate with lots of popular and mainstream technologies. In this sect
   stubs.rst
   extras.rst
   jupyter_notebooks.rst
+  pycharm.rst

--- a/docs/pages/usage/integrations/pycharm.rst
+++ b/docs/pages/usage/integrations/pycharm.rst
@@ -1,0 +1,62 @@
+PyCharm
+-------
+
+There are two ways to use ``wemake-python-styleguide`` inside
+`PyCharm <https://www.jetbrains.com/pycharm/>`_:
+
+1. `Flake8 Support plugin <https://plugins.jetbrains.com/plugin/11563-flake8-support>`_
+2. A custom **File Watcher** configured to run ``flake8`` with WPS enabled
+
+The File Watcher approach is useful
+when you want real-time feedback on every file save
+or when the plugin does not pick up your WPS installation.
+
+Prerequisites
+~~~~~~~~~~~~~
+
+Make sure you have ``wemake-python-styleguide`` installed.
+We recommend using `uv <https://docs.astral.sh/uv/>`_:
+
+.. code:: bash
+
+  uv tool install --with-executables-from flake8 wemake-python-styleguide
+
+After installation the ``flake8`` binary is available on your ``PATH``
+(usually at ``~/.local/bin/flake8`` on Linux and macOS).
+
+Setting up a File Watcher
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+1. Open **Settings** (or **Preferences** on macOS).
+2. Navigate to **Tools → File Watchers**.
+3. Click **+** and choose **<custom>**.
+4. Configure the watcher:
+
+   - **Name**: ``wemake-python-styleguide``
+   - **File type**: ``Python``
+   - **Scope**: ``Project Files``
+   - **Program**: ``flake8`` (or the full path from above)
+   - **Arguments**: ``--select=WPS $FilePath$``
+   - **Output paths to refresh**: ``$FilePath$``
+   - **Working directory**: ``$ProjectFileDir$``
+
+5. In the **Advanced Options** section enable:
+
+   - **Auto-save edited files to trigger the watcher**
+   - **Trigger the watcher on external changes**
+
+6. Click **OK**.
+
+The watcher will run WPS on every save and show violations
+directly in the PyCharm editor and in the **Inspections** panel.
+
+Troubleshooting
+~~~~~~~~~~~~~~~
+
+If you do not see any violations:
+
+- Make sure the **Program** path points to the ``flake8`` binary
+  that has ``wemake-python-styleguide`` installed inside the same environment.
+- Try running the same command from the terminal to verify it works.
+- Check that your project has a valid ``setup.cfg`` or ``pyproject.toml``
+  with WPS configuration.


### PR DESCRIPTION
Added a dedicated PyCharm integration guide (`pycharm.rst`) with step-by-step File Watcher setup for running WPS on file save. Updated `editors.rst` and `index.rst` with internal cross-references to the new page.

## Checklist

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [ ] I have created at least one test case for the changes I have made
  N/A: this PR only adds documentation. No code changes requiring unit tests.
- [x] I have updated the documentation for the changes I have made
- [ ] I have added my changes to the `CHANGELOG.md`
  Skipped per [previous review](https://github.com/wemake-services/wemake-python-styleguide/pull/3641): doc changes do not require changelog entries.

## Related issues

Closes wemake-services#2904

## Notes

This is a remake of #3641. The previous PR had two issues:
1. Used incorrect `uvx install` command (uvx does not have `install` subcommand). Fixed to `uv tool install --with-executables-from flake8 wemake-python-styleguide`.
2. Included unrelated changes from a stale branch (`.pre-commit-config.yaml`, `Dockerfile`). This branch is rebased cleanly on latest `master`.