### PR TITLE
docs: add PyCharm LSP integration guide (fixes wemake-services#3586)

### DIFF
--- a/docs/pages/usage/integrations/pycharm.rst
+++ b/docs/pages/usage/integrations/pycharm.rst
@@ -1,15 +1,18 @@
 PyCharm
 -------
 
-There are two ways to use ``wemake-python-styleguide`` inside
+There are three ways to use ``wemake-python-styleguide`` inside
 `PyCharm <https://www.jetbrains.com/pycharm/>`_:
 
 1. `Flake8 Support plugin <https://plugins.jetbrains.com/plugin/11563-flake8-support>`_
 2. A custom **File Watcher** configured to run ``flake8`` with WPS enabled
+3. An **LSP server** via ``python-lsp-server`` (requires `LSP4IJ <https://plugins.jetbrains.com/plugin/23257-lsp4ij>`__)
 
 The File Watcher approach is useful
 when you want real-time feedback on every file save
 or when the plugin does not pick up your WPS installation.
+The LSP approach provides the richest IDE integration
+with inline diagnostics, hover tooltips, and quick fixes.
 
 Prerequisites
 ~~~~~~~~~~~~~
@@ -49,6 +52,75 @@ Setting up a File Watcher
 
 The watcher will run WPS on every save and show violations
 directly in the PyCharm editor and in the **Inspections** panel.
+
+Setting up an LSP server
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+This method uses ``python-lsp-server`` together with the LSP4IJ plugin
+to provide inline error highlighting, hover information, and more.
+
+1. **Install the LSP4IJ plugin**
+
+   Go to **Settings → Plugins → Marketplace**, search for
+   `LSP4IJ <https://plugins.jetbrains.com/plugin/23257-lsp4ij>`__
+   and install it.
+
+2. **Install ``python-lsp-server``**
+
+   We recommend using `uv <https://docs.astral.sh/uv/>`_:
+
+   .. code:: bash
+
+     uv tool install \
+       --with flake8 \
+       --with wemake-python-styleguide \
+       --with pyls-flake8 \
+       python-lsp-server
+
+   After installation the ``pylsp`` binary is available on your ``PATH``
+   (usually at ``~/.local/bin/pylsp`` on Linux and macOS).
+
+3. **Find the ``pylsp`` executable**
+
+   Run ``where pylsp`` (or ``which pylsp``) and note the full path.
+
+4. **Create a new LSP server definition**
+
+   1. Open **Settings → Languages & Frameworks →
+      Language Server Protocol → Server Definitions**.
+   2. Click **+** to add a new server.
+   3. Set **Name** to ``pylsp-wps`` and **Path**
+      to the ``pylsp`` executable from step 3.
+   4. Switch to the **Configuration** tab and paste:
+
+      .. code:: json
+
+        {
+          "pylsp": {
+            "plugins": {
+              "flake8": {
+                "enabled": true,
+                "select": ["WPS", "E"]
+              },
+              "pycodestyle": { "enabled": false },
+              "pyflakes": { "enabled": false },
+              "mccabe": { "enabled": false }
+            }
+          }
+        }
+
+   5. In **Mappings** add ``Python`` as the language for this server.
+   6. Click **OK**.
+
+5. **Restart PyCharm**
+
+   Restart the IDE completely so the LSP server can initialise.
+
+6. **Verify**
+
+   Open a Python file and introduce an intentional WPS violation.
+   You should see inline squiggles and hover tooltips
+   with the violation message.
 
 Troubleshooting
 ~~~~~~~~~~~~~~~


### PR DESCRIPTION
Extended the PyCharm integration guide with a third method:
setting up WPS via python-lsp-server and the LSP4IJ plugin.

- Updated the introduction to mention three approaches
  (plugin, File Watcher, and LSP).
- Added a new "Setting up an LSP server" section with
  uv-based installation instructions and LSP4IJ configuration.
- Adapted the original tutorial from #3586 to use `uv` instead of `pipx`
  to match the project's tooling recommendations.
- Kept the existing File Watcher and Troubleshooting sections intact.

## Checklist

- [x] I have double checked that there are no unrelated changes in this pull request
- [ ] I have created at least one test case for the changes I have made
  N/A: this PR only adds documentation. No code changes requiring unit tests.
- [x] I have updated the documentation for the changes I have made
- [ ] I have added my changes to the `CHANGELOG.md`
  Skipped: doc changes do not require changelog entries (per previous review).

## Related issues

Closes wemake-services#3586

## Notes

This is a follow-up to #3645 (PyCharm File Watcher guide). The two PRs
complement each other by covering both File Watcher and LSP workflows.