### PR TITLE
Do not count attribute docstrings for WPS226

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ Semantic versioning in our case means:
 
 - Count overused str and bytes separately for `WPS226`, 3782
 - Do not count docstrings for `WPS226`, #3803
-- Do not count attribute docstrings for `WPS226`, #3805
+- Do not count attribute and type alias docstrings for `WPS226`, #3805
 - Adds direct links to violations when searching by code, #3790
 
 ### Misc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Semantic versioning in our case means:
 
 - Count overused str and bytes separately for `WPS226`, 3782
 - Do not count docstrings for `WPS226`, #3803
+- Do not count attribute docstrings for `WPS226`, #3805
 - Adds direct links to violations when searching by code, #3790
 
 ### Misc

--- a/tests/test_visitors/test_ast/test_complexity/test_overuses/test_overused_string.py
+++ b/tests/test_visitors/test_ast/test_complexity/test_overuses/test_overused_string.py
@@ -209,7 +209,7 @@ def third():
     {0}
 
 def fourth():
-    print(4)
+    x = 1
     {0}
 """
 

--- a/tests/test_visitors/test_ast/test_complexity/test_overuses/test_overused_string.py
+++ b/tests/test_visitors/test_ast/test_complexity/test_overuses/test_overused_string.py
@@ -1,6 +1,6 @@
 import pytest
 
-from wemake_python_styleguide.compat.constants import PY314
+from wemake_python_styleguide.compat.constants import PY312, PY314
 from wemake_python_styleguide.violations.complexity import (
     OverusedStringViolation,
 )
@@ -213,6 +213,36 @@ def fourth():
     {0}
 """
 
+# Type aliases are documented the very same way, see:
+# https://discuss.python.org/t/docstrings-for-type-aliases/108901
+explicit_type_alias_docstrings = """
+Timeout: TypeAlias = float
+{0}
+
+Retries: TypeAlias = int
+{0}
+
+Backoff: TypeAlias = float
+{0}
+"""
+
+type_alias_docstrings = pytest.param(
+    """
+    type Timeout = float | None
+    {0}
+
+    type Retries = int
+    {0}
+
+    type Backoff = float
+    {0}
+    """,
+    marks=pytest.mark.skipif(
+        not PY312,
+        reason='`type` aliases are only in Python 3.12+',
+    ),
+)
+
 EXPECTED_LOCATION = (2, 8)
 
 
@@ -419,6 +449,8 @@ def test_common_strings_allowed(
         function_docstrings,
         module_attribute_docstrings,
         class_attribute_docstrings,
+        explicit_type_alias_docstrings,
+        type_alias_docstrings,
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/test_visitors/test_ast/test_complexity/test_overuses/test_overused_string.py
+++ b/tests/test_visitors/test_ast/test_complexity/test_overuses/test_overused_string.py
@@ -213,6 +213,26 @@ def fourth():
     {0}
 """
 
+# `x.some = 1` defines an attribute of `x`, not of the module, the class,
+# or the instance we are in. So, there's nothing here to document.
+foreign_attribute_docstrings = """
+x.some = 1
+{0}
+
+def first():
+    x.some = 1
+    {0}
+
+class Some:
+    def second(self, x):
+        x.some = 1
+        {0}
+
+    def third(self):
+        self.some.other = 1
+        {0}
+"""
+
 # Type aliases are documented the very same way, see:
 # https://discuss.python.org/t/docstrings-for-type-aliases/108901
 explicit_type_alias_docstrings = """
@@ -482,6 +502,7 @@ def test_docstrings_not_counted(
     [
         not_a_docstring,
         not_an_attribute_docstring,
+        foreign_attribute_docstrings,
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/test_visitors/test_ast/test_complexity/test_overuses/test_overused_string.py
+++ b/tests/test_visitors/test_ast/test_complexity/test_overuses/test_overused_string.py
@@ -169,6 +169,50 @@ def fourth():
     {0}
 '''
 
+# See:
+# https://github.com/wemake-services/wemake-python-styleguide/issues/3805
+module_attribute_docstrings = """
+first = 1
+{0}
+
+second: int = 2
+{0}
+
+third: int
+{0}
+"""
+
+class_attribute_docstrings = """
+class Some:
+    first = 1
+    {0}
+
+    second: int = 2
+    {0}
+
+    def __init__(self):
+        self.third = 3
+        {0}
+"""
+
+not_an_attribute_docstring = """
+def first():
+    print(1)
+    {0}
+
+def second():
+    print(2)
+    {0}
+
+def third():
+    print(3)
+    {0}
+
+def fourth():
+    print(4)
+    {0}
+"""
+
 EXPECTED_LOCATION = (2, 8)
 
 
@@ -373,6 +417,8 @@ def test_common_strings_allowed(
     [
         module_docstring,
         function_docstrings,
+        module_attribute_docstrings,
+        class_attribute_docstrings,
     ],
 )
 @pytest.mark.parametrize(
@@ -400,20 +446,28 @@ def test_docstrings_not_counted(
 
 
 @pytest.mark.parametrize(
+    'strings',
+    [
+        not_a_docstring,
+        not_an_attribute_docstring,
+    ],
+)
+@pytest.mark.parametrize(
     'string_value',
     [
         '"""Not a docstring."""',
         '"Not a docstring."',
     ],
 )
-def test_strings_after_docstrings_counted(
+def test_strings_in_other_places_counted(
     assert_errors,
     parse_ast_tree,
     options,
+    strings,
     string_value,
 ):
-    """Ensures that only the first string in a body is a docstring."""
-    tree = parse_ast_tree(not_a_docstring.format(string_value))
+    """Ensures that strings documenting nothing are still counted."""
+    tree = parse_ast_tree(strings.format(string_value))
 
     option_values = options(max_string_usages=0)
     visitor = StringOveruseVisitor(option_values, tree=tree)

--- a/tests/test_visitors/test_ast/test_complexity/test_overuses/test_overused_string.py
+++ b/tests/test_visitors/test_ast/test_complexity/test_overuses/test_overused_string.py
@@ -205,7 +205,7 @@ def second():
     {0}
 
 def third():
-    print(3)
+    y: int = 0
     {0}
 
 def fourth():

--- a/tests/test_visitors/test_ast/test_complexity/test_overuses/test_overused_string.py
+++ b/tests/test_visitors/test_ast/test_complexity/test_overuses/test_overused_string.py
@@ -197,7 +197,7 @@ class Some:
 
 not_an_attribute_docstring = """
 def first():
-    print(1)
+    x = y = 1
     {0}
 
 def second():

--- a/tests/test_visitors/test_ast/test_complexity/test_overuses/test_overused_string.py
+++ b/tests/test_visitors/test_ast/test_complexity/test_overuses/test_overused_string.py
@@ -201,7 +201,7 @@ def first():
     {0}
 
 def second():
-    print(2)
+    x, y = call()
     {0}
 
 def third():

--- a/wemake_python_styleguide/logic/tree/strings.py
+++ b/wemake_python_styleguide/logic/tree/strings.py
@@ -1,10 +1,14 @@
 import ast
 import itertools
+from typing import Final
 
 from wemake_python_styleguide.compat import nodes
 from wemake_python_styleguide.compat.aliases import AssignNodes
 from wemake_python_styleguide.logic.nodes import get_context, get_parent
 from wemake_python_styleguide.logic.walk import get_closest_parent
+
+#: Nodes that a docstring can document by being placed right after them.
+_DocumentedNodes: Final = (*AssignNodes, nodes.TypeAlias)
 
 
 def is_doc_string(node: ast.AST) -> bool:
@@ -31,6 +35,8 @@ def is_doc_string_value(node: ast.AST) -> bool:
 
     Attribute docstrings count as well: PEP 258 documents
     an assignment with a string placed right after it.
+    Type aliases are documented the same way, see
+    https://discuss.python.org/t/docstrings-for-type-aliases/108901
     """
     statement = get_parent(node)
     if statement is None or not is_doc_string(statement):
@@ -46,11 +52,11 @@ def _is_doc_string_place(
     body: list[ast.stmt],
     statement: ast.AST,
 ) -> bool:
-    """Docstrings open a definition's body or follow an assignment."""
+    """Docstrings open a definition's body or follow what they document."""
     if body[0] is statement:
         return True
     return any(
-        current is statement and isinstance(previous, AssignNodes)
+        current is statement and isinstance(previous, _DocumentedNodes)
         for previous, current in itertools.pairwise(body)
     )
 

--- a/wemake_python_styleguide/logic/tree/strings.py
+++ b/wemake_python_styleguide/logic/tree/strings.py
@@ -1,16 +1,13 @@
 import ast
 import itertools
-from typing import Final
 
 from wemake_python_styleguide.compat import nodes
 from wemake_python_styleguide.compat.aliases import AssignNodes, FunctionNodes
 from wemake_python_styleguide.compat.functions import get_assign_targets
 from wemake_python_styleguide.logic.nodes import get_context, get_parent
+from wemake_python_styleguide.logic.tree.attributes import is_special_attr
 from wemake_python_styleguide.logic.walk import get_closest_parent
 from wemake_python_styleguide.types import ContextNodes
-
-#: Targets that define an attribute a docstring can document.
-_AttributeTargets: Final = (ast.Name, ast.Attribute)
 
 
 def is_doc_string(node: ast.AST) -> bool:
@@ -67,10 +64,14 @@ def _is_documented(statement: ast.stmt, context: ContextNodes) -> bool:
     targets = get_assign_targets(statement)
     if len(targets) != 1:  # `x = y = 1` defines no single attribute
         return False
+    target = targets[0]
     if isinstance(context, FunctionNodes):
-        # Locals are not attributes, only `self.some = 1` is one.
-        return isinstance(targets[0], ast.Attribute)
-    return isinstance(targets[0], _AttributeTargets)
+        # Locals are not attributes. Only `self.some = 1` defines one,
+        # while `x.some = 1` documents an attribute of some other object.
+        return isinstance(target, ast.Attribute) and is_special_attr(target)
+    # Modules and classes define their attributes by plain names,
+    # `x.some = 1` here belongs to `x`, not to this module or class.
+    return isinstance(target, ast.Name)
 
 
 def has_format_string_conversion(component: ast.AST) -> bool:

--- a/wemake_python_styleguide/logic/tree/strings.py
+++ b/wemake_python_styleguide/logic/tree/strings.py
@@ -3,12 +3,13 @@ import itertools
 from typing import Final
 
 from wemake_python_styleguide.compat import nodes
-from wemake_python_styleguide.compat.aliases import AssignNodes
+from wemake_python_styleguide.compat.aliases import FunctionNodes
 from wemake_python_styleguide.logic.nodes import get_context, get_parent
 from wemake_python_styleguide.logic.walk import get_closest_parent
+from wemake_python_styleguide.types import ContextNodes
 
-#: Nodes that a docstring can document by being placed right after them.
-_DocumentedNodes: Final = (*AssignNodes, nodes.TypeAlias)
+#: Targets that define an attribute a docstring can document.
+_AttributeTargets: Final = (ast.Name, ast.Attribute)
 
 
 def is_doc_string(node: ast.AST) -> bool:
@@ -34,7 +35,7 @@ def is_doc_string_value(node: ast.AST) -> bool:
     this one works with the string constant inside of them.
 
     Attribute docstrings count as well: PEP 258 documents
-    an assignment with a string placed right after it.
+    an attribute with a string placed right after it.
     Type aliases are documented the same way, see
     https://discuss.python.org/t/docstrings-for-type-aliases/108901
     """
@@ -42,23 +43,42 @@ def is_doc_string_value(node: ast.AST) -> bool:
     if statement is None or not is_doc_string(statement):
         return False
     context = get_context(statement)
-    return context is not None and _is_doc_string_place(
-        context.body,
-        statement,
-    )
+    return context is not None and _is_doc_string_place(context, statement)
 
 
 def _is_doc_string_place(
-    body: list[ast.stmt],
+    context: ContextNodes,
     statement: ast.AST,
 ) -> bool:
     """Docstrings open a definition's body or follow what they document."""
-    if body[0] is statement:
+    if context.body[0] is statement:
         return True
     return any(
-        current is statement and isinstance(previous, _DocumentedNodes)
-        for previous, current in itertools.pairwise(body)
+        current is statement and _is_documented(previous, context)
+        for previous, current in itertools.pairwise(context.body)
     )
+
+
+def _is_documented(statement: ast.stmt, context: ContextNodes) -> bool:
+    """Only type aliases and single attribute definitions are documented."""
+    targets = _get_assign_targets(statement)
+    if not targets:  # `type X = int` names things without a target
+        return isinstance(statement, nodes.TypeAlias)
+    if len(targets) != 1:  # `x = y = 1` defines no single attribute
+        return False
+    if isinstance(context, FunctionNodes):
+        # Locals are not attributes, only `self.some = 1` is one.
+        return isinstance(targets[0], ast.Attribute)
+    return isinstance(targets[0], _AttributeTargets)
+
+
+def _get_assign_targets(statement: ast.stmt) -> list[ast.expr]:
+    """Returns what the statement assigns to, if it assigns at all."""
+    if isinstance(statement, ast.Assign):
+        return statement.targets
+    if isinstance(statement, ast.AnnAssign):
+        return [statement.target]
+    return []
 
 
 def has_format_string_conversion(component: ast.AST) -> bool:

--- a/wemake_python_styleguide/logic/tree/strings.py
+++ b/wemake_python_styleguide/logic/tree/strings.py
@@ -1,6 +1,8 @@
 import ast
+import itertools
 
 from wemake_python_styleguide.compat import nodes
+from wemake_python_styleguide.compat.aliases import AssignNodes
 from wemake_python_styleguide.logic.nodes import get_context, get_parent
 from wemake_python_styleguide.logic.walk import get_closest_parent
 
@@ -26,12 +28,31 @@ def is_doc_string_value(node: ast.AST) -> bool:
 
     While :func:`is_doc_string` works with statements,
     this one works with the string constant inside of them.
+
+    Attribute docstrings count as well: PEP 258 documents
+    an assignment with a string placed right after it.
     """
     statement = get_parent(node)
     if statement is None or not is_doc_string(statement):
         return False
     context = get_context(statement)
-    return context is not None and context.body[0] is statement
+    return context is not None and _is_doc_string_place(
+        context.body,
+        statement,
+    )
+
+
+def _is_doc_string_place(
+    body: list[ast.stmt],
+    statement: ast.AST,
+) -> bool:
+    """Docstrings open a definition's body or follow an assignment."""
+    if body[0] is statement:
+        return True
+    return any(
+        current is statement and isinstance(previous, AssignNodes)
+        for previous, current in itertools.pairwise(body)
+    )
 
 
 def has_format_string_conversion(component: ast.AST) -> bool:

--- a/wemake_python_styleguide/logic/tree/strings.py
+++ b/wemake_python_styleguide/logic/tree/strings.py
@@ -3,7 +3,8 @@ import itertools
 from typing import Final
 
 from wemake_python_styleguide.compat import nodes
-from wemake_python_styleguide.compat.aliases import FunctionNodes
+from wemake_python_styleguide.compat.aliases import AssignNodes, FunctionNodes
+from wemake_python_styleguide.compat.functions import get_assign_targets
 from wemake_python_styleguide.logic.nodes import get_context, get_parent
 from wemake_python_styleguide.logic.walk import get_closest_parent
 from wemake_python_styleguide.types import ContextNodes
@@ -61,24 +62,15 @@ def _is_doc_string_place(
 
 def _is_documented(statement: ast.stmt, context: ContextNodes) -> bool:
     """Only type aliases and single attribute definitions are documented."""
-    targets = _get_assign_targets(statement)
-    if not targets:  # `type X = int` names things without a target
-        return isinstance(statement, nodes.TypeAlias)
+    if not isinstance(statement, AssignNodes):
+        return isinstance(statement, nodes.TypeAlias)  # `type X = int`
+    targets = get_assign_targets(statement)
     if len(targets) != 1:  # `x = y = 1` defines no single attribute
         return False
     if isinstance(context, FunctionNodes):
         # Locals are not attributes, only `self.some = 1` is one.
         return isinstance(targets[0], ast.Attribute)
     return isinstance(targets[0], _AttributeTargets)
-
-
-def _get_assign_targets(statement: ast.stmt) -> list[ast.expr]:
-    """Returns what the statement assigns to, if it assigns at all."""
-    if isinstance(statement, ast.Assign):
-        return statement.targets
-    if isinstance(statement, ast.AnnAssign):
-        return [statement.target]
-    return []
 
 
 def has_format_string_conversion(component: ast.AST) -> bool:

--- a/wemake_python_styleguide/violations/complexity.py
+++ b/wemake_python_styleguide/violations/complexity.py
@@ -822,8 +822,9 @@ class OverusedStringViolation(MaybeASTViolation):
 
     Docstrings are not counted as well,
     because they document the code and cannot be deduplicated.
-    This includes attribute docstrings from PEP 258,
-    the ones placed right after an assignment.
+    This includes attribute docstrings from PEP 258
+    and type alias docstrings,
+    the ones placed right after an assignment or a ``type`` statement.
 
     The violation points to the first occurrence of the overused string literal.
 

--- a/wemake_python_styleguide/violations/complexity.py
+++ b/wemake_python_styleguide/violations/complexity.py
@@ -823,8 +823,9 @@ class OverusedStringViolation(MaybeASTViolation):
     Docstrings are not counted as well,
     because they document the code and cannot be deduplicated.
     This includes attribute docstrings from PEP 258
-    and type alias docstrings,
-    the ones placed right after an assignment or a ``type`` statement.
+    and type alias docstrings, the ones placed right after
+    an attribute definition or a ``type`` statement.
+    Local variables are not attributes, so they are still counted.
 
     The violation points to the first occurrence of the overused string literal.
 

--- a/wemake_python_styleguide/violations/complexity.py
+++ b/wemake_python_styleguide/violations/complexity.py
@@ -822,6 +822,8 @@ class OverusedStringViolation(MaybeASTViolation):
 
     Docstrings are not counted as well,
     because they document the code and cannot be deduplicated.
+    This includes attribute docstrings from PEP 258,
+    the ones placed right after an assignment.
 
     The violation points to the first occurrence of the overused string literal.
 


### PR DESCRIPTION
# I have made things!

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->
`WPS226` still counted PEP 258 attribute docstrings after #3804. Four class attributes sharing one:

```
attr_doc.py:3:5: WPS226 Found string literal over-use: 'Some field docs.' 4 > 3
```

Same reasoning as #3803. The string documents the assignment above it, so moving it into a named constant would stop it from being documentation.

`is_doc_string_value()` accepted exactly one position, `body[0]` of the nearest module, class or function. It now accepts a second, and the lookup moved into a helper:

```python
def _is_doc_string_place(body, statement) -> bool:
    """Docstrings open a definition's body or follow an assignment."""
    if body[0] is statement:
        return True
    return any(
        current is statement and isinstance(previous, AssignNodes)
        for previous, current in itertools.pairwise(body)
    )
```

`AssignNodes` is the existing `(ast.Assign, ast.AnnAssign)` tuple, so `first = 1`, `second: int = 2` and a bare `third: int` all work. I left `ast.AugAssign` out, since `count += 1` followed by a string isn't documenting anything.

The search stays inside the context's own body. `self.third = 3` in `__init__` is covered, because the context there is the method. A string after an assignment nested inside an `if` still counts, same as before, and so does one that follows anything other than an assignment. Both have tests.

One thing that looks odd in the diff: `is_doc_string_value()` now ends with `context is not None and _is_doc_string_place(...)` instead of an early return. Writing it as `if context is None: return False` drops coverage below 100%, because `get_context()` returns `None` only for the module node itself, and that can never be a docstring statement.

## AI Policy

- [x] I have read and agree to the [AI Policy](https://github.com/wemake-services/wemake-python-styleguide/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result


## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made
- [x] I have added my changes to the `CHANGELOG.md`

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->
Closes #3805 
<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->

🙏 Please, if you or your company is finding wemake-python-styleguide valuable, help us sustain the project by sponsoring it transparently on https://opencollective.com/wemake-python-styleguide. As a thank you, your profile/company logo will be added to our main README which receives hundreds of unique visitors per day.
