### PR TITLE
simplify count_consecutive_unary_operator

### DIFF
--- a/wemake_python_styleguide/logic/tree/operators.py
+++ b/wemake_python_styleguide/logic/tree/operators.py
@@ -35,24 +35,28 @@ def get_parent_ignoring_unary(node: ast.AST) -> ast.AST | None:
         node = parent
 
 
-def count_consecutive_unary_operator(
+def max_consecutive_unary_operators(
     node: ast.AST,
     operator: type[ast.unaryop],
-    counter: int = 0,
-    max_counter: int = 0,
 ) -> int:
     """Counts the maximum number of consecutive identical unary operators."""
-    parent = get_parent(node)
-    if not isinstance(parent, ast.UnaryOp):
-        return max(counter, max_counter)
+    current_streak = 0
+    max_streak = 0
+    current = node
 
-    if isinstance(parent.op, operator):
-        return count_consecutive_unary_operator(
-            parent, operator, counter + 1, max_counter
-        )
-    if counter > max_counter:
-        return count_consecutive_unary_operator(parent, operator, 0, counter)
-    return count_consecutive_unary_operator(parent, operator, 0, max_counter)
+    while True:
+        parent = get_parent(current)
+
+        if not isinstance(parent, ast.UnaryOp):
+            return max(current_streak, max_streak)
+
+        if isinstance(parent.op, operator):
+            current_streak += 1
+        else:
+            max_streak = max(max_streak, current_streak)
+            current_streak = 0
+
+        current = parent
 
 
 def get_reduced_unary_operators(

--- a/wemake_python_styleguide/visitors/ast/operators.py
+++ b/wemake_python_styleguide/visitors/ast/operators.py
@@ -7,8 +7,8 @@ from wemake_python_styleguide.compat.aliases import TextNodes
 from wemake_python_styleguide.logic import walk
 from wemake_python_styleguide.logic.nodes import get_parent
 from wemake_python_styleguide.logic.tree.operators import (
-    count_consecutive_unary_operator,
     get_reduced_unary_operators,
+    max_consecutive_unary_operators,
     unwrap_unary_node,
 )
 from wemake_python_styleguide.types import AnyNodes
@@ -105,7 +105,7 @@ class UselessOperatorsVisitor(base.BaseNodeVisitor):  # noqa: WPS214
 
     def _check_operator_count(self, node: ast.Constant) -> None:
         for node_type, limit in self._unary_limits.items():
-            if count_consecutive_unary_operator(node, node_type) > limit:
+            if max_consecutive_unary_operators(node, node_type) > limit:
                 self.add_violation(
                     consistency.UselessOperatorsViolation(
                         node,


### PR DESCRIPTION
# I have made things!

Replaces the recursive implementation of `count_consecutive_unary_operator` with an iterative one.

## Reasoning

- Avoids potential `RecursionError`
- Slightly improves performance by eliminating function call overhead.

And most importantly:
- Improves readability. The iterative version is more compact and the logic for updating the maximum streak and resetting the current streak is now explicit and straightforward, making the code easier to follow and maintain.


<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [ ] I have created at least one test case for the changes I have made
- [ ] I have updated the documentation for the changes I have made
- [ ] I have added my changes to the `CHANGELOG.md`

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->

🙏 Please, if you or your company is finding wemake-python-styleguide valuable, help us sustain the project by sponsoring it transparently on https://opencollective.com/wemake-python-styleguide. As a thank you, your profile/company logo will be added to our main README which receives hundreds of unique visitors per day.
