### PR TITLE
Add WPS484: forbid strings that document nothing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ Semantic versioning in our case means:
 
 ## WIP
 
+### Features
+
+- Adds `WPS484`: forbid strings that look like docstrings
+  but document nothing, #3808
+
 ### Bugfixes
 
 - Count overused str and bytes separately for `WPS226`, 3782

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,15 @@ Semantic versioning in our case means:
   change the client facing API, change code conventions significantly, etc.
 
 
-## 1.8.1
+## WIP
 
 ### Features
 
 - Adds `WPS484`: forbid strings that look like docstrings
   but document nothing, #3808
+
+
+## 1.8.1
 
 ### Bugfixes
 

--- a/tests/fixtures/noqa/noqa.py
+++ b/tests/fixtures/noqa/noqa.py
@@ -789,3 +789,6 @@ finally:
 
 if not user in users:  # noqa: WPS364
     my_print('legacy not-in style')
+
+some_sequence.first = 1
+'Documents nothing.'  # noqa: WPS484

--- a/tests/test_checker/test_noqa.py
+++ b/tests/test_checker/test_noqa.py
@@ -258,6 +258,7 @@ SHOULD_BE_RAISED = make_immutable(
         'WPS481': 10,
         'WPS482': 0,  # enabled only in python 3.15+
         'WPS483': 0,  # enabled only in python 3.15+
+        'WPS484': 1,
         'WPS500': 1,
         'WPS501': 1,
         'WPS502': 0,  # disabled since 1.0.0

--- a/tests/test_visitors/test_ast/test_complexity/test_overuses/test_overused_string.py
+++ b/tests/test_visitors/test_ast/test_complexity/test_overuses/test_overused_string.py
@@ -213,6 +213,27 @@ def fourth():
     {0}
 """
 
+# Only a constructor defines instance attributes, other methods just
+# assign to an object that is already made, there's nothing to document.
+not_a_constructor_docstring = """
+class Some:
+    def first(self):
+        self.field = 1
+        {0}
+
+    def second(self):
+        self.field = 2
+        {0}
+
+    def third(self):
+        self.field = 3
+        {0}
+
+    def fourth(self):
+        self.field = 4
+        {0}
+"""
+
 # `x.some = 1` defines an attribute of `x`, not of the module, the class,
 # or the instance we are in. So, there's nothing here to document.
 foreign_attribute_docstrings = """
@@ -502,6 +523,7 @@ def test_docstrings_not_counted(
     [
         not_a_docstring,
         not_an_attribute_docstring,
+        not_a_constructor_docstring,
         foreign_attribute_docstrings,
     ],
 )

--- a/tests/test_visitors/test_ast/test_statements/test_doc_string_placement.py
+++ b/tests/test_visitors/test_ast/test_statements/test_doc_string_placement.py
@@ -8,26 +8,26 @@ from wemake_python_styleguide.visitors.ast.statements import (
     DocStringPlacementVisitor,
 )
 
-module_docstring = "'Docs.'"
+module_docstring = '{0}'
 
 function_docstring = """
 def some():
-    'Docs.'
+    {0}
 """
 
 class_docstring = """
 class Some:
-    'Docs.'
+    {0}
 """
 
 module_attribute = """
 first = 1
-'Docs.'
+{0}
 """
 
 annotated_module_attribute = """
 first: int = 1
-'Docs.'
+{0}
 """
 
 class_attribute = """
@@ -35,7 +35,7 @@ class Some:
     'Class docs.'
 
     first = 1
-    'Docs.'
+    {0}
 """
 
 instance_attribute = """
@@ -43,13 +43,21 @@ class Some:
     def __init__(self):
         'Method docs.'
         self.first = 1
-        'Docs.'
+        {0}
+"""
+
+instance_attribute_in_new = """
+class Some:
+    def __new__(cls):
+        'Method docs.'
+        cls.first = 1
+        {0}
 """
 
 type_alias = pytest.param(
     """
     type Some = int
-    'Docs.'
+    {0}
     """,
     marks=pytest.mark.skipif(
         not PY312,
@@ -59,7 +67,7 @@ type_alias = pytest.param(
 
 foreign_attribute = """
 some.first = 1
-'Docs.'
+{0}
 """
 
 instance_attribute_outside_constructor = """
@@ -67,26 +75,26 @@ class Some:
     def method(self):
         'Method docs.'
         self.first = 1
-        'Docs.'
+        {0}
 """
 
 local_variable = """
 def some():
     'Function docs.'
     first = 1
-    'Docs.'
+    {0}
 """
 
 multiple_targets = """
 first = second = 1
-'Docs.'
+{0}
 """
 
 inside_condition = """
 def some(arg):
     'Function docs.'
     if arg:
-        'Docs.'
+        {0}
         return 1
     return 0
 """
@@ -95,13 +103,13 @@ after_call = """
 def some():
     'Function docs.'
     print(1)
-    'Docs.'
+    {0}
 """
 
 after_doc_string = """
 def some():
     'Function docs.'
-    'Docs.'
+    {0}
 """
 
 
@@ -115,7 +123,17 @@ def some():
         annotated_module_attribute,
         class_attribute,
         instance_attribute,
+        instance_attribute_in_new,
         type_alias,
+    ],
+)
+@pytest.mark.parametrize(
+    'string_value',
+    [
+        '"Doc"',
+        "'Doc'",
+        '"""Doc"""',
+        "'''Doc'''",
     ],
 )
 def test_documenting_string(
@@ -123,9 +141,10 @@ def test_documenting_string(
     parse_ast_tree,
     default_options,
     code,
+    string_value,
 ):
     """Testing that strings documenting something are allowed."""
-    tree = parse_ast_tree(code)
+    tree = parse_ast_tree(code.format(string_value))
 
     visitor = DocStringPlacementVisitor(default_options, tree=tree)
     visitor.run()
@@ -145,14 +164,24 @@ def test_documenting_string(
         after_doc_string,
     ],
 )
+@pytest.mark.parametrize(
+    'string_value',
+    [
+        '"Doc"',
+        "'Doc'",
+        '"""Doc"""',
+        "'''Doc'''",
+    ],
+)
 def test_string_documenting_nothing(
     assert_errors,
     parse_ast_tree,
     default_options,
     code,
+    string_value,
 ):
     """Testing that strings documenting nothing are forbidden."""
-    tree = parse_ast_tree(code)
+    tree = parse_ast_tree(code.format(string_value))
 
     visitor = DocStringPlacementVisitor(default_options, tree=tree)
     visitor.run()

--- a/tests/test_visitors/test_ast/test_statements/test_doc_string_placement.py
+++ b/tests/test_visitors/test_ast/test_statements/test_doc_string_placement.py
@@ -38,6 +38,24 @@ class Some:
     {0}
 """
 
+dataclass_attribute = """
+@dataclass
+class Some:
+    'Class docs.'
+
+    first: int
+    {0}
+"""
+
+dataclass_attribute_with_default = """
+@dataclass
+class Some:
+    'Class docs.'
+
+    first: int = 0
+    {0}
+"""
+
 instance_attribute = """
 class Some:
     def __init__(self):
@@ -68,6 +86,33 @@ type_alias = pytest.param(
 foreign_attribute = """
 some.first = 1
 {0}
+"""
+
+# A docstring goes after the attribute it documents, never before it.
+before_module_attribute = """
+'Module docs.'
+
+{0}
+first = 1
+"""
+
+before_class_attribute = """
+class Some:
+    'Class docs.'
+
+    {0}
+    first: int
+"""
+
+between_attributes = """
+class Some:
+    'Class docs.'
+
+    first = 1
+    'Documents first.'
+
+    {0}
+    second = 2
 """
 
 instance_attribute_outside_constructor = """
@@ -122,6 +167,8 @@ def some():
         module_attribute,
         annotated_module_attribute,
         class_attribute,
+        dataclass_attribute,
+        dataclass_attribute_with_default,
         instance_attribute,
         instance_attribute_in_new,
         type_alias,
@@ -156,6 +203,9 @@ def test_documenting_string(
     'code',
     [
         foreign_attribute,
+        before_module_attribute,
+        before_class_attribute,
+        between_attributes,
         instance_attribute_outside_constructor,
         local_variable,
         multiple_targets,

--- a/tests/test_visitors/test_ast/test_statements/test_doc_string_placement.py
+++ b/tests/test_visitors/test_ast/test_statements/test_doc_string_placement.py
@@ -1,0 +1,151 @@
+import pytest
+
+from wemake_python_styleguide.compat.constants import PY312
+from wemake_python_styleguide.violations.best_practices import (
+    WrongDocStringPlacementViolation,
+)
+from wemake_python_styleguide.visitors.ast.statements import (
+    DocStringPlacementVisitor,
+)
+
+module_docstring = "'Docs.'"
+
+function_docstring = """
+def some():
+    'Docs.'
+"""
+
+class_docstring = """
+class Some:
+    'Docs.'
+"""
+
+module_attribute = """
+first = 1
+'Docs.'
+"""
+
+annotated_module_attribute = """
+first: int = 1
+'Docs.'
+"""
+
+class_attribute = """
+class Some:
+    'Class docs.'
+
+    first = 1
+    'Docs.'
+"""
+
+instance_attribute = """
+class Some:
+    def __init__(self):
+        'Method docs.'
+        self.first = 1
+        'Docs.'
+"""
+
+type_alias = pytest.param(
+    """
+    type Some = int
+    'Docs.'
+    """,
+    marks=pytest.mark.skipif(
+        not PY312,
+        reason='`type` aliases are only in Python 3.12+',
+    ),
+)
+
+foreign_attribute = """
+some.first = 1
+'Docs.'
+"""
+
+local_variable = """
+def some():
+    'Function docs.'
+    first = 1
+    'Docs.'
+"""
+
+multiple_targets = """
+first = second = 1
+'Docs.'
+"""
+
+inside_condition = """
+def some(arg):
+    'Function docs.'
+    if arg:
+        'Docs.'
+        return 1
+    return 0
+"""
+
+after_call = """
+def some():
+    'Function docs.'
+    print(1)
+    'Docs.'
+"""
+
+after_doc_string = """
+def some():
+    'Function docs.'
+    'Docs.'
+"""
+
+
+@pytest.mark.parametrize(
+    'code',
+    [
+        module_docstring,
+        function_docstring,
+        class_docstring,
+        module_attribute,
+        annotated_module_attribute,
+        class_attribute,
+        instance_attribute,
+        type_alias,
+    ],
+)
+def test_documenting_string(
+    assert_errors,
+    parse_ast_tree,
+    default_options,
+    code,
+):
+    """Testing that strings documenting something are allowed."""
+    tree = parse_ast_tree(code)
+
+    visitor = DocStringPlacementVisitor(default_options, tree=tree)
+    visitor.run()
+
+    assert_errors(visitor, [])
+
+
+@pytest.mark.parametrize(
+    'code',
+    [
+        foreign_attribute,
+        local_variable,
+        multiple_targets,
+        inside_condition,
+        after_call,
+        after_doc_string,
+    ],
+)
+def test_string_documenting_nothing(
+    assert_errors,
+    parse_ast_tree,
+    default_options,
+    code,
+):
+    """Testing that strings documenting nothing are forbidden."""
+    tree = parse_ast_tree(code)
+
+    visitor = DocStringPlacementVisitor(default_options, tree=tree)
+    visitor.run()
+
+    assert_errors(visitor, [WrongDocStringPlacementViolation])

--- a/tests/test_visitors/test_ast/test_statements/test_doc_string_placement.py
+++ b/tests/test_visitors/test_ast/test_statements/test_doc_string_placement.py
@@ -62,6 +62,14 @@ some.first = 1
 'Docs.'
 """
 
+instance_attribute_outside_constructor = """
+class Some:
+    def method(self):
+        'Method docs.'
+        self.first = 1
+        'Docs.'
+"""
+
 local_variable = """
 def some():
     'Function docs.'
@@ -129,6 +137,7 @@ def test_documenting_string(
     'code',
     [
         foreign_attribute,
+        instance_attribute_outside_constructor,
         local_variable,
         multiple_targets,
         inside_condition,

--- a/wemake_python_styleguide/logic/tree/strings.py
+++ b/wemake_python_styleguide/logic/tree/strings.py
@@ -1,14 +1,17 @@
 import ast
 import itertools
+from typing import Final
 
 from wemake_python_styleguide.compat import nodes
 from wemake_python_styleguide.compat.aliases import AssignNodes, FunctionNodes
 from wemake_python_styleguide.compat.functions import get_assign_targets
-from wemake_python_styleguide.constants import INIT
 from wemake_python_styleguide.logic.nodes import get_context, get_parent
 from wemake_python_styleguide.logic.tree.attributes import is_special_attr
 from wemake_python_styleguide.logic.walk import get_closest_parent
 from wemake_python_styleguide.types import ContextNodes
+
+#: Methods that define the instance attributes a docstring can document.
+_ConstructorMethods: Final = frozenset(('__init__', '__new__'))
 
 
 def is_doc_string(node: ast.AST) -> bool:
@@ -70,7 +73,7 @@ def _is_documented(statement: ast.stmt, context: ContextNodes) -> bool:
         # Only a constructor defines the instance attributes. Locals are
         # not attributes, and `x.some = 1` belongs to some other object.
         return (
-            context.name == INIT
+            context.name in _ConstructorMethods
             and isinstance(target, ast.Attribute)
             and is_special_attr(target)
         )

--- a/wemake_python_styleguide/logic/tree/strings.py
+++ b/wemake_python_styleguide/logic/tree/strings.py
@@ -4,6 +4,7 @@ import itertools
 from wemake_python_styleguide.compat import nodes
 from wemake_python_styleguide.compat.aliases import AssignNodes, FunctionNodes
 from wemake_python_styleguide.compat.functions import get_assign_targets
+from wemake_python_styleguide.constants import INIT
 from wemake_python_styleguide.logic.nodes import get_context, get_parent
 from wemake_python_styleguide.logic.tree.attributes import is_special_attr
 from wemake_python_styleguide.logic.walk import get_closest_parent
@@ -66,9 +67,13 @@ def _is_documented(statement: ast.stmt, context: ContextNodes) -> bool:
         return False
     target = targets[0]
     if isinstance(context, FunctionNodes):
-        # Locals are not attributes. Only `self.some = 1` defines one,
-        # while `x.some = 1` documents an attribute of some other object.
-        return isinstance(target, ast.Attribute) and is_special_attr(target)
+        # Only a constructor defines the instance attributes. Locals are
+        # not attributes, and `x.some = 1` belongs to some other object.
+        return (
+            context.name == INIT
+            and isinstance(target, ast.Attribute)
+            and is_special_attr(target)
+        )
     # Modules and classes define their attributes by plain names,
     # `x.some = 1` here belongs to `x`, not to this module or class.
     return isinstance(target, ast.Name)

--- a/wemake_python_styleguide/presets/types/tree.py
+++ b/wemake_python_styleguide/presets/types/tree.py
@@ -32,6 +32,7 @@ PRESET: Final = (
     statements.WrongNamedKeywordVisitor,
     statements.AssignmentPatternsVisitor,
     statements.WrongMethodArgumentsVisitor,
+    statements.DocStringPlacementVisitor,
     keywords.WrongRaiseVisitor,
     keywords.WrongKeywordVisitor,
     keywords.WrongContextManagerVisitor,

--- a/wemake_python_styleguide/violations/best_practices.py
+++ b/wemake_python_styleguide/violations/best_practices.py
@@ -3148,7 +3148,7 @@ class WrongDocStringPlacementViolation(ASTViolation):
 
         # Correct:
         first = 1
-        \"\"\"Documents ``first``.\"\"\"
+        """Documents ``first``."""
 
         # Wrong:
         some.first = 1

--- a/wemake_python_styleguide/violations/best_practices.py
+++ b/wemake_python_styleguide/violations/best_practices.py
@@ -3143,12 +3143,17 @@ class WrongDocStringPlacementViolation(ASTViolation):
     Solution:
         Move the string to a place where it documents something,
         or turn it into a regular ``#`` comment.
+        A docstring goes after the attribute it documents, never before it.
 
     Example::
 
         # Correct:
         first = 1
         '''Documents ``first``.'''
+
+        # Wrong:
+        '''Documents nothing, a docstring goes after the attribute.'''
+        first = 1
 
         # Wrong:
         some.first = 1

--- a/wemake_python_styleguide/violations/best_practices.py
+++ b/wemake_python_styleguide/violations/best_practices.py
@@ -3148,11 +3148,11 @@ class WrongDocStringPlacementViolation(ASTViolation):
 
         # Correct:
         first = 1
-        """Documents ``first``."""
+        '''Documents ``first``.'''
 
         # Wrong:
         some.first = 1
-        \"\"\"Documents nothing, ``first`` belongs to ``some``.\"\"\"
+        '''Documents nothing, ``first`` belongs to ``some``.'''
 
     .. versionadded:: 1.9.0
 

--- a/wemake_python_styleguide/violations/best_practices.py
+++ b/wemake_python_styleguide/violations/best_practices.py
@@ -3128,7 +3128,7 @@ class WrongDocStringPlacementViolation(ASTViolation):
 
     1. as the first statement of a module, class, or function body
     2. after an assignment to a plain name in a module or a class
-    3. after an assignment to ``self`` inside a method
+    3. after an assignment to ``self`` inside a constructor
     4. after a ``type`` alias on ``python3.12+``
 
     Anywhere else it does nothing at runtime,

--- a/wemake_python_styleguide/violations/best_practices.py
+++ b/wemake_python_styleguide/violations/best_practices.py
@@ -3117,3 +3117,46 @@ class ForbidMappingProxyTypeViolation(ASTViolation):
         'Found a `types.MappingProxyType` usage, prefer `frozendict` on 3.15+'
     )
     code = 483
+
+
+@final
+class WrongDocStringPlacementViolation(ASTViolation):
+    """
+    Forbid strings that look like docstrings, but document nothing.
+
+    A string statement documents something only when it is placed:
+
+    1. as the first statement of a module, class, or function body
+    2. after an assignment to a plain name in a module or a class
+    3. after an assignment to ``self`` inside a method
+    4. after a ``type`` alias on ``python3.12+``
+
+    Anywhere else it does nothing at runtime,
+    while still reading like documentation.
+
+    Reasoning:
+        Such strings are dead code that looks alive.
+        A reader takes them for documentation of the line above,
+        while no tool will ever render them,
+        and the code they seem to describe can change without notice.
+
+    Solution:
+        Move the string to a place where it documents something,
+        or turn it into a regular ``#`` comment.
+
+    Example::
+
+        # Correct:
+        first = 1
+        \"\"\"Documents ``first``.\"\"\"
+
+        # Wrong:
+        some.first = 1
+        \"\"\"Documents nothing, ``first`` belongs to ``some``.\"\"\"
+
+    .. versionadded:: 1.9.0
+
+    """
+
+    error_template = 'Found a string that documents nothing'
+    code = 484

--- a/wemake_python_styleguide/violations/complexity.py
+++ b/wemake_python_styleguide/violations/complexity.py
@@ -825,7 +825,9 @@ class OverusedStringViolation(MaybeASTViolation):
     This includes attribute docstrings from PEP 258
     and type alias docstrings, the ones placed right after
     an attribute definition or a ``type`` statement.
-    Local variables are not attributes, so they are still counted.
+    Instance attributes are only defined in a constructor,
+    and local variables are not attributes at all,
+    so both of these are still counted.
 
     The violation points to the first occurrence of the overused string literal.
 

--- a/wemake_python_styleguide/visitors/ast/statements.py
+++ b/wemake_python_styleguide/visitors/ast/statements.py
@@ -10,12 +10,14 @@ from wemake_python_styleguide.compat.aliases import (
 from wemake_python_styleguide.compat.nodes import TryStar
 from wemake_python_styleguide.logic.arguments import call_args
 from wemake_python_styleguide.logic.naming import name_nodes
+from wemake_python_styleguide.logic.tree import strings
 from wemake_python_styleguide.logic.tree.collections import (
     first,
     sequence_of_node,
 )
 from wemake_python_styleguide.violations.best_practices import (
     UnreachableCodeViolation,
+    WrongDocStringPlacementViolation,
     WrongNamedKeywordViolation,
 )
 from wemake_python_styleguide.violations.consistency import (
@@ -358,3 +360,19 @@ class WrongMethodArgumentsVisitor(BaseNodeVisitor):
             if isinstance(arg, self._no_tuples_collections):
                 self.add_violation(NotATupleArgumentViolation(node))
                 break
+
+
+@final
+class DocStringPlacementVisitor(BaseNodeVisitor):
+    """Restricts strings that look like docstrings, but document nothing."""
+
+    def visit_Expr(self, node: ast.Expr) -> None:
+        """Checks that a string statement documents something."""
+        self._check_doc_string_place(node)
+        self.generic_visit(node)
+
+    def _check_doc_string_place(self, node: ast.Expr) -> None:
+        if strings.is_doc_string(node) and not strings.is_doc_string_value(
+            node.value,
+        ):
+            self.add_violation(WrongDocStringPlacementViolation(node))


### PR DESCRIPTION
# I have made things!

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->
Adds `WPS484`, the rule from #3808. It flags a string statement placed where it cannot document anything:

```python
some.first = 1
"""Documents nothing, `first` belongs to `some`."""


def some(arg):
    """Function docs."""
    if arg:
        """Neither does this."""
        return arg
    return 0
```

A string documents something in exactly four places:

- opening a module, class or function body
- after an assignment to a plain name in a module or a class
- after `self.some = ...` inside a method
- after a `type Some = ...` alias on `python3.12+`

The check itself is a single condition, because `WPS226` already had to answer this same question in order to skip docstrings:

```python
def _check_doc_string_place(self, node: ast.Expr) -> None:
    if strings.is_doc_string(node) and not strings.is_doc_string_value(
        node.value,
    ):
        self.add_violation(WrongDocStringPlacementViolation(node))
```

That reuse is the point of the rule, not a shortcut. Both rules now read one definition of a documenting position, so refining it later moves them together instead of letting two copies drift.

The violation sits in `best_practices.py` next to `WPS428`, the old "statement has no effect" rule that was retired to ruff's `B015`/`B018` in 1.0.0. Neither of those flags a string, which is how these slip through today.

`wemake-python-styleguide` itself is clean under the new rule.

### Open to review
I picked these three without asking, so say if any is wrong:

- the name, `WrongDocStringPlacementViolation`
- the code, `WPS484`
- counting `type Some = int` docstrings as a valid position, given they're still only a proposal upstream

## AI Policy

- [x] I have read and agree to the [AI Policy](https://github.com/wemake-services/wemake-python-styleguide/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result


## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made
- [x] I have added my changes to the `CHANGELOG.md`

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->
Closes #3808
<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->

🙏 Please, if you or your company is finding wemake-python-styleguide valuable, help us sustain the project by sponsoring it transparently on https://opencollective.com/wemake-python-styleguide. As a thank you, your profile/company logo will be added to our main README which receives hundreds of unique visitors per day.
