### PR TITLE
Do not count docstrings for WPS226

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Semantic versioning in our case means:
 ### Bugfixes
 
 - Count overused str and bytes separately for `WPS226`, 3782
+- Do not count docstrings for `WPS226`, #3803
 - Adds direct links to violations when searching by code, #3790
 
 ### Misc

--- a/tests/test_visitors/test_ast/test_complexity/test_overuses/test_overused_string.py
+++ b/tests/test_visitors/test_ast/test_complexity/test_overuses/test_overused_string.py
@@ -131,6 +131,44 @@ tstring_same_prefix2 = pytest.param(
     ),
 )
 
+# See:
+# https://github.com/wemake-services/wemake-python-styleguide/issues/3803
+module_docstring = """
+{0}
+"""
+
+function_docstrings = """
+def first():
+    {0}
+
+def second():
+    {0}
+
+class Some:
+    {0}
+
+    def method(self):
+        {0}
+"""
+
+not_a_docstring = '''
+def first():
+    """Docs."""
+    {0}
+
+def second():
+    """Docs."""
+    {0}
+
+def third():
+    """Docs."""
+    {0}
+
+def fourth():
+    """Docs."""
+    {0}
+'''
+
 EXPECTED_LOCATION = (2, 8)
 
 
@@ -328,6 +366,60 @@ def test_common_strings_allowed(
     visitor.run()
 
     assert_errors(visitor, [])
+
+
+@pytest.mark.parametrize(
+    'strings',
+    [
+        module_docstring,
+        function_docstrings,
+    ],
+)
+@pytest.mark.parametrize(
+    'string_value',
+    [
+        '"""Docstring."""',
+        '"Docstring."',
+    ],
+)
+def test_docstrings_not_counted(
+    assert_errors,
+    parse_ast_tree,
+    options,
+    strings,
+    string_value,
+):
+    """Ensures that docstrings do not count against the overuse limit."""
+    tree = parse_ast_tree(strings.format(string_value))
+
+    option_values = options(max_string_usages=0)
+    visitor = StringOveruseVisitor(option_values, tree=tree)
+    visitor.run()
+
+    assert_errors(visitor, [])
+
+
+@pytest.mark.parametrize(
+    'string_value',
+    [
+        '"""Not a docstring."""',
+        '"Not a docstring."',
+    ],
+)
+def test_strings_after_docstrings_counted(
+    assert_errors,
+    parse_ast_tree,
+    options,
+    string_value,
+):
+    """Ensures that only the first string in a body is a docstring."""
+    tree = parse_ast_tree(not_a_docstring.format(string_value))
+
+    option_values = options(max_string_usages=0)
+    visitor = StringOveruseVisitor(option_values, tree=tree)
+    visitor.run()
+
+    assert_errors(visitor, [OverusedStringViolation])
 
 
 @pytest.mark.parametrize(

--- a/wemake_python_styleguide/logic/tree/strings.py
+++ b/wemake_python_styleguide/logic/tree/strings.py
@@ -1,6 +1,7 @@
 import ast
 
 from wemake_python_styleguide.compat import nodes
+from wemake_python_styleguide.logic.nodes import get_context, get_parent
 from wemake_python_styleguide.logic.walk import get_closest_parent
 
 
@@ -17,6 +18,20 @@ def is_doc_string(node: ast.AST) -> bool:
         node.value.value,
         str,
     )
+
+
+def is_doc_string_value(node: ast.AST) -> bool:
+    """
+    Tells whether or not the given node is a docstring's own constant.
+
+    While :func:`is_doc_string` works with statements,
+    this one works with the string constant inside of them.
+    """
+    statement = get_parent(node)
+    if statement is None or not is_doc_string(statement):
+        return False
+    context = get_context(statement)
+    return context is not None and context.body[0] is statement
 
 
 def has_format_string_conversion(component: ast.AST) -> bool:

--- a/wemake_python_styleguide/violations/complexity.py
+++ b/wemake_python_styleguide/violations/complexity.py
@@ -820,6 +820,9 @@ class OverusedStringViolation(MaybeASTViolation):
     single space `' '`, new line `'\n'`, `'\r\n'` and tabulator `'\t'`
     do not count against string literal overuse limit.
 
+    Docstrings are not counted as well,
+    because they document the code and cannot be deduplicated.
+
     The violation points to the first occurrence of the overused string literal.
 
     Reasoning:

--- a/wemake_python_styleguide/visitors/ast/complexity/overuses.py
+++ b/wemake_python_styleguide/visitors/ast/complexity/overuses.py
@@ -7,7 +7,7 @@ from wemake_python_styleguide.compat import nodes
 from wemake_python_styleguide.compat.aliases import FunctionNodes
 from wemake_python_styleguide.logic import source, walk
 from wemake_python_styleguide.logic.complexity import overuses
-from wemake_python_styleguide.logic.tree import annotations
+from wemake_python_styleguide.logic.tree import annotations, strings
 from wemake_python_styleguide.types import AnyNodes
 from wemake_python_styleguide.violations import complexity
 from wemake_python_styleguide.visitors import base
@@ -105,6 +105,10 @@ class StringOveruseVisitor(base.BaseNodeVisitor):
         first_nodes: defaultdict[_StrOrBytes, ast.Constant],
     ) -> None:
         if annotations.is_annotation(node):
+            return
+
+        # Docstrings are documentation, not real string usages:
+        if strings.is_doc_string_value(node):
             return
 
         # Part of the f-string or t-string:


### PR DESCRIPTION
# I have made things!

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->
`WPS226` counted docstrings as string literal usages. Four functions sharing one docstring were enough to trigger it:

```
repro.py:2:5: WPS226 Found string literal over-use: 'Lazy endpoint spec.' 4 > 3
```

The violation asks you to move an overused literal into a named constant. You can't do that to a docstring, so it shouldn't be counted at all.

`logic/tree/strings.py` already has `is_doc_string()`, but it takes the statement (`ast.Expr`), and the visitor works with the `ast.Constant` inside it. That function has four other call sites, so I left it alone and put `is_doc_string_value()` next to it. The definition is the one the old docstring already states: the first statement of the nearest module, class or function.

```python
statement = get_parent(node)
if statement is None or not is_doc_string(statement):
    return False
context = get_context(statement)
return context is not None and context.body[0] is statement
```

`StringOveruseVisitor._check_constant` returns early on it, next to the existing annotation and f-string checks. Bytes go through the same method and always fail the check, since bytes can't be a docstring.

Only `body[0]` is treated as a docstring. A bare string statement sitting after the real docstring still counts, and there's a test for that.

One case this doesn't cover: PEP 258 attribute docstrings are still counted. Different shape, and I'd rather not widen the fix here — I can open a separate issue if you think it's worth handling.

## AI Policy

- [x] I have read and agree to the [AI Policy](https://github.com/wemake-services/wemake-python-styleguide/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result


## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made
- [x] I have added my changes to the `CHANGELOG.md`

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->
Closes #3803 
<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->

🙏 Please, if you or your company is finding wemake-python-styleguide valuable, help us sustain the project by sponsoring it transparently on https://opencollective.com/wemake-python-styleguide. As a thank you, your profile/company logo will be added to our main README which receives hundreds of unique visitors per day.
