### PR TITLE
Remove the Spellcheckers section from CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,32 +112,6 @@ mypy wemake_python_styleguide
 This step is mandatory during the CI.
 
 
-## Spellcheckers
-
-This project is developed by a diverse and multilingual group of people.
-Many of us are not English native speakers and we also know that people can make mistakes and typos even in the simplest of words.
-
-So, that's why we use a bunch of tools to find and fix spelling and grammar.
-
-You will need to install them manually, because we don't ship them with the dependencies:
-
-```bash
-pip install codespell flake8-spellcheck
-```
-
-And then you can use them:
-
-```bash
-# codespell:
-codespell -w wemake_python_styleguide tests docs scripts styles *.md --ignore-words ./tests/whitelist.txt
-
-# flake8-spellcheck:
-flake8 --whitelist ./tests/whitelist.txt .
-```
-
-We run them from time to time, this is not in the CI yet.
-
-
 ## Submitting your code
 
 We use [trunk based](https://trunkbaseddevelopment.com/)


### PR DESCRIPTION
Removes the Spellcheckers section from `CONTRIBUTING.md`.

proposed in #3783, `codespell` runs in `pre-commit` now. Also removed the `flake8-spellcheck` command, which reports nothing because `setup.cfg` has `select = WPS, E999`.

FYI the `pre-commit` hook still uses `[tool.codespell]` and works fine.

## Checklist

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [ ] I have created at least one test case for the changes I have made
  N/A: documentation only, no code changes.
- [x] I have updated the documentation for the changes I have made
- [ ] I have added my changes to the `CHANGELOG.md`
  N/A: documentation only. Happy to add an entry if you'd prefer one.

## Related issues

Closes #3783