### PR TITLE
[BUG] Prevent domain names from triggering WPS347

### DIFF
--- a/wemake_python_styleguide/visitors/ast/imports.py
+++ b/wemake_python_styleguide/visitors/ast/imports.py
@@ -72,6 +72,12 @@ class _ImportFromValidator(_BaseImportValidator):
 
     def _check_vague_alias(self, node: ast.ImportFrom) -> None:
         for alias in node.names:
+            is_imported_as_domain_name = (
+                alias.asname
+                and alias.asname in self._options.allowed_domain_names
+            )
+            if is_imported_as_domain_name:
+                continue
             for name in filter(None, (alias.name, alias.asname)):
                 is_regular_import = (
                     alias.asname and name != alias.asname


### PR DESCRIPTION
When having `flake8-typing-as-t` that enforces a pallets-originating convention of doing `import t as t`. I have it configured with the `import t as _t` enforcement mode. To follow the same convention with typing-only imports from other modules, I also import the `collections.abc` module similarly:

```python
import typing as _t

if _t.TYPE_CHECKING:
    from collections import abc as _c
```

That `from collections import abc as _c` line incorrectly trips the WPS347 rule check claiming that it's vague.

I however correctly set the `_c` as a domain name as follows:
```ini
# .flake8

# flake8-typing-as-t
# TYT02:
typing-as-t-imported-name = _t

# wemake-python-styleguide
# WPS111:
# `_t` will be enforced by `flake8-typing-as-t`
allowed-domain-names =
  _t,
  _c,
```

This patch makes the check respect the `allowed-domain-names` setting thus preventing WPS from reporting a false-positive match.

This is a promptly checked change via a local `site-packages` modification but is coded in-browser without any additional validation or testing. Feel free to push additional tests into the branch.

----

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [ ] I have created at least one test case for the changes I have made
- [ ] I have updated the documentation for the changes I have made
- [ ] I have added my changes to the `CHANGELOG.md`