### PR TITLE
feat: extend f-string rules to t-strings (#3613)

### DIFF
--- a/tests/test_visitors/test_ast/test_builtins/test_strings/test_formatted_string.py
+++ b/tests/test_visitors/test_ast/test_builtins/test_strings/test_formatted_string.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 
 from wemake_python_styleguide.violations.complexity import (
@@ -259,3 +261,50 @@ def test_simple_f_string(assert_errors, parse_ast_tree, code, default_options):
     visitor.run()
 
     assert_errors(visitor, [])
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 14),
+    reason='t-strings are only in Python 3.14+',
+)
+@pytest.mark.parametrize(
+    'code',
+    [
+        't"smth {value}"',
+        't"smth {user.get_full_name()}"',
+        't""',
+    ],
+)
+def test_simple_t_string(assert_errors, parse_ast_tree, code, default_options):
+    """Testing that non complex ``t`` strings are allowed."""
+    tree = parse_ast_tree(code)
+
+    visitor = WrongFormatStringVisitor(default_options, tree=tree)
+    visitor.run()
+
+    assert_errors(visitor, [])
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 14),
+    reason='t-strings are only in Python 3.14+',
+)
+@pytest.mark.parametrize(
+    'code',
+    [
+        't"smth {value1 + value2}"',
+        't"smth {math_func(1, 2, 3, 4)}"',
+        't"smth {value=:{filler}^{padding}.{precision}f}"',
+    ],
+)
+def test_complex_t_string(assert_errors, parse_ast_tree, code, default_options):
+    """Testing that complex ``t`` strings are not allowed."""
+    tree = parse_ast_tree(code)
+
+    visitor = WrongFormatStringVisitor(default_options, tree=tree)
+    visitor.run()
+
+    assert_errors(
+        visitor,
+        [TooComplexFormattedStringViolation],
+    )

--- a/tests/test_visitors/test_ast/test_builtins/test_strings/test_formatted_string.py
+++ b/tests/test_visitors/test_ast/test_builtins/test_strings/test_formatted_string.py
@@ -82,7 +82,7 @@ f_double_call_arg = "{0}'{{foo()(arg)}}'"
 f_single_chained_functions = "{0}'{{f1().f2()}}'"
 f_function_with_four_args = "{0}'{{func(arg1, arg2, arg3, arg4)}}'"
 f_method_with_four_args = "{0}'{{obj.meth(arg1, arg2, arg3, arg4)}}-post'"
-f_nested_string = """{0}'{{{0}"{{value}}"}}'"""
+f_nested_string = """{0}'{{{0}"{{value}}"}}'"""  # noqa: WPS322
 # Disallowed format specifiers
 f_format_var_multi = "{0}'pre {{value:{{fmt1}}{{fmt2}}}}'"
 f_format_var_chain = "{0}'{{value:{{fmt.attr.attr}}}}'"
@@ -116,7 +116,7 @@ f_format_assign_var_multi = "{0}'{{value=:{{fmt1}}{{fmt2}}}}'"
 # regression 1921
 f_string_comma_format = '{0}"Count={{count:,}}"'
 
-PREFIXES = [
+PREFIXES = (
     'f',
     pytest.param(
         't',
@@ -125,7 +125,7 @@ PREFIXES = [
             reason='t-strings are only in Python 3.14+',
         ),
     ),
-]
+)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_visitors/test_ast/test_builtins/test_strings/test_formatted_string.py
+++ b/tests/test_visitors/test_ast/test_builtins/test_strings/test_formatted_string.py
@@ -275,7 +275,12 @@ def test_simple_f_string(assert_errors, parse_ast_tree, code, default_options):
         't""',
     ],
 )
-def test_simple_t_string(assert_errors, parse_ast_tree, code, default_options):
+def test_simple_t_string(  # pragma: >=3.14 cover
+    assert_errors,
+    parse_ast_tree,
+    code,
+    default_options,
+):
     """Testing that non complex ``t`` strings are allowed."""
     tree = parse_ast_tree(code)
 
@@ -297,7 +302,12 @@ def test_simple_t_string(assert_errors, parse_ast_tree, code, default_options):
         't"smth {value=:{filler}^{padding}.{precision}f}"',
     ],
 )
-def test_complex_t_string(assert_errors, parse_ast_tree, code, default_options):
+def test_complex_t_string(  # pragma: >=3.14 cover
+    assert_errors,
+    parse_ast_tree,
+    code,
+    default_options,
+):
     """Testing that complex ``t`` strings are not allowed."""
     tree = parse_ast_tree(code)
 

--- a/tests/test_visitors/test_ast/test_builtins/test_strings/test_formatted_string.py
+++ b/tests/test_visitors/test_ast/test_builtins/test_strings/test_formatted_string.py
@@ -22,99 +22,110 @@ some.format(2)
 """
 
 # Allowed
-f_single_chained_attr = "f'{attr1.attr2}'"
-f_variable_lookup = "f'smth {value}'"
-f_multi_variable_lookup = "f'smth {value1} {value2} {value3}'"
-f_dict_lookup_str_key = 'f\'smth {dict_value["key"]}\''
-f_list_index_lookup = "f'smth {list_value[0]}'"
-f_function_empty_args = "f'smth {user.get_full_name()}'"
-f_attr_on_function = "f'{fcn().attr}'"
-f_true_index = "f'{array[True]}'"
-f_none_index = "f'{array[None]}'"
-f_byte_index = 'f\'{array[b"Hello"]}\''
-f_empty_string = "f''"
-f_function_with_single_arg = "f'smth {func(arg)}'"
-f_function_with_three_args = "f'{func(arg1, arg2, arg3)}'"
-f_method_with_three_args = "f'{obj.method(arg1, arg2, arg3)}'"
-f_assign = "f'{value=}'"
-f_assign_attr = "f'{value.attr=}'"
-f_assign_call = "f'{value()=}'"
+f_single_chained_attr = "{0}'{{attr1.attr2}}'"
+f_variable_lookup = "{0}'smth {{value}}'"
+f_multi_variable_lookup = "{0}'smth {{value1}} {{value2}} {{value3}}'"
+f_dict_lookup_str_key = '{0}\'smth {{dict_value["key"]}}\''
+f_list_index_lookup = "{0}'smth {{list_value[0]}}'"
+f_function_empty_args = "{0}'smth {{user.get_full_name()}}'"
+f_attr_on_function = "{0}'{{fcn().attr}}'"
+f_true_index = "{0}'{{array[True]}}'"
+f_none_index = "{0}'{{array[None]}}'"
+f_byte_index = '{0}\'{{array[b"Hello"]}}\''
+f_empty_string = "{0}''"
+f_function_with_single_arg = "{0}'smth {{func(arg)}}'"
+f_function_with_three_args = "{0}'{{func(arg1, arg2, arg3)}}'"
+f_method_with_three_args = "{0}'{{obj.method(arg1, arg2, arg3)}}'"
+f_assign = "{0}'{{value=}}'"
+f_assign_attr = "{0}'{{value.attr=}}'"
+f_assign_call = "{0}'{{value()=}}'"
 
 # Allowed format specifiers
-f_format_aligned = "f'{value:<5}'"
-f_format_str = "f'{value!s}'"
-f_format_repr = "f'{value!r}'"
-f_format_code = "f'{value!a}'"
-f_format_hex_lower_short = "f'{value:x}'"
-f_format_hex_upper_short = "f'{value:X}'"
-f_format_hex_lower_long = "f'{value:#x}'"
-f_format_hex_upper_long = "f'{value:#X}'"
-f_format_char = "f'{value:c}'"
-f_format_rounded = "f'{value:.123456f}'"
-f_format_scientific = "f'{value:.456789e}'"
-f_format_var_single = "f'{value:{fmt}}'"
-f_format_var_single2 = "f'{value1:{fmt1}} {value2:{fmt2}}'"
-f_format_var_single_index = "f'{value:{fmt[0]}}'"
-f_format_var_single_call = "f'{value:{fmt()}}'"
-f_format_conversions = "f'{value1!r} {value2!s} {value3!a}'"
-f_format_assign = "f'{value=:<8}'"
-f_format_assign_conversion = "f'{value=!r}'"
-f_format_assign_attr = "f'{value.attr=:.456e}'"
-f_format_assign_var_single = "f'{value=:{fmt}}'"
-f_format_assign_var_single2 = "f'{value1=:{fmt1}} {value2=:{fmt2}}'"
+f_format_aligned = "{0}'{{value:<5}}'"
+f_format_str = "{0}'{{value!s}}'"
+f_format_repr = "{0}'{{value!r}}'"
+f_format_code = "{0}'{{value!a}}'"
+f_format_hex_lower_short = "{0}'{{value:x}}'"
+f_format_hex_upper_short = "{0}'{{value:X}}'"
+f_format_hex_lower_long = "{0}'{{value:#x}}'"
+f_format_hex_upper_long = "{0}'{{value:#X}}'"
+f_format_char = "{0}'{{value:c}}'"
+f_format_rounded = "{0}'{{value:.123456f}}'"
+f_format_scientific = "{0}'{{value:.456789e}}'"
+f_format_var_single = "{0}'{{value:{{fmt}}}}'"
+f_format_var_single2 = "{0}'{{value1:{{fmt1}}}} {{value2:{{fmt2}}}}'"
+f_format_var_single_index = "{0}'{{value:{{fmt[0]}}}}'"
+f_format_var_single_call = "{0}'{{value:{{fmt()}}}}'"
+f_format_conversions = "{0}'{{value1!r}} {{value2!s}} {{value3!a}}'"
+f_format_assign = "{0}'{{value=:<8}}'"
+f_format_assign_conversion = "{0}'{{value=!r}}'"
+f_format_assign_attr = "{0}'{{value.attr=:.456e}}'"
+f_format_assign_var_single = "{0}'{{value=:{{fmt}}}}'"
+f_format_assign_var_single2 = "{0}'{{value1=:{{fmt1}}}} {{value2=:{{fmt2}}}}'"
 
 # Disallowed
-f_string = "f'x + y = {2 + 2}'"
-f_double_indexing = "f'{list[0][1]}'"
-f_calling_returned_function = "f'{calling_returned_function()()}'"
+f_string = "{0}'x + y = {{2 + 2}}'"
+f_double_indexing = "{0}'{{list[0][1]}}'"
+f_calling_returned_function = "{0}'{{calling_returned_function()()}}'"
 f_complex_f_string = """
-    f'{reverse(\"url-name\")}?{\"&\".join(\"user=\"+uid for uid in user_ids)}'
+    {0}'{{reverse("url-name")}}?{{"&".join("user=" + uid for uid in user_ids)}}'
 """
-f_dict_lookup_function_empty_args = "f'smth {dict_value[func()]}'"
-f_list_slice_lookup = "f'smth {list[:]}'"
-f_attr_on_returned_value = "f'{some.call().attr}'"
-f_function_on_attr = "f'{some.attr.call()}'"
-f_array_object = "f'{some.first[0].attr.other}'"
-f_double_chained_attr = "f'{attr1.attr2.attr3}'"
-f_triple_call = "f'{foo()()()}'"
-f_triple_lookup = "f'{arr[0][1][2]}'"
-f_double_call_arg = "f'{foo()(arg)}'"
-f_single_chained_functions = "f'{f1().f2()}'"
-f_function_with_four_args = "f'{func(arg1, arg2, arg3, arg4)}'"
-f_method_with_four_args = "f'{obj.meth(arg1, arg2, arg3, arg4)}-post'"
-f_nested_string = 'f\'{f"{value}"}\''
+f_dict_lookup_function_empty_args = "{0}'smth {{dict_value[func()]}}'"
+f_list_slice_lookup = "{0}'smth {{list[:]}}'"
+f_attr_on_returned_value = "{0}'{{some.call().attr}}'"
+f_function_on_attr = "{0}'{{some.attr.call()}}'"
+f_array_object = "{0}'{{some.first[0].attr.other}}'"
+f_double_chained_attr = "{0}'{{attr1.attr2.attr3}}'"
+f_triple_call = "{0}'{{foo()()()}}'"
+f_triple_lookup = "{0}'{{arr[0][1][2]}}'"
+f_double_call_arg = "{0}'{{foo()(arg)}}'"
+f_single_chained_functions = "{0}'{{f1().f2()}}'"
+f_function_with_four_args = "{0}'{{func(arg1, arg2, arg3, arg4)}}'"
+f_method_with_four_args = "{0}'{{obj.meth(arg1, arg2, arg3, arg4)}}-post'"
+f_nested_string = """{0}'{{{0}"{{value}}"}}'"""
 # Disallowed format specifiers
-f_format_var_multi = "f'pre {value:{fmt1}{fmt2}}'"
-f_format_var_chain = "f'{value:{fmt.attr.attr}}'"
-f_format_var_before1 = "f'{value:{fmt}10}'"
-f_format_var_before2 = "f'{value:{fmt}.4f}'"
-f_format_var_after1 = "f'{value:_{fmt}}'"
-f_format_var_after2 = "f'{value:_^{fmt}}'"
-f_format_var_between1 = "f'{value:_{fmt}10}'"
-f_format_var_between2 = "f'{value:.{precision}f}'"
-f_format_var_around = "f'{value:{fmt1}^{fmt2}}'"
-f_format_str_const = "f'{value!s:10}'"
-f_format_repr_const = "f'{value!r:10}'"
-f_format_code_const = "f'{value!a:10}'"
-f_format_str_var = "f'{value!s:{fmt}}'"
-f_format_repr_var = "f'{value!r:{fmt}}'"
-f_format_code_var = "f'{value!a:{fmt}}'"
-f_format_hex_lower_short_const = "f'{value:10x}'"
-f_format_hex_upper_short_const = "f'{value:10X}'"
-f_format_hex_lower_long_const = "f'{value:#10x}'"
-f_format_hex_upper_long_const = "f'{value:#10X}'"
-f_format_char_const = "f'{value:10c}'"
-f_format_round_const = "f'{value:10.4f}'"
-f_format_scientific_const = "f'{value:10.7e}'"
-f_format_useless1 = "f'{value:_}'"
-f_format_useless2 = "f'{value:_<}'"
-f_format_assign_const = "f'{value=:_^8.2f}'"
-f_format_assign_conversion_const = "f'{value=!r:_>11}'"
-f_format_assign_var_chain = "f'{value=:{fmt.attr.attr}}'"
-f_format_assign_var_multi = "f'{value=:{fmt1}{fmt2}}'"
+f_format_var_multi = "{0}'pre {{value:{{fmt1}}{{fmt2}}}}'"
+f_format_var_chain = "{0}'{{value:{{fmt.attr.attr}}}}'"
+f_format_var_before1 = "{0}'{{value:{{fmt}}10}}'"
+f_format_var_before2 = "{0}'{{value:{{fmt}}.4f}}'"
+f_format_var_after1 = "{0}'{{value:_{{fmt}}}}'"
+f_format_var_after2 = "{0}'{{value:_^{{fmt}}}}'"
+f_format_var_between1 = "{0}'{{value:_{{fmt}}10}}'"
+f_format_var_between2 = "{0}'{{value:.{{precision}}f}}'"
+f_format_var_around = "{0}'{{value:{{fmt1}}^{{fmt2}}}}'"
+f_format_str_const = "{0}'{{value!s:10}}'"
+f_format_repr_const = "{0}'{{value!r:10}}'"
+f_format_code_const = "{0}'{{value!a:10}}'"
+f_format_str_var = "{0}'{{value!s:{{fmt}}}}'"
+f_format_repr_var = "{0}'{{value!r:{{fmt}}}}'"
+f_format_code_var = "{0}'{{value!a:{{fmt}}}}'"
+f_format_hex_lower_short_const = "{0}'{{value:10x}}'"
+f_format_hex_upper_short_const = "{0}'{{value:10X}}'"
+f_format_hex_lower_long_const = "{0}'{{value:#10x}}'"
+f_format_hex_upper_long_const = "{0}'{{value:#10X}}'"
+f_format_char_const = "{0}'{{value:10c}}'"
+f_format_round_const = "{0}'{{value:10.4f}}'"
+f_format_scientific_const = "{0}'{{value:10.7e}}'"
+f_format_useless1 = "{0}'{{value:_}}'"
+f_format_useless2 = "{0}'{{value:_<}}'"
+f_format_assign_const = "{0}'{{value=:_^8.2f}}'"
+f_format_assign_conversion_const = "{0}'{{value=!r:_>11}}'"
+f_format_assign_var_chain = "{0}'{{value=:{{fmt.attr.attr}}}}'"
+f_format_assign_var_multi = "{0}'{{value=:{{fmt1}}{{fmt2}}}}'"
 
 # regression 1921
-f_string_comma_format = 'f"Count={count:,}"'
+f_string_comma_format = '{0}"Count={{count:,}}"'
+
+PREFIXES = [
+    'f',
+    pytest.param(
+        't',
+        marks=pytest.mark.skipif(
+            sys.version_info < (3, 14),
+            reason='t-strings are only in Python 3.14+',
+        ),
+    ),
+]
 
 
 @pytest.mark.parametrize(
@@ -144,6 +155,7 @@ def test_string_normal(
     assert_errors(visitor, [])
 
 
+@pytest.mark.parametrize('prefix', PREFIXES)
 @pytest.mark.parametrize(
     'code',
     [
@@ -195,9 +207,15 @@ def test_string_normal(
         f_format_assign_var_multi,
     ],
 )
-def test_complex_f_string(assert_errors, parse_ast_tree, code, default_options):
-    """Testing that complex ``f`` strings are not allowed."""
-    tree = parse_ast_tree(code)
+def test_complex_formatted_string(
+    assert_errors,
+    parse_ast_tree,
+    code,
+    prefix,
+    default_options,
+):
+    """Testing that complex formatted strings are not allowed."""
+    tree = parse_ast_tree(code.format(prefix))
 
     visitor = WrongFormatStringVisitor(default_options, tree=tree)
     visitor.run()
@@ -208,6 +226,7 @@ def test_complex_f_string(assert_errors, parse_ast_tree, code, default_options):
     )
 
 
+@pytest.mark.parametrize('prefix', PREFIXES)
 @pytest.mark.parametrize(
     'code',
     [
@@ -253,68 +272,17 @@ def test_complex_f_string(assert_errors, parse_ast_tree, code, default_options):
         f_format_assign_var_single2,
     ],
 )
-def test_simple_f_string(assert_errors, parse_ast_tree, code, default_options):
-    """Testing that non complex ``f`` strings are allowed."""
-    tree = parse_ast_tree(code)
+def test_simple_formatted_string(
+    assert_errors,
+    parse_ast_tree,
+    code,
+    prefix,
+    default_options,
+):
+    """Testing that non complex formatted strings are allowed."""
+    tree = parse_ast_tree(code.format(prefix))
 
     visitor = WrongFormatStringVisitor(default_options, tree=tree)
     visitor.run()
 
     assert_errors(visitor, [])
-
-
-@pytest.mark.skipif(
-    sys.version_info < (3, 14),
-    reason='t-strings are only in Python 3.14+',
-)
-@pytest.mark.parametrize(
-    'code',
-    [
-        't"smth {value}"',
-        't"smth {user.get_full_name()}"',
-        't""',
-    ],
-)
-def test_simple_t_string(  # pragma: >=3.14 cover
-    assert_errors,
-    parse_ast_tree,
-    code,
-    default_options,
-):
-    """Testing that non complex ``t`` strings are allowed."""
-    tree = parse_ast_tree(code)
-
-    visitor = WrongFormatStringVisitor(default_options, tree=tree)
-    visitor.run()
-
-    assert_errors(visitor, [])
-
-
-@pytest.mark.skipif(
-    sys.version_info < (3, 14),
-    reason='t-strings are only in Python 3.14+',
-)
-@pytest.mark.parametrize(
-    'code',
-    [
-        't"smth {value1 + value2}"',
-        't"smth {math_func(1, 2, 3, 4)}"',
-        't"smth {value=:{filler}^{padding}.{precision}f}"',
-    ],
-)
-def test_complex_t_string(  # pragma: >=3.14 cover
-    assert_errors,
-    parse_ast_tree,
-    code,
-    default_options,
-):
-    """Testing that complex ``t`` strings are not allowed."""
-    tree = parse_ast_tree(code)
-
-    visitor = WrongFormatStringVisitor(default_options, tree=tree)
-    visitor.run()
-
-    assert_errors(
-        visitor,
-        [TooComplexFormattedStringViolation],
-    )

--- a/tests/test_visitors/test_ast/test_complexity/test_jones/test_line_complexity.py
+++ b/tests/test_visitors/test_ast/test_complexity/test_jones/test_line_complexity.py
@@ -1,6 +1,6 @@
 import pytest
 
-from wemake_python_styleguide.compat.constants import PY312
+from wemake_python_styleguide.compat.constants import PY312, PY314
 from wemake_python_styleguide.violations.complexity import (
     LineComplexityViolation,
 )
@@ -11,7 +11,15 @@ from wemake_python_styleguide.visitors.ast.complexity.jones import (
 line_simple = 'x = 2'
 line_with_types = 'x: int = 2'
 line_with_complex_types = 'x: Dict[Tuple[str, str, int], Set[List[attr.Val]]]'
-line_with_complex_typealias = 'type Al[X] = Di[Tup[s, s, i], Set[Li[attr.Val]]]'
+line_with_complex_typealias = pytest.param(
+    'type Al[X] = Di[Tup[s, s, i], Set[Li[attr.Val]]]',
+    marks=[
+        pytest.mark.skipif(
+            not PY312,
+            reason='PEP695 was added in 3.12',
+        ),
+    ],
+)
 line_with_comprehension = 'x = [f for f in "abc"]'
 line_with_math = 'x = y * 2 + 19 / 9.3'
 line_inside_function = """
@@ -62,6 +70,22 @@ regression1216 = 'call.endswith(post) and len(node.args) == self._post[post]'
 # See
 # https://github.com/wemake-services/wemake-python-styleguide/issues/3350
 regression3350 = 'x = f"Values: {a}, {b}, {c}, {d}"'
+regression3350_tstring = pytest.param(
+    'x = t"Values: {a}, {b}, {c}, {d}"',
+    marks=pytest.mark.skipif(
+        not PY314,
+        reason='t-strings are only in Python 3.14+',
+    ),
+)
+
+
+def _with_values(pytest_param, *extra):
+    return pytest.param(
+        *pytest_param.values,
+        *extra,
+        marks=pytest_param.marks,
+        id=pytest_param.id,
+    )
 
 
 @pytest.mark.parametrize(
@@ -82,16 +106,9 @@ regression3350 = 'x = f"Values: {a}, {b}, {c}, {d}"'
         class_with_function,
         class_with_async_function,
         class_with_usual_and_async_function,
-        pytest.param(
-            line_with_complex_typealias,
-            marks=[
-                pytest.mark.skipif(
-                    not PY312,
-                    reason='PEP695 was added in 3.12',
-                ),
-            ],
-        ),
+        line_with_complex_typealias,
         regression3350,
+        regression3350_tstring,
     ],
 )
 def test_regular_nodes(assert_errors, parse_ast_tree, code, default_options):
@@ -110,7 +127,7 @@ def test_regular_nodes(assert_errors, parse_ast_tree, code, default_options):
         (line_simple, 3),
         (line_with_types, 3),
         (line_with_complex_types, 2),
-        (line_with_complex_typealias, 3),
+        _with_values(line_with_complex_typealias, 3),
         (line_with_comprehension, 6),
         (line_with_math, 9),
         (line_inside_function, 4),
@@ -129,8 +146,6 @@ def test_complex_lines(
     options,
 ):
     """Testing that complex lines do raise violations."""
-    if code == line_with_complex_typealias and not PY312:  # pragma: no cover
-        pytest.skip('PEP695 was added in 3.12')
     tree = parse_ast_tree(code)
 
     option_values = options(max_line_complexity=1)
@@ -174,6 +189,7 @@ def test_same_complexity(parse_ast_tree, default_options):
         (line_with_math, 9),
         (regression1216, 15),
         (regression3350, 10),  # used to be 15
+        _with_values(regression3350_tstring, 10),  # used to be 15
     ],
 )
 def test_exact_complexity(parse_ast_tree, default_options, code, complexity):

--- a/tests/test_visitors/test_ast/test_complexity/test_overuses/test_overused_string.py
+++ b/tests/test_visitors/test_ast/test_complexity/test_overuses/test_overused_string.py
@@ -1,5 +1,6 @@
 import pytest
 
+from wemake_python_styleguide.compat.constants import PY314
 from wemake_python_styleguide.violations.complexity import (
     OverusedStringViolation,
 )
@@ -107,6 +108,28 @@ fstring_same_prefix2 = """
 x = f'{pattern}-postfix'
 y = f'{pattern}-postfix'
 """
+
+tstring_same_prefix1 = pytest.param(
+    """
+    x = f'Hello, {pattern}'
+    y = f'Hello, {pattern}'
+    """,
+    marks=pytest.mark.skipif(
+        not PY314,
+        reason='t-strings are only in Python 3.14+',
+    ),
+)
+
+tstring_same_prefix2 = pytest.param(
+    """
+    x = f'{pattern}-postfix'
+    y = f'{pattern}-postfix'
+    """,
+    marks=pytest.mark.skipif(
+        not PY314,
+        reason='t-strings are only in Python 3.14+',
+    ),
+)
 
 EXPECTED_LOCATION = (2, 8)
 
@@ -280,9 +303,11 @@ def test_common_strings_allowed(
     [
         fstring_same_prefix1,
         fstring_same_prefix2,
+        tstring_same_prefix1,
+        tstring_same_prefix2,
     ],
 )
-def test_fstring_strings_not_counted(
+def test_format_strings_not_counted(
     assert_errors,
     parse_ast_tree,
     options,

--- a/tests/test_visitors/test_ast/test_operators/test_string_concat.py
+++ b/tests/test_visitors/test_ast/test_operators/test_string_concat.py
@@ -1,5 +1,6 @@
 import pytest
 
+from wemake_python_styleguide.compat.constants import PY314
 from wemake_python_styleguide.violations.consistency import (
     ExplicitStringConcatViolation,
 )
@@ -48,6 +49,20 @@ long_text = (
 )
 """
 
+multiline_format_concat_t = pytest.param(
+    """
+    long_text = (
+        t'first {0}' +
+        t'second' +
+        t'third'
+    )
+    """,
+    marks=pytest.mark.skipif(
+        not PY314,
+        reason='t-strings are only in Python 3.14+',
+    ),
+)
+
 
 @pytest.mark.parametrize(
     'expression',
@@ -62,6 +77,13 @@ long_text = (
         '+= b"123"',
         '+= f""',
         '+= b""',
+        pytest.param(
+            '+ t"{x}"',
+            marks=pytest.mark.skipif(
+                not PY314,
+                reason='t-strings are only in Python 3.14+',
+            ),
+        ),
     ],
 )
 def test_string_concat(
@@ -110,6 +132,7 @@ def test_correct_operation(
         multiline_bytes_concat,
         multiline_format_concat,
         multiline_mixed_concat,
+        multiline_format_concat_t,
     ],
 )
 def test_correct_multiline_operation(

--- a/tests/test_visitors/test_tokenize/test_comments/test_comment_in_formatted_string312.py
+++ b/tests/test_visitors/test_tokenize/test_comments/test_comment_in_formatted_string312.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 
 from wemake_python_styleguide.compat.constants import PY312
@@ -198,6 +200,64 @@ def test_wrong_formatted_string(
     code,
 ) -> None:
     """Checking that the wrong string has violations."""
+    file_tokens = parse_tokens(code)
+
+    visitor = CommentInFormattedStringVisitor(
+        default_options,
+        file_tokens=file_tokens,
+    )
+    visitor.run()
+
+    assert_errors(visitor, [CommentInFormattedStringViolation])
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 14),
+    reason='t-strings are only in Python 3.14+',
+)
+@pytest.mark.parametrize(
+    'code',
+    [
+        'foo = t"test{a}"',
+        'foo = t\'test {a} # testing\'',
+    ],
+)
+def test_correct_t_string_comments(
+    parse_tokens,
+    assert_errors,
+    default_options,
+    code,
+) -> None:
+    """Checking that valid t-strings have no comment violations."""
+    file_tokens = parse_tokens(code)
+
+    visitor = CommentInFormattedStringVisitor(
+        default_options,
+        file_tokens=file_tokens,
+    )
+    visitor.run()
+
+    assert_errors(visitor, [])
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 14),
+    reason='t-strings are only in Python 3.14+',
+)
+@pytest.mark.parametrize(
+    'code',
+    [
+        'foo = t"test{a # comment\n}"',
+        'foo = rt"test{a # comment\n}"',
+    ],
+)
+def test_wrong_t_string_comments(
+    parse_tokens,
+    assert_errors,
+    default_options,
+    code,
+) -> None:
+    """Checking that comments inside t-string expressions cause violations."""
     file_tokens = parse_tokens(code)
 
     visitor = CommentInFormattedStringVisitor(

--- a/tests/test_visitors/test_tokenize/test_comments/test_comment_in_formatted_string312.py
+++ b/tests/test_visitors/test_tokenize/test_comments/test_comment_in_formatted_string312.py
@@ -219,7 +219,7 @@ def test_wrong_formatted_string(
     'code',
     [
         'foo = t"test{a}"',
-        'foo = t\'test {a} # testing\'',
+        "foo = t'test {a} # testing'",
     ],
 )
 def test_correct_t_string_comments(

--- a/tests/test_visitors/test_tokenize/test_comments/test_comment_in_formatted_string312.py
+++ b/tests/test_visitors/test_tokenize/test_comments/test_comment_in_formatted_string312.py
@@ -16,131 +16,143 @@ if not PY312:  # pragma: >=3.12 no cover
         allow_module_level=True,
     )
 
+PREFIXES = (
+    'f',
+    pytest.param(
+        't',
+        marks=pytest.mark.skipif(
+            sys.version_info < (3, 14),
+            reason='t-strings are only in Python 3.14+',
+        ),
+    ),
+)
+
 # Correct
 fstring_without_comments = """
-foo = f"test{a}"
+foo = {0}"test{{a}}"
 """
 
 fstring_with_hash_single_quotes = """
-foo = f'test {a} # testing'
+foo = {0}'test {{a}} # testing'
 """
 
 fstring_with_hash = """
-foo = f"test{a} # testing"
+foo = {0}"test{{a}} # testing"
 """
 
 fstring_with_hash_between_braces = """
-foo = f"test{a} # comment {b} # comment"
+foo = {0}"test{{a}} # comment {{b}} # comment"
 """
 
 
 fstring_with_two_values = """
-f"My name is {name} and I am {age} years old."
+{0}"My name is {{name}} and I am {{age}} years old."
 """
 
 
 fstring_with_math_operation = """
-f"The sum of {x} and {y} is {x + y}."
+{0}"The sum of {{x}} and {{y}} is {{x + y}}."
 """
 
 fstring_with_hash_between_quotes = """
-foo = f"hello" # comment "{bar}" # comment"
+foo = {0}"hello" # comment "{{bar}}" # comment"
 """
 
 
 fstring_in_docstring = '''
-foo = f"""hello"{bar}" # comment world"""
+foo = {0}"""hello"{{bar}}" # comment world"""
 '''
 
 # Wrong
 fstring_with_comment = """
-foo = f"test{a # comment
-}"
+foo = {0}"test{{a # comment
+}}"
 """
 
 rfstring_with_comment = """
-foo = rf"test{a # comment
-}"
+foo = r{0}"test{{a # comment
+}}"
 """
 
 rfstring_with_comment_single_quotes = """
-foo = rf'test{a # comment
-}'
+foo = r{0}'test{{a # comment
+}}'
 """
 
 
 rfstring_with_comment_triple_quotes = '''
-foo = rf"""test{a # comment
-}"""
+foo = r{0}"""test{{a # comment
+}}"""
 '''
 
 rfstring_with_comment_triple_single_quotes = """
-foo = rf'''test{a # comment
-}'''
+foo = rf'''test{{a # comment
+}}'''
 """
 
 
 frstring_with_comment = """
-foo = fr"test{a # comment
-}"
+foo = {0}r"test{{a # comment
+}}"
 """
 
 frstring_with_comment_single_quotes = """
-foo = fr'test{a # comment
-}'
+foo = {0}r'test{{a # comment
+}}'
 """
 
 
 frstring_with_comment_triple_quotes = '''
-foo = fr"""test{a # comment
-}"""
+foo = {0}r"""test{{a # comment
+}}"""
 '''
 
 frstring_with_comment_triple_single_quotes = """
-foo = fr'''test{a # comment
-}'''
+foo = {0}r'''test{{a # comment
+}}'''
 """
 
 fstring_with_comment_single_quotes = """
-foo = f'test{a # comment
-}'
+foo = {0}'test{{a # comment
+}}'
 """
 
 fstring_with_comment_and_hash_on_new_line = """
-foo = f"test{a # comment
-} # comment"
+foo = {0}"test{{a # comment
+}} # comment"
 """
 
 fstring_with_two_values_and_comment = """
-foo = f"test{a} and test{b # Testing values
-}"
+foo = {0}"test{{a}} and test{{b # Testing values
+}}"
 """
 
 
 multiline_fstring_with_comment = """
-foo = (f"test{value}"
-       f"test{another_value}"
-       f"test{wrong # This is not allowed
-       }"
-       f"test{value}")
+foo = ({0}"test{{value}}"
+       {0}"test{{another_value}}"
+       {0}"test{{wrong # This is not allowed
+       }}"
+       {0}"test{{value}}")
 """
 
 fstring_with_comment_and_second_line = """
-foo = f"hello{bar # comment
-}world"
+foo = {0}"hello{{bar # comment
+}}world"
 """
 
 fstring_with_comment_between_quotes = """
-foo = f"hello'{bar # comment
-}'world"
+foo = {0}"hello'{{bar # comment
+}}'world"
 """
 
 fstring_with_comment_in_docstring = '''
-foo = f"""hello"{bar # comment
-}world"""
+foo = {0}"""hello"{{bar # comment
+}}world"""
 '''
 
 
+@pytest.mark.parametrize('prefix', PREFIXES)
 @pytest.mark.parametrize(
     'code',
     [
@@ -159,9 +171,10 @@ def test_correct_formatted_string(
     assert_errors,
     default_options,
     code,
+    prefix,
 ) -> None:
     """Check that there are no violations in the correct string."""
-    file_tokens = parse_tokens(code)
+    file_tokens = parse_tokens(code.format(prefix))
 
     visitor = CommentInFormattedStringVisitor(
         default_options,
@@ -172,6 +185,7 @@ def test_correct_formatted_string(
     assert_errors(visitor, [])
 
 
+@pytest.mark.parametrize('prefix', PREFIXES)
 @pytest.mark.parametrize(
     'code',
     [
@@ -198,67 +212,10 @@ def test_wrong_formatted_string(
     assert_errors,
     default_options,
     code,
+    prefix,
 ) -> None:
     """Checking that the wrong string has violations."""
-    file_tokens = parse_tokens(code)
-
-    visitor = CommentInFormattedStringVisitor(
-        default_options,
-        file_tokens=file_tokens,
-    )
-    visitor.run()
-
-    assert_errors(visitor, [CommentInFormattedStringViolation])
-
-
-@pytest.mark.skipif(
-    sys.version_info < (3, 14),
-    reason='t-strings are only in Python 3.14+',
-)
-@pytest.mark.parametrize(
-    'code',
-    [
-        'foo = t"test{a}"',
-        "foo = t'test {a} # testing'",
-    ],
-)
-def test_correct_t_string_comments(  # pragma: >=3.14 cover
-    parse_tokens,
-    assert_errors,
-    default_options,
-    code,
-) -> None:
-    """Checking that valid t-strings have no comment violations."""
-    file_tokens = parse_tokens(code)
-
-    visitor = CommentInFormattedStringVisitor(
-        default_options,
-        file_tokens=file_tokens,
-    )
-    visitor.run()
-
-    assert_errors(visitor, [])
-
-
-@pytest.mark.skipif(
-    sys.version_info < (3, 14),
-    reason='t-strings are only in Python 3.14+',
-)
-@pytest.mark.parametrize(
-    'code',
-    [
-        'foo = t"test{a # comment\n}"',
-        'foo = rt"test{a # comment\n}"',
-    ],
-)
-def test_wrong_t_string_comments(  # pragma: >=3.14 cover
-    parse_tokens,
-    assert_errors,
-    default_options,
-    code,
-) -> None:
-    """Checking that comments inside t-string expressions cause violations."""
-    file_tokens = parse_tokens(code)
+    file_tokens = parse_tokens(code.format(prefix))
 
     visitor = CommentInFormattedStringVisitor(
         default_options,

--- a/tests/test_visitors/test_tokenize/test_comments/test_comment_in_formatted_string312.py
+++ b/tests/test_visitors/test_tokenize/test_comments/test_comment_in_formatted_string312.py
@@ -222,7 +222,7 @@ def test_wrong_formatted_string(
         "foo = t'test {a} # testing'",
     ],
 )
-def test_correct_t_string_comments(
+def test_correct_t_string_comments(  # pragma: >=3.14 cover
     parse_tokens,
     assert_errors,
     default_options,
@@ -251,7 +251,7 @@ def test_correct_t_string_comments(
         'foo = rt"test{a # comment\n}"',
     ],
 )
-def test_wrong_t_string_comments(
+def test_wrong_t_string_comments(  # pragma: >=3.14 cover
     parse_tokens,
     assert_errors,
     default_options,

--- a/tests/test_visitors/test_tokenize/test_primitives/test_string_tokens/test_mulitiline_formatted_string312.py
+++ b/tests/test_visitors/test_tokenize/test_primitives/test_string_tokens/test_mulitiline_formatted_string312.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 
 from wemake_python_styleguide.compat.constants import PY312
@@ -83,6 +85,61 @@ def test_incorrectly_formatted_string(
     code,
 ):
     """Ensures that correct formatting works."""
+    tokens = parse_tokens(code)
+    visitor = MultilineFormattedStringTokenVisitor(
+        default_options,
+        file_tokens=tokens,
+    )
+    assert_errors(visitor, [MultilineFormattedStringViolation])
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 14),
+    reason='t-strings are only in Python 3.14+',
+)
+@pytest.mark.parametrize(
+    'code',
+    [
+        "x = t'''{1}'''",
+        'x = t"""{1}"""',
+        "x = tr'''{1}'''",
+    ],
+)
+def test_correctly_formatted_t_string(
+    parse_tokens,
+    assert_errors,
+    default_options,
+    code,
+):
+    """Ensures that correct multiline t-string formatting works."""
+    tokens = parse_tokens(code)
+    visitor = MultilineFormattedStringTokenVisitor(
+        default_options,
+        file_tokens=tokens,
+    )
+    visitor.run()
+    assert_errors(visitor, [])
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 14),
+    reason='t-strings are only in Python 3.14+',
+)
+@pytest.mark.parametrize(
+    'code',
+    [
+        "x = t'{1\n}'",
+        'x = t"{1\n}"',
+        "x = tr'{1\n}'",
+    ],
+)
+def test_incorrectly_formatted_t_string(
+    parse_tokens,
+    assert_errors,
+    default_options,
+    code,
+):
+    """Ensures that multiline single-quote t-strings cause violations."""
     tokens = parse_tokens(code)
     visitor = MultilineFormattedStringTokenVisitor(
         default_options,

--- a/tests/test_visitors/test_tokenize/test_primitives/test_string_tokens/test_mulitiline_formatted_string312.py
+++ b/tests/test_visitors/test_tokenize/test_primitives/test_string_tokens/test_mulitiline_formatted_string312.py
@@ -90,6 +90,7 @@ def test_incorrectly_formatted_string(
         default_options,
         file_tokens=tokens,
     )
+    visitor.run()
     assert_errors(visitor, [MultilineFormattedStringViolation])
 
 

--- a/tests/test_visitors/test_tokenize/test_primitives/test_string_tokens/test_mulitiline_formatted_string312.py
+++ b/tests/test_visitors/test_tokenize/test_primitives/test_string_tokens/test_mulitiline_formatted_string312.py
@@ -106,7 +106,7 @@ def test_incorrectly_formatted_string(
         "x = tr'''{1}'''",
     ],
 )
-def test_correctly_formatted_t_string(
+def test_correctly_formatted_t_string(  # pragma: >=3.14 cover
     parse_tokens,
     assert_errors,
     default_options,
@@ -134,7 +134,7 @@ def test_correctly_formatted_t_string(
         "x = tr'{1\n}'",
     ],
 )
-def test_incorrectly_formatted_t_string(
+def test_incorrectly_formatted_t_string(  # pragma: >=3.14 cover
     parse_tokens,
     assert_errors,
     default_options,

--- a/tests/test_visitors/test_tokenize/test_primitives/test_string_tokens/test_mulitiline_formatted_string312.py
+++ b/tests/test_visitors/test_tokenize/test_primitives/test_string_tokens/test_mulitiline_formatted_string312.py
@@ -16,35 +16,48 @@ if not PY312:  # pragma: >=3.12 no cover
         allow_module_level=True,
     )
 
+PREFIXES = (
+    'f',
+    pytest.param(
+        't',
+        marks=pytest.mark.skipif(
+            sys.version_info < (3, 14),
+            reason='t-strings are only in Python 3.14+',
+        ),
+    ),
+)
+
 # Wrong:
-single_quote_formatted_string_wrong = """x=f'{ 1
-}'
+single_quote_formatted_string_wrong = """x={0}'{{ 1
+}}'
 """
 
-fr_prefix_formatted_string_wrong = """x=fr'{1
-}'"""
+fr_prefix_formatted_string_wrong = """x={0}r'{{1
+}}'"""
 
-double_quote_formatted_string_wrong = """x=f" {2} { 1
-}"
+double_quote_formatted_string_wrong = """x={0}" {{2}} {{ 1
+}}"
 """
 
 # Correct:
-triple_quote_formatted_string_first_correct = """x=f'''{ 1
-}'''
+triple_quote_formatted_string_first_correct = """x={0}'''{{ 1
+}}'''
 """
 
-triple_quote_formatted_string_second_correct = '''x=f"""{ 1
-}"""
+triple_quote_formatted_string_second_correct = '''x={0}"""{{ 1
+}}"""
 '''
+
 single_line_formatted_string = (
-    """formatted_string_complex = f'1+1={1 + 1}'  # noqa: WPS237"""
+    """formatted_string_complex = {0}'1+1={{1 + 1}}'  # noqa: WPS237"""
 )
 
 fr_prefix_formatted_string = (
-    """formatted_string_complex = fr'1+1={1 + 1}'  # noqa: WPS237"""
+    """formatted_string_complex = {0}r'1+1={{1 + 1}}'  # noqa: WPS237"""
 )
 
 
+@pytest.mark.parametrize('prefix', PREFIXES)
 @pytest.mark.parametrize(
     'code',
     [
@@ -59,9 +72,10 @@ def test_correctly_formatted_string(
     assert_errors,
     default_options,
     code,
+    prefix,
 ):
     """Ensures that correct formatting works."""
-    tokens = parse_tokens(code)
+    tokens = parse_tokens(code.format(prefix))
     visitor = MultilineFormattedStringTokenVisitor(
         default_options,
         file_tokens=tokens,
@@ -70,6 +84,7 @@ def test_correctly_formatted_string(
     assert_errors(visitor, [])
 
 
+@pytest.mark.parametrize('prefix', PREFIXES)
 @pytest.mark.parametrize(
     'code',
     [
@@ -83,65 +98,10 @@ def test_incorrectly_formatted_string(
     assert_errors,
     default_options,
     code,
+    prefix,
 ):
     """Ensures that correct formatting works."""
-    tokens = parse_tokens(code)
-    visitor = MultilineFormattedStringTokenVisitor(
-        default_options,
-        file_tokens=tokens,
-    )
-    visitor.run()
-    assert_errors(visitor, [MultilineFormattedStringViolation])
-
-
-@pytest.mark.skipif(
-    sys.version_info < (3, 14),
-    reason='t-strings are only in Python 3.14+',
-)
-@pytest.mark.parametrize(
-    'code',
-    [
-        "x = t'''{1}'''",
-        'x = t"""{1}"""',
-        "x = tr'''{1}'''",
-    ],
-)
-def test_correctly_formatted_t_string(  # pragma: >=3.14 cover
-    parse_tokens,
-    assert_errors,
-    default_options,
-    code,
-):
-    """Ensures that correct multiline t-string formatting works."""
-    tokens = parse_tokens(code)
-    visitor = MultilineFormattedStringTokenVisitor(
-        default_options,
-        file_tokens=tokens,
-    )
-    visitor.run()
-    assert_errors(visitor, [])
-
-
-@pytest.mark.skipif(
-    sys.version_info < (3, 14),
-    reason='t-strings are only in Python 3.14+',
-)
-@pytest.mark.parametrize(
-    'code',
-    [
-        "x = t'{1\n}'",
-        'x = t"{1\n}"',
-        "x = tr'{1\n}'",
-    ],
-)
-def test_incorrectly_formatted_t_string(  # pragma: >=3.14 cover
-    parse_tokens,
-    assert_errors,
-    default_options,
-    code,
-):
-    """Ensures that multiline single-quote t-strings cause violations."""
-    tokens = parse_tokens(code)
+    tokens = parse_tokens(code.format(prefix))
     visitor = MultilineFormattedStringTokenVisitor(
         default_options,
         file_tokens=tokens,

--- a/wemake_python_styleguide/compat/constants.py
+++ b/wemake_python_styleguide/compat/constants.py
@@ -15,6 +15,9 @@ PY312: Final = sys.version_info >= (3, 12)
 # This indicates that we are running on python3.13+
 PY313: Final = sys.version_info >= (3, 13)
 
+# This indicates that we are running on python3.14+
+PY314: Final = sys.version_info >= (3, 14)
+
 # This indicates that we are running on python3.15+
 PY315: Final = sys.version_info >= (3, 15)
 

--- a/wemake_python_styleguide/compat/nodes.py
+++ b/wemake_python_styleguide/compat/nodes.py
@@ -59,7 +59,7 @@ else:  # pragma: <3.14 cover
     class TemplateStr(ast.expr):
         """Used to define `TemplateStr` nodes in `python3.14+`."""
 
-        values: list[ast.expr]
+        values: list[ast.expr]  # noqa: WPS110
 
     class Interpolation(ast.expr):
         """Used to define `Interpolation` nodes in `python3.14+`."""

--- a/wemake_python_styleguide/compat/nodes.py
+++ b/wemake_python_styleguide/compat/nodes.py
@@ -49,3 +49,22 @@ else:  # pragma: <3.13 cover
         """Used to define `TypeVarTuple` nodes from `python3.12+`."""
 
         name: str
+
+
+if sys.version_info >= (3, 14):  # pragma: >=3.14 cover
+    from ast import Interpolation as Interpolation
+    from ast import TemplateStr as TemplateStr
+else:  # pragma: <3.14 cover
+
+    class TemplateStr(ast.expr):
+        """Used to define `TemplateStr` nodes in `python3.14+`."""
+
+        values: list[ast.expr]
+
+    class Interpolation(ast.expr):
+        """Used to define `Interpolation` nodes in `python3.14+`."""
+
+        value: ast.expr  # noqa: WPS110
+        conversion: int
+        format_spec: ast.expr | None
+

--- a/wemake_python_styleguide/compat/nodes.py
+++ b/wemake_python_styleguide/compat/nodes.py
@@ -67,4 +67,3 @@ else:  # pragma: <3.14 cover
         value: ast.expr  # noqa: WPS110
         conversion: int
         format_spec: ast.expr | None
-

--- a/wemake_python_styleguide/logic/tree/strings.py
+++ b/wemake_python_styleguide/logic/tree/strings.py
@@ -1,5 +1,6 @@
 import ast
 
+from wemake_python_styleguide.compat import nodes
 from wemake_python_styleguide.logic.walk import get_closest_parent
 
 
@@ -19,11 +20,13 @@ def is_doc_string(node: ast.AST) -> bool:
 
 
 def has_fstring_conversion(component: ast.AST) -> bool:
-    """Checks whether f-string with the component has a conversion specifier."""
+    """Checks whether f/t-string with the component has a conversion specifier."""
     formatted_component = (
-        get_closest_parent(component, ast.FormattedValue) or component
+        get_closest_parent(component, (ast.FormattedValue, nodes.Interpolation))
+        or component
     )
     return (
-        isinstance(formatted_component, ast.FormattedValue)
+        isinstance(formatted_component, (ast.FormattedValue, nodes.Interpolation))
         and formatted_component.conversion != -1
     )
+

--- a/wemake_python_styleguide/logic/tree/strings.py
+++ b/wemake_python_styleguide/logic/tree/strings.py
@@ -20,7 +20,7 @@ def is_doc_string(node: ast.AST) -> bool:
 
 
 def has_fstring_conversion(component: ast.AST) -> bool:
-    """Checks whether f/t-string with the component has a conversion specifier."""
+    """Checks whether formatted string component has a conversion specifier."""
     formatted_component = (
         get_closest_parent(component, (ast.FormattedValue, nodes.Interpolation))
         or component

--- a/wemake_python_styleguide/logic/tree/strings.py
+++ b/wemake_python_styleguide/logic/tree/strings.py
@@ -26,7 +26,8 @@ def has_fstring_conversion(component: ast.AST) -> bool:
         or component
     )
     return (
-        isinstance(formatted_component, (ast.FormattedValue, nodes.Interpolation))
+        isinstance(
+            formatted_component, (ast.FormattedValue, nodes.Interpolation)
+        )
         and formatted_component.conversion != -1
     )
-

--- a/wemake_python_styleguide/logic/tree/strings.py
+++ b/wemake_python_styleguide/logic/tree/strings.py
@@ -27,7 +27,8 @@ def has_fstring_conversion(component: ast.AST) -> bool:
     )
     return (
         isinstance(
-            formatted_component, (ast.FormattedValue, nodes.Interpolation)
+            formatted_component,
+            (ast.FormattedValue, nodes.Interpolation),
         )
         and formatted_component.conversion != -1
     )

--- a/wemake_python_styleguide/logic/tree/strings.py
+++ b/wemake_python_styleguide/logic/tree/strings.py
@@ -19,7 +19,7 @@ def is_doc_string(node: ast.AST) -> bool:
     )
 
 
-def has_fstring_conversion(component: ast.AST) -> bool:
+def has_format_string_conversion(component: ast.AST) -> bool:
     """Checks whether formatted string component has a conversion specifier."""
     formatted_component = (
         get_closest_parent(component, (ast.FormattedValue, nodes.Interpolation))

--- a/wemake_python_styleguide/violations/best_practices.py
+++ b/wemake_python_styleguide/violations/best_practices.py
@@ -2937,8 +2937,8 @@ class MultilineFormattedStringViolation(TokenizeViolation):
     Forbid using multi-line formatted string with single and double quotes.
 
     Reasoning:
-        Multiline f-strings must use triple quotes for clarity.
-        Single f-strings may not span lines.
+        Multiline f-strings and t-strings must use triple quotes for clarity.
+        Single f-strings and t-strings may not span lines.
 
     Solution:
         Use triple quotes instead of single quotes.
@@ -2969,11 +2969,11 @@ class CommentInFormattedStringViolation(TokenizeViolation):
     Is only emitted on ``python3.12+``.
 
     Reasoning:
-        Comments make fstring implicitly multiline.
+        Comments make f-strings and t-strings implicitly multiline.
         And comments must not be present in strings. This is not right.
 
     Solution:
-        Don't write comments inside fstrings.
+        Don't write comments inside formatted strings.
 
     Example::
 

--- a/wemake_python_styleguide/violations/best_practices.py
+++ b/wemake_python_styleguide/violations/best_practices.py
@@ -2936,6 +2936,8 @@ class MultilineFormattedStringViolation(TokenizeViolation):
     """
     Forbid using multi-line formatted string with single and double quotes.
 
+    Is only emitted on ``python3.12+`` (``t``-strings on ``python3.14+``).
+
     Reasoning:
         Multiline f-strings and t-strings must use triple quotes for clarity.
         Single f-strings and t-strings may not span lines.
@@ -2966,7 +2968,7 @@ class CommentInFormattedStringViolation(TokenizeViolation):
     """
     Forbid using comments inside formatted strings.
 
-    Is only emitted on ``python3.12+``.
+    Is only emitted on ``python3.12+`` (``t``-strings on ``python3.14+``).
 
     Reasoning:
         Comments make f-strings and t-strings implicitly multiline.

--- a/wemake_python_styleguide/violations/best_practices.py
+++ b/wemake_python_styleguide/violations/best_practices.py
@@ -2945,7 +2945,8 @@ class MultilineFormattedStringViolation(TokenizeViolation):
     """
     Forbid using multi-line formatted string with single and double quotes.
 
-    Is only emitted on ``python3.12+`` (``t``-strings on ``python3.14+``).
+    Is only emitted on ``python3.12+`` for ``f``=strings
+    and on ``python3.14+`` for ``t``-strings.
 
     Reasoning:
         Multiline f-strings and t-strings must use triple quotes for clarity.
@@ -2965,6 +2966,8 @@ class MultilineFormattedStringViolation(TokenizeViolation):
         ...}'
 
     .. versionadded:: 1.2.0
+    .. versionchanged:: 1.8.0
+        Added ``t``-string support.
 
     """
 
@@ -2977,7 +2980,8 @@ class CommentInFormattedStringViolation(TokenizeViolation):
     """
     Forbid using comments inside formatted strings.
 
-    Is only emitted on ``python3.12+`` (``t``-strings on ``python3.14+``).
+    Is only emitted on ``python3.12+`` for ``f``=strings
+    and on ``python3.14+`` for ``t``-strings.
 
     Reasoning:
         Comments make f-strings and t-strings implicitly multiline.
@@ -2996,6 +3000,8 @@ class CommentInFormattedStringViolation(TokenizeViolation):
         }'
 
     .. versionadded:: 1.2.0
+    .. versionchanged:: 1.8.0
+        Added ``t``-string support.
 
     """
 

--- a/wemake_python_styleguide/violations/complexity.py
+++ b/wemake_python_styleguide/violations/complexity.py
@@ -1142,7 +1142,7 @@ class TooLongTupleUnpackViolation(ASTViolation):
 @final
 class TooComplexFormattedStringViolation(ASTViolation):
     """
-    Forbids ``f`` strings that are too complex.
+    Forbids ``f`` and ``t`` strings that are too complex.
 
     A complex format string is defined as use of any formatted value
     that is not:
@@ -1156,9 +1156,9 @@ class TooComplexFormattedStringViolation(ASTViolation):
     using more than one specifier for a single value.
 
     Reasoning:
-        Complex ``f`` strings are often difficult to understand,
+        Complex ``f`` and ``t`` strings are often difficult to understand,
         making the code less readable. Generally we don't allow
-        ``f`` strings but this violation exists in case the user
+        formatted strings but this violation exists in case the user
         decides to ignore the general violation.
 
     Solution:

--- a/wemake_python_styleguide/violations/complexity.py
+++ b/wemake_python_styleguide/violations/complexity.py
@@ -1144,6 +1144,8 @@ class TooComplexFormattedStringViolation(ASTViolation):
     """
     Forbids ``f`` and ``t`` strings that are too complex.
 
+    ``t``-strings are only checked on ``python3.14+``.
+
     A complex format string is defined as use of any formatted value
     that is not:
 

--- a/wemake_python_styleguide/violations/complexity.py
+++ b/wemake_python_styleguide/violations/complexity.py
@@ -1207,10 +1207,12 @@ class TooComplexFormattedStringViolation(ASTViolation):
     .. versionadded:: 0.15.0
     .. versionchanged:: 1.6.0
         Complex format specifiers are forbidden.
+    .. versionchanged:: 1.8.0
+        Added ``t``-strings support.
 
     """
 
-    error_template = 'Found a too complex `f` string'
+    error_template = 'Found a too complex formatted string'
     code = 237
 
 

--- a/wemake_python_styleguide/violations/consistency.py
+++ b/wemake_python_styleguide/violations/consistency.py
@@ -1464,7 +1464,7 @@ class ExplicitStringConcatViolation(ASTViolation):
 
     Reasoning:
         When formatting strings one must use ``.format``
-        and not any other formatting methods like ``%``, ``+``, or ``f``.
+        and not any other formatting methods like ``%``, ``+``, ``f``, or ``t``.
         This is done for consistency reasons.
 
     Solution:

--- a/wemake_python_styleguide/visitors/ast/builtins.py
+++ b/wemake_python_styleguide/visitors/ast/builtins.py
@@ -5,6 +5,7 @@ from collections.abc import Sequence
 from typing import ClassVar, Final, TypeAlias, final
 
 from wemake_python_styleguide import constants
+from wemake_python_styleguide.compat import nodes
 from wemake_python_styleguide.compat.aliases import (
     AssignNodesWithWalrus,
     FunctionNodes,
@@ -106,13 +107,24 @@ class WrongFormatStringVisitor(base.BaseNodeVisitor):
         self._check_complex_formatted_string(node)
         self.generic_visit(node)
 
-    def _check_complex_formatted_string(self, node: ast.JoinedStr) -> None:
-        """Allows all simple uses of `f` strings."""
-        parent = walk.get_closest_parent(node, ast.JoinedStr)
+    def visit_TemplateStr(self, node: nodes.TemplateStr) -> None:
+        """Forbids use of ``t`` strings that are too complex."""
+        self._check_complex_formatted_string(node)
+        self.generic_visit(node)
+
+    def _check_complex_formatted_string(
+        self,
+        node: ast.JoinedStr | nodes.TemplateStr,
+    ) -> None:
+        """Allows all simple uses of `f` and `t` strings."""
+        parent = walk.get_closest_parent(
+            node,
+            (ast.JoinedStr, nodes.TemplateStr),
+        )
         for string_component in node.values:
             # check component complexity
             is_component_complex = False
-            if isinstance(string_component, ast.FormattedValue):
+            if isinstance(string_component, ast.FormattedValue | nodes.Interpolation):
                 is_component_complex = not self._is_valid_formatted_value(
                     string_component.value
                 )

--- a/wemake_python_styleguide/visitors/ast/builtins.py
+++ b/wemake_python_styleguide/visitors/ast/builtins.py
@@ -124,7 +124,9 @@ class WrongFormatStringVisitor(base.BaseNodeVisitor):
         for string_component in node.values:
             # check component complexity
             is_component_complex = False
-            if isinstance(string_component, ast.FormattedValue | nodes.Interpolation):
+            if isinstance(
+                string_component, ast.FormattedValue | nodes.Interpolation
+            ):
                 is_component_complex = not self._is_valid_formatted_value(
                     string_component.value
                 )

--- a/wemake_python_styleguide/visitors/ast/builtins.py
+++ b/wemake_python_styleguide/visitors/ast/builtins.py
@@ -36,6 +36,9 @@ from wemake_python_styleguide.visitors import base, decorators
 #: Items that can be inside a hash.
 _HashItems: TypeAlias = Sequence[ast.AST | None]
 
+#: Any formatted string node (f-string or t-string).
+_AnyFormattedString: TypeAlias = ast.JoinedStr | nodes.TemplateStr
+
 
 @final
 @decorators.alias(
@@ -110,7 +113,7 @@ class WrongFormatStringVisitor(base.BaseNodeVisitor):
     _max_chained_items = 3
 
     def visit_any_formatted_string(
-        self, node: ast.JoinedStr | nodes.TemplateStr
+        self, node: _AnyFormattedString
     ) -> None:
         """Forbids use of ``f`` and ``t`` strings that are too complex."""
         self._check_complex_formatted_string(node)
@@ -118,7 +121,7 @@ class WrongFormatStringVisitor(base.BaseNodeVisitor):
 
     def _check_complex_formatted_string(
         self,
-        node: ast.JoinedStr | nodes.TemplateStr,
+        node: _AnyFormattedString,
     ) -> None:
         """Allows all simple uses of `f` and `t` strings."""
         parent = walk.get_closest_parent(

--- a/wemake_python_styleguide/visitors/ast/builtins.py
+++ b/wemake_python_styleguide/visitors/ast/builtins.py
@@ -84,8 +84,15 @@ class WrongStringVisitor(base.BaseNodeVisitor):
 
 
 @final
-class WrongFormatStringVisitor(base.BaseNodeVisitor):  # noqa: WPS214
-    """Restricts usage of ``f`` strings."""
+@decorators.alias(
+    'visit_any_formatted_string',
+    (
+        'visit_JoinedStr',
+        'visit_TemplateStr',
+    ),
+)
+class WrongFormatStringVisitor(base.BaseNodeVisitor):
+    """Restricts usage of ``f`` and ``t`` strings."""
 
     _valid_format_index: ClassVar[AnyNodes] = (
         ast.Constant,
@@ -102,13 +109,10 @@ class WrongFormatStringVisitor(base.BaseNodeVisitor):  # noqa: WPS214
     )
     _max_chained_items = 3
 
-    def visit_JoinedStr(self, node: ast.JoinedStr) -> None:
-        """Forbids use of ``f`` strings and too complex ``f`` strings."""
-        self._check_complex_formatted_string(node)
-        self.generic_visit(node)
-
-    def visit_TemplateStr(self, node: nodes.TemplateStr) -> None:
-        """Forbids use of ``t`` strings that are too complex."""
+    def visit_any_formatted_string(
+        self, node: ast.JoinedStr | nodes.TemplateStr
+    ) -> None:
+        """Forbids use of ``f`` and ``t`` strings that are too complex."""
         self._check_complex_formatted_string(node)
         self.generic_visit(node)
 

--- a/wemake_python_styleguide/visitors/ast/builtins.py
+++ b/wemake_python_styleguide/visitors/ast/builtins.py
@@ -84,7 +84,7 @@ class WrongStringVisitor(base.BaseNodeVisitor):
 
 
 @final
-class WrongFormatStringVisitor(base.BaseNodeVisitor):
+class WrongFormatStringVisitor(base.BaseNodeVisitor):  # noqa: WPS214
     """Restricts usage of ``f`` strings."""
 
     _valid_format_index: ClassVar[AnyNodes] = (

--- a/wemake_python_styleguide/visitors/ast/builtins.py
+++ b/wemake_python_styleguide/visitors/ast/builtins.py
@@ -112,9 +112,7 @@ class WrongFormatStringVisitor(base.BaseNodeVisitor):
     )
     _max_chained_items = 3
 
-    def visit_any_formatted_string(
-        self, node: _AnyFormattedString
-    ) -> None:
+    def visit_any_formatted_string(self, node: _AnyFormattedString) -> None:
         """Forbids use of ``f`` and ``t`` strings that are too complex."""
         self._check_complex_formatted_string(node)
         self.generic_visit(node)

--- a/wemake_python_styleguide/visitors/ast/builtins.py
+++ b/wemake_python_styleguide/visitors/ast/builtins.py
@@ -138,7 +138,7 @@ class WrongFormatStringVisitor(base.BaseNodeVisitor):
                 )
             # check format complexity for nested JoinedStr
             is_format_complex = parent and (
-                strings.has_fstring_conversion(string_component)
+                strings.has_format_string_conversion(string_component)
                 or len(node.values) > 1
                 or not self._is_const_format_valid(string_component, parent)
             )

--- a/wemake_python_styleguide/visitors/ast/builtins.py
+++ b/wemake_python_styleguide/visitors/ast/builtins.py
@@ -130,7 +130,8 @@ class WrongFormatStringVisitor(base.BaseNodeVisitor):
             # check component complexity
             is_component_complex = False
             if isinstance(
-                string_component, ast.FormattedValue | nodes.Interpolation
+                string_component,
+                ast.FormattedValue | nodes.Interpolation,
             ):
                 is_component_complex = not self._is_valid_formatted_value(
                     string_component.value

--- a/wemake_python_styleguide/visitors/ast/complexity/jones.py
+++ b/wemake_python_styleguide/visitors/ast/complexity/jones.py
@@ -12,6 +12,7 @@ from collections import defaultdict
 from statistics import median
 from typing import final
 
+from wemake_python_styleguide.compat import nodes
 from wemake_python_styleguide.compat.aliases import FunctionNodes
 from wemake_python_styleguide.compat.nodes import TypeAlias as ast_TypeAlias
 from wemake_python_styleguide.violations.complexity import (
@@ -32,8 +33,9 @@ class JonesComplexityVisitor(BaseNodeVisitor):
 
     Some nodes are ignored because there's no sense in analyzing them.
     Some nodes like type annotations are not affecting line complexity,
-    so we do not count them. FormattedValue and JoinedStr nodes are not
-    counted, because they have no visible impact on source code.
+    so we do not count them. FormattedValue, JoinedStr, Interpolation, and
+    TemplateStr nodes are not counted, because they have no visible impact
+    on source code.
     """
 
     _ignored_nodes = (
@@ -42,6 +44,8 @@ class JonesComplexityVisitor(BaseNodeVisitor):
         ast.expr_context,
         ast.FormattedValue,
         ast.JoinedStr,
+        nodes.Interpolation,
+        nodes.TemplateStr,
     )
 
     def __init__(self, *args, **kwargs) -> None:

--- a/wemake_python_styleguide/visitors/ast/complexity/overuses.py
+++ b/wemake_python_styleguide/visitors/ast/complexity/overuses.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 from collections.abc import Callable
 from typing import ClassVar, TypeAlias, final
 
+from wemake_python_styleguide.compat import nodes
 from wemake_python_styleguide.compat.aliases import FunctionNodes
 from wemake_python_styleguide.logic import source, walk
 from wemake_python_styleguide.logic.complexity import overuses
@@ -83,8 +84,8 @@ class StringOveruseVisitor(base.BaseNodeVisitor):
         if annotations.is_annotation(node):
             return
 
-        # Part of the f-string:
-        if walk.get_closest_parent(node, parents=(ast.JoinedStr,)):
+        # Part of the f-string or t-string:
+        if walk.get_closest_parent(node, parents=(ast.JoinedStr, nodes.TemplateStr)):
             return
 
         # Some strings are so common, that it makes no sense to check if

--- a/wemake_python_styleguide/visitors/ast/complexity/overuses.py
+++ b/wemake_python_styleguide/visitors/ast/complexity/overuses.py
@@ -85,7 +85,9 @@ class StringOveruseVisitor(base.BaseNodeVisitor):
             return
 
         # Part of the f-string or t-string:
-        if walk.get_closest_parent(node, parents=(ast.JoinedStr, nodes.TemplateStr)):
+        if walk.get_closest_parent(
+            node, parents=(ast.JoinedStr, nodes.TemplateStr)
+        ):
             return
 
         # Some strings are so common, that it makes no sense to check if

--- a/wemake_python_styleguide/visitors/ast/complexity/overuses.py
+++ b/wemake_python_styleguide/visitors/ast/complexity/overuses.py
@@ -86,7 +86,8 @@ class StringOveruseVisitor(base.BaseNodeVisitor):
 
         # Part of the f-string or t-string:
         if walk.get_closest_parent(
-            node, parents=(ast.JoinedStr, nodes.TemplateStr)
+            node,
+            parents=(ast.JoinedStr, nodes.TemplateStr),
         ):
             return
 

--- a/wemake_python_styleguide/visitors/ast/operators.py
+++ b/wemake_python_styleguide/visitors/ast/operators.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 from collections.abc import Mapping, Sequence
 from typing import ClassVar, TypeAlias, final
 
+from wemake_python_styleguide.compat import nodes
 from wemake_python_styleguide.compat.aliases import TextNodes
 from wemake_python_styleguide.logic import walk
 from wemake_python_styleguide.logic.nodes import get_parent
@@ -241,6 +242,7 @@ class WrongMathOperatorVisitor(base.BaseNodeVisitor):
     _string_nodes: ClassVar[AnyNodes] = (
         TextNodes,
         ast.JoinedStr,
+        nodes.TemplateStr,
     )
 
     _list_nodes: ClassVar[AnyNodes] = (

--- a/wemake_python_styleguide/visitors/tokenize/comments.py
+++ b/wemake_python_styleguide/visitors/tokenize/comments.py
@@ -321,7 +321,7 @@ class CommentInFormattedStringVisitor(BaseTokenVisitor):  # pragma: >=3.12 cover
     _comment_in_fstring: ClassVar[re.Pattern[str]] = re.compile(
         r"""
         .*                  # (1) anything before the f-string
-        fr?(['"])           # (2) `f` or `fr`prefix + a single or double quote
+        (?:[ft]r?|r[ft])(['"]) # (2) f/t prefix + a single or double quote
         .*                  # (3) any characters up to…
         \{                  # (4) opening brace
         [^}]*               # (5) any characters except closing braces
@@ -333,6 +333,10 @@ class CommentInFormattedStringVisitor(BaseTokenVisitor):  # pragma: >=3.12 cover
 
     def visit_fstring_start(self, token: tokenize.TokenInfo) -> None:
         """Performs fstring check."""
+        self._check_is_fstring_ends_with_comment(token)
+
+    def visit_tstring_start(self, token: tokenize.TokenInfo) -> None:
+        """Performs t-string check."""
         self._check_is_fstring_ends_with_comment(token)
 
     def _check_is_fstring_ends_with_comment(

--- a/wemake_python_styleguide/visitors/tokenize/comments.py
+++ b/wemake_python_styleguide/visitors/tokenize/comments.py
@@ -335,7 +335,10 @@ class CommentInFormattedStringVisitor(BaseTokenVisitor):  # pragma: >=3.12 cover
         """Performs fstring check."""
         self._check_is_fstring_ends_with_comment(token)
 
-    def visit_tstring_start(self, token: tokenize.TokenInfo) -> None:
+    def visit_tstring_start(  # pragma: >=3.14 cover
+        self,
+        token: tokenize.TokenInfo,
+    ) -> None:
         """Performs t-string check."""
         self._check_is_fstring_ends_with_comment(token)
 

--- a/wemake_python_styleguide/visitors/tokenize/primitives.py
+++ b/wemake_python_styleguide/visitors/tokenize/primitives.py
@@ -238,7 +238,7 @@ class MultilineFormattedStringTokenVisitor(
     _multiline_fstring_pattern: ClassVar[re.Pattern[str]] = re.compile(
         r"""
         .*                  # (1) anything before the f-string
-        fr?(['"])           # (2) `f` or `fr`prefix + a single or double quote
+        (?:[ft]r?|r[ft])(['"]) # (2) f/t prefix + a single or double quote
         (?!\1\1)            # (3) not triple quote
         .*                  # (4) any characters up to…
         (\{.*\}.)*          # (5) any fully closed {…} expressions, if present
@@ -253,7 +253,11 @@ class MultilineFormattedStringTokenVisitor(
         """Performs check."""
         self._check_fstring_is_multi_lined(token)
 
+    def visit_tstring_start(self, token: tokenize.TokenInfo) -> None:
+        """Performs check for t-strings."""
+        self._check_fstring_is_multi_lined(token)
+
     def _check_fstring_is_multi_lined(self, token: tokenize.TokenInfo) -> None:
-        """Finds if f-string is multi-line."""
+        """Finds if f/t-string is multi-line."""
         if self._multiline_fstring_pattern.match(token.line):
             self.add_violation(MultilineFormattedStringViolation(token))

--- a/wemake_python_styleguide/visitors/tokenize/primitives.py
+++ b/wemake_python_styleguide/visitors/tokenize/primitives.py
@@ -253,7 +253,10 @@ class MultilineFormattedStringTokenVisitor(
         """Performs check."""
         self._check_fstring_is_multi_lined(token)
 
-    def visit_tstring_start(self, token: tokenize.TokenInfo) -> None:
+    def visit_tstring_start(  # pragma: >=3.14 cover
+        self,
+        token: tokenize.TokenInfo,
+    ) -> None:
         """Performs check for t-strings."""
         self._check_fstring_is_multi_lined(token)
 


### PR DESCRIPTION
# Extend style rules for f-strings to t-strings (Python 3.14+)

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made
- [ ] I have added my changes to the `CHANGELOG.md`

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

- Closes #3613

---

## Summary of Changes

Python 3.14 introduces **Template Strings (`t-strings`)** via [PEP 750](https://peps.python.org/pep-0750/). Since `t-strings` share formatting and interpolation syntax with `f-strings`, this PR extends our existing formatted string style rules to cover `t-strings` as well.

### 1. AST Compatibility Shims (`compat/nodes.py`)
- Added conditional shims for `ast.TemplateStr` and `ast.Interpolation`. On Python versions `< 3.14`, these fallback to safe stub classes inheriting from `ast.expr` so type checking and AST traversal work cleanly across all Python versions without raising `AttributeError`.

### 2. AST Visitor Extensions (`visitors/ast/`)
- **`builtins.py`**: Added `visit_TemplateStr` handler and generalized `_check_complex_formatted_string` to inspect both `ast.JoinedStr` and `nodes.TemplateStr`, enforcing complexity restrictions (**WPS237**) on `t-string` interpolation expressions.
- **`complexity/jones.py`**: Added `TemplateStr` and `Interpolation` to ignored node types so internal formatting nodes do not inflate inline Jones line complexity scores.
- **`complexity/overuses.py`**: Updated `_check_string_constant` to ignore string constants nested inside `nodes.TemplateStr`.
- **`operators.py`**: Added `TemplateStr` to string classes for math operator checking.

### 3. Tokenize Visitor Extensions (`visitors/tokenize/`)
- **`primitives.py`**: Added `visit_tstring_start` handler and updated `_multiline_fstring_pattern` regex to match `f` and `t` string prefixes (`(?:[ft]r?|r[ft])(['"])`), enforcing triple-quote requirements for multiline formatted strings (**WPS479**).
- **`comments.py`**: Added `visit_tstring_start` handler and updated `_comment_in_fstring` regex to forbid inline comments inside `t-string` expressions (**WPS480**).

### 4. Violation Documentation (`violations/`)
- Updated violation descriptions and docstrings for **WPS237** (`TooComplexFormattedStringViolation`), **WPS479** (`MultilineFormattedStringViolation`), and **WPS480** (`CommentInFormattedStringViolation`) to explicitly state they forbid complex expressions, multiline quotes, and inline comments in both `f-strings` and `t-strings`.

### 5. Automated Testing (`tests/`)
- Added unit test cases covering simple and complex `t-string` usages across AST and tokenize visitors in `test_formatted_string.py`, `test_mulitiline_formatted_string312.py`, and `test_comment_in_formatted_string312.py`.
- Guarded all new `t-string` tests with `@pytest.mark.skipif(sys.version_info < (3, 14), reason='t-strings are only in Python 3.14+')`.

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->

🙏 Please, if you or your company is finding wemake-python-styleguide valuable, help us sustain the project by sponsoring it transparently on https://opencollective.com/wemake-python-styleguide. As a thank you, your profile/company logo will be added to our main README which receives hundreds of unique visitors per day.
