### PR TITLE
feat(consistency): add SingleCaseMatchViolation (WPS367)

### DIFF
--- a/tests/test_visitors/test_ast/test_conditions/test_single_case_match.py
+++ b/tests/test_visitors/test_ast/test_conditions/test_single_case_match.py
@@ -1,0 +1,141 @@
+import pytest
+
+from wemake_python_styleguide.violations.consistency import (
+    SingleCaseMatchViolation,
+)
+from wemake_python_styleguide.visitors.ast.conditions import (
+    SimplifiableMatchVisitor,
+)
+
+# Wrong: single case without guard
+single_case_match = """
+match subject:
+    case {0}:
+        pass
+"""
+
+# Wrong: single case with as binding
+single_case_with_as = """
+match subject:
+    case {0} as x:
+        pass
+"""
+
+# Correct: single case with guard (should not raise)
+single_case_with_guard = """
+match subject:
+    case {0} if check():
+        pass
+"""
+
+# Correct: multiple cases (should not raise)
+multi_case_match = """
+match subject:
+    case 1:
+        pass
+    case 2:
+        pass
+"""
+
+# Correct: single case with wildcard (should not raise)
+single_wildcard_match = """
+match subject:
+    case _:
+        pass
+"""
+
+# Correct: single case irrefutable binding (should not raise)
+single_irrefutable_match = """
+match subject:
+    case x:
+        pass
+"""
+
+
+@pytest.mark.parametrize(
+    'code',
+    [
+        '1',
+        'True',
+        'None',
+        '"string"',
+        'ns.CONST',
+        'State.REJECTED',
+    ],
+)
+def test_single_case_match_violation(
+    code,
+    assert_errors,
+    parse_ast_tree,
+    default_options,
+):
+    """Test that single-case match raises a violation."""
+    tree = parse_ast_tree(single_case_match.format(code))
+    visitor = SimplifiableMatchVisitor(default_options, tree=tree)
+    visitor.run()
+    assert_errors(visitor, [SingleCaseMatchViolation])
+
+
+@pytest.mark.parametrize(
+    'code',
+    [
+        '1',
+        'True',
+        'None',
+        '"string"',
+    ],
+)
+def test_single_case_with_as_violation(
+    code,
+    assert_errors,
+    parse_ast_tree,
+    default_options,
+):
+    """Test that single-case match with as binding raises a violation."""
+    tree = parse_ast_tree(single_case_with_as.format(code))
+    visitor = SimplifiableMatchVisitor(default_options, tree=tree)
+    visitor.run()
+    assert_errors(visitor, [SingleCaseMatchViolation])
+
+
+@pytest.mark.parametrize(
+    'code',
+    [
+        '1',
+        'True',
+        'None',
+        '"string"',
+    ],
+)
+def test_single_case_with_guard_no_violation(
+    code,
+    assert_errors,
+    parse_ast_tree,
+    default_options,
+):
+    """Test that single-case match with guard does not raise."""
+    tree = parse_ast_tree(single_case_with_guard.format(code))
+    visitor = SimplifiableMatchVisitor(default_options, tree=tree)
+    visitor.run()
+    assert_errors(visitor, [])
+
+
+@pytest.mark.parametrize(
+    'template',
+    [
+        multi_case_match,
+        single_wildcard_match,
+        single_irrefutable_match,
+    ],
+)
+def test_no_violation_templates(
+    template,
+    assert_errors,
+    parse_ast_tree,
+    default_options,
+):
+    """Test that non-violating patterns do not raise."""
+    tree = parse_ast_tree(template)
+    visitor = SimplifiableMatchVisitor(default_options, tree=tree)
+    visitor.run()
+    assert_errors(visitor, [])

--- a/wemake_python_styleguide/violations/consistency.py
+++ b/wemake_python_styleguide/violations/consistency.py
@@ -2511,3 +2511,36 @@ class MeaninglessBooleanOperationViolation(ASTViolation):
 
     error_template = 'Found meaningless boolean operation'
     code = 366
+
+
+@final
+class SingleCaseMatchViolation(ASTViolation):
+    """
+    Some ``match`` statements with a single case can be simplified to ``if``.
+
+    Reasoning:
+        Using ``match`` for a single case is unnecessarily verbose
+        and less readable than a simple ``if`` statement.
+        A single ``case`` with no wildcard/default adds no value
+        over a plain ``if`` condition.
+
+    Solution:
+        Replace ``match ... case`` with ``if``.
+
+    Example::
+
+        # Correct:
+        if x == 1:
+            do_something()
+
+        # Wrong:
+        match x:
+            case 1:
+                do_something()
+
+    .. versionadded:: 1.7.0
+
+    """
+
+    error_template = 'Found single-case `match` that can be just `if`'
+    code = 367

--- a/wemake_python_styleguide/visitors/ast/conditions.py
+++ b/wemake_python_styleguide/visitors/ast/conditions.py
@@ -208,6 +208,11 @@ class SimplifiableMatchVisitor(BaseNodeVisitor):
 
     def _check_simplifiable_match(self, node: ast.Match) -> None:
         cases = node.cases
+
+        if len(cases) == 1:
+            self.add_violation(consistency.SingleCaseMatchViolation(node))
+            return
+
         if len(cases) == 2:
             first, second = cases
 


### PR DESCRIPTION
## Description

Adds a new violation `SingleCaseMatchViolation` (WPS367) to detect single-case `match` statements that can be simplified to a plain `if` statement.

## Problem

A `match` statement with only one `case` and no wildcard/default is unnecessarily verbose and less readable than a simple `if` statement:

```python
# Bad (WPS367)
match x:
    case 1:
        do_something()

# Good
if x == 1:
    do_something()
```

## Changes

- **violations/consistency.py**: Added `SingleCaseMatchViolation` class (code 367)
- **visitors/ast/conditions.py**: Added `len(cases) == 1` check to `SimplifiableMatchVisitor._check_simplifiable_match`
- **tests/test_visitors/test_ast/test_conditions/test_single_case_match.py**: Added test cases for violation and non-violation scenarios

## Test Cases

- Single case with literal patterns (1, True, None, strings) -> violation
- Single case with `as` binding -> violation
- Single case with guard (`if check()`) -> no violation
- Multiple cases -> no violation
- Wildcard pattern -> no violation
- Irrefutable binding -> no violation

Closes #3528