### PR TITLE
Fix violation code search links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Semantic versioning in our case means:
 ### Bugfixes
 
 - Count overused str and bytes separately for `WPS226`, 3782
+- Adds direct links to violations when searching by code, #3790
 
 ### Misc
 

--- a/docs/ext/plugincodes.py
+++ b/docs/ext/plugincodes.py
@@ -99,6 +99,14 @@ class PlugincodesDirective(SphinxDirective):
             'exclude-members': 'error_template,code',
         }
         for violation_class in violation_classes:
+            self.env.domains.standard_domain.note_object(
+                'violation-code',
+                violation_class.full_code,
+                (
+                    f'{violation_class.__module__}.'
+                    f'{violation_class.__qualname__}'
+                ),
+            )
             local_autodoc = AutodocDirective(
                 name='autoclass',
                 arguments=[violation_class.__name__],
@@ -161,4 +169,9 @@ def setup(app: Sphinx) -> None:
     """Setup for sphinx extension."""
     app.setup_extension('sphinx.ext.autosummary')
     app.setup_extension('sphinx.ext.autodoc')
+    app.add_object_type(
+        'violation-code',
+        'violation',
+        objname='violation code',
+    )
     app.add_directive('plugincodes', PlugincodesDirective)


### PR DESCRIPTION
This change registers each WPS code as a Sphinx object of the`violation-code` type. 

The object name is the violation code, while its target is the existing anchor generated by `autoclass`.

As a result, Sphinx search now displays a dedicated result such as `WPS335 (violation code, in Consistency)`, which links directly to `WrongLoopIterTypeViolation`.

The regular full-text result is still present.

## Result
<img width="2129" height="821" alt="image" src="https://github.com/user-attachments/assets/262a1c03-73fa-4693-ba20-99e27078c5c6" />

## Verification

  - Built the HTML documentation with Sphinx warnings treated as errors.
  - Verified searches for multiple violation codes.
  - Verified that the dedicated result links to the corresponding violation anchor.
  - Ran Ruff, Flake8, import-linter, mypy, and dependency checks.

## AI Policy

- [x] I have read and agree to the [AI Policy](https://github.com/wemake-services/wemake-python-styleguide/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result


## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [ ] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made
- [x] I have added my changes to the `CHANGELOG.md`

## Related issues


- Closes #3790
