### PR TITLE
rename function_name

### DIFF
--- a/wemake_python_styleguide/visitors/ast/functions.py
+++ b/wemake_python_styleguide/visitors/ast/functions.py
@@ -66,13 +66,13 @@ class WrongFunctionCallVisitor(base.BaseNodeVisitor):
         self.generic_visit(node)
 
     def _check_wrong_function_called(self, node: ast.Call) -> None:
-        function_name = functions.given_function_called(
+        wrong_function_called = functions.given_function_called(
             node,
             FUNCTIONS_BLACKLIST,
         )
-        if function_name:
+        if wrong_function_called:
             self.add_violation(
-                WrongFunctionCallViolation(node, text=function_name),
+                WrongFunctionCallViolation(node, text=wrong_function_called),
             )
 
     def _check_super_context(self, node: ast.Call) -> None:


### PR DESCRIPTION
# I have made things!
While exploring the codebase, I noticed that the variable name `function_name` was misleading, it could be empty, so it didn't clearly show that it's used as an indicator of a violation. The new name makes that clearer. Literally, when I read `if function_name:`, I couldn't understand what was being verified or what the variable represented. ( I had to navigate to `given_function_called` ). You agree that name is misleading? Perhaps you can suggest a better one than `is_wrong_name` :)
<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [ ] I have created at least one test case for the changes I have made
- [ ] I have updated the documentation for the changes I have made
- [ ] I have added my changes to the `CHANGELOG.md`

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->

🙏 Please, if you or your company is finding wemake-python-styleguide valuable, help us sustain the project by sponsoring it transparently on https://opencollective.com/wemake-python-styleguide. As a thank you, your profile/company logo will be added to our main README which receives hundreds of unique visitors per day.
