### PR TITLE
test: exercise t-string coverage in overused string and comment tests

### DIFF
--- a/tests/test_visitors/test_ast/test_complexity/test_overuses/test_overused_string.py
+++ b/tests/test_visitors/test_ast/test_complexity/test_overuses/test_overused_string.py
@@ -111,8 +111,8 @@ y = f'{pattern}-postfix'
 
 tstring_same_prefix1 = pytest.param(
     """
-    x = f'Hello, {pattern}'
-    y = f'Hello, {pattern}'
+    x = t'Hello, {pattern}'
+    y = t'Hello, {pattern}'
     """,
     marks=pytest.mark.skipif(
         not PY314,
@@ -122,8 +122,8 @@ tstring_same_prefix1 = pytest.param(
 
 tstring_same_prefix2 = pytest.param(
     """
-    x = f'{pattern}-postfix'
-    y = f'{pattern}-postfix'
+    x = t'{pattern}-postfix'
+    y = t'{pattern}-postfix'
     """,
     marks=pytest.mark.skipif(
         not PY314,

--- a/tests/test_visitors/test_tokenize/test_comments/test_comment_in_formatted_string312.py
+++ b/tests/test_visitors/test_tokenize/test_comments/test_comment_in_formatted_string312.py
@@ -84,7 +84,7 @@ foo = r{0}"""test{{a # comment
 '''
 
 rfstring_with_comment_triple_single_quotes = """
-foo = rf'''test{{a # comment
+foo = r{0}'''test{{a # comment
 }}'''
 """
 


### PR DESCRIPTION
## Summary

Addresses #3793 where two test constants touched by #3702 did not exercise t-strings:

1. tests/test_visitors/test_ast/test_complexity/test_overuses/test_overused_string.py: Updated tstring_same_prefix1 and tstring_same_prefix2 to use t'...' prefixes rather than repeating f'...'.
2. tests/test_visitors/test_tokenize/test_comments/test_comment_in_formatted_string312.py: Updated rfstring_with_comment_triple_single_quotes to use r{0}''' formatting placeholder rather than hardcoded rf'''.

Fixes #3793

## Validation
- Ran pytest on both test modules under Python 3.14 (190 passed).